### PR TITLE
add missing initialization and clean code

### DIFF
--- a/src/sharder.cpp
+++ b/src/sharder.cpp
@@ -482,7 +482,7 @@ int Sharder::Init(
     else
     {
         bool retry = false;
-        uint64_t start_ts;
+        uint64_t start_ts = 0;
         cluster_config_.cc_nodes_.at(native_ng_)
             ->OnLeaderStart(1, start_ts, retry);
         assert(!retry);


### PR DESCRIPTION
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Reference the link of issue using `fixes eloqdb/tx_service#issue_id`
- [ ] Reference the link of RFC if exists
- [x] Pass `./mtr --suite=mono_main,mono_multi,mono_basic`

Only adding a missing initialization but also some code format.
The initialization is important because it can make txservice send a junk value to logservice and mislead logservice to send replay log that is before checkpointing when the junk value is smaller than timestamp of the last checkpoint.
