### PR TITLE
Revert "Fix UploadRangeSlicesCc::Wait() and UploadBatchSliceCc::Wait(…

### DIFF
--- a/include/cc/range_cc_map.h
+++ b/include/cc/range_cc_map.h
@@ -1291,7 +1291,7 @@ public:
             req.SetError(CcErrorCode::UPLOAD_BATCH_REJECTED);
         }
 
-        return true;
+        return false;
     }
 
     TableType Type() const override

--- a/src/remote/cc_node_service.cpp
+++ b/src/remote/cc_node_service.cpp
@@ -1336,7 +1336,6 @@ void CcNodeService::UploadRangeSlices(
     uint16_t rand_core = std::rand() % core_cnt;
     // upload range slices info
     UploadRangeSlicesCc req;
-    req.Use();
     req.Reset(table_name,
               ng_id,
               old_partition_id,
@@ -1409,7 +1408,6 @@ void CcNodeService::UploadBatchSlices(
     }
 
     UploadBatchSlicesCc req;
-    req.Use();
     req.Reset(
         table_name, ng_id, ng_term, core_cnt, write_entry_tuple, slices_info);
 


### PR DESCRIPTION
…) (#1613)"

This reverts commit 7c39f6edb7e16198117c749ffa9b20093b8dcc48.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Reference the link of issue using `fixes eloqdb/tx_service#issue_id`
- [ ] Reference the link of RFC if exists
- [ ] Pass `./mtr --suite=mono_main,mono_multi,mono_basic`
