### PR TITLE
replace union in FlushRecord and RangeBucketRecord with variant

### DIFF
--- a/include/tx_key.h
+++ b/include/tx_key.h
@@ -567,7 +567,7 @@ public:
      */
     void Release()
     {
-        obj_addr_ = obj_addr_ & mask;
+        obj_addr_ &= mask;
     }
 
 private:

--- a/src/cc/cc_entry.cpp
+++ b/src/cc/cc_entry.cpp
@@ -206,17 +206,14 @@ bool VersionedLruEntry<Versioned, RangePartitioned>::GetBeingCkpt() const
 
 TxKey FlushRecord::Key() const
 {
-    if (key_type_ == FlushKeyType::TxKey)
+    if (std::holds_alternative<TxKey>(flush_key_))
     {
-        return tx_key_.GetShallowCopy();
+        return std::get<TxKey>(flush_key_).GetShallowCopy();
     }
-    else
-    {
-        assert(
-            "The flush key is of type KeyIndex and cannot return the key "
-            "pointer.");
-        return TxKey();
-    }
+    assert(false &&
+           "The flush key is of type KeyIndex and cannot return the key "
+           "pointer.");
+    return TxKey();
 }
 
 template struct VersionedLruEntry<true, true>;


### PR DESCRIPTION
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Reference the link of issue using `fixes eloqdb/tx_service#issue_id`
- [ ] Reference the link of RFC if exists
- [x] Pass `./mtr --suite=mono_main,mono_multi,mono_basic`

Replace union fields in FlushRecord and RangeBucketRecord with variants. Since currently a field is already used to tell the type, changing to variant will not introduce more memory usage.
