### PR TITLE
Dead lock check infinite loop

### DIFF
--- a/include/dead_lock_check.h
+++ b/include/dead_lock_check.h
@@ -237,11 +237,11 @@ protected:
 
     LocalCcShards &local_shards_;
     std::unique_ptr<CheckDeadLockCc> dead_lock_cc_;
-    // The last time to receive check command
+    // The last time to check dead lock.
     uint64_t last_check_time_;
     // The node to rise dead lock check.
     uint32_t check_node_id_;
-
+    // If the dead lock check is requested by this node.
     bool requested_check_{false};
 };
 }  // namespace txservice


### PR DESCRIPTION
1. Given a rate limit of DeadLockCheck, e.g. every 1 or 2 seconds interval contains 1 DeadLockCheck
2. If in the last interval, there is a request_check and last_check_time_ happens before last interval, do a check

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Reference the link of issue using `fixes eloqdb/tx_service#issue_id`
- [ ] Reference the link of RFC if exists
- [ ] Pass `./mtr --suite=mono_main,mono_multi,mono_basic`
