### PR TITLE
Ckpt refactor

### DIFF
--- a/include/cc/catalog_cc_map.h
+++ b/include/cc/catalog_cc_map.h
@@ -142,17 +142,7 @@ public:
             }
         }
 
-        bool ret = TemplateCcMap::Execute(req);
-        if (!ret)
-        {
-            // Acquire lock blocked. We need to flush the data sync
-            // flush buffer so that catalog read lock held by the 
-            // data sync tx can be released.
-            shard_->local_shards_.FlushCurrentFlushBuffer();
-        }
-
-        return ret;
-
+        return TemplateCcMap::Execute(req);
     }
 
     bool Execute(PostWriteAllCc &req) override

--- a/include/cc/catalog_cc_map.h
+++ b/include/cc/catalog_cc_map.h
@@ -142,7 +142,17 @@ public:
             }
         }
 
-        return TemplateCcMap::Execute(req);
+        bool ret = TemplateCcMap::Execute(req);
+        if (!ret)
+        {
+            // Acquire lock blocked. We need to flush the data sync
+            // flush buffer so that catalog read lock held by the 
+            // data sync tx can be released.
+            shard_->local_shards_.FlushCurrentFlushBuffer();
+        }
+
+        return ret;
+
     }
 
     bool Execute(PostWriteAllCc &req) override

--- a/include/cc/cc_entry.h
+++ b/include/cc/cc_entry.h
@@ -278,7 +278,14 @@ public:
 
     uint64_t FlushSize()
     {
-        return Key().Size() + PayloadSize();
+        if (std::holds_alternative<TxKey>(flush_key_))
+        {
+            return Key().Size() + PayloadSize();
+        }
+        else
+        {
+            return sizeof(size_t) + PayloadSize();
+        }
     }
 };
 

--- a/include/cc/cc_req_misc.h
+++ b/include/cc/cc_req_misc.h
@@ -703,9 +703,9 @@ public:
     UpdateCceCkptTsCc(
         NodeGroupId node_group_id,
         int64_t term,
-        absl::flat_hash_map<size_t, std::vector<std::vector<CkptTsEntry>>>
-            &&cce_entries)
-        : cce_entries_(std::move(cce_entries)),
+        absl::flat_hash_map<size_t, std::vector<CkptTsEntry>>
+            &cce_entries)
+        : cce_entries_(cce_entries),
           node_group_id_(node_group_id),
           term_(term)
     {
@@ -714,7 +714,7 @@ public:
 
         for (const auto &entry : cce_entries_)
         {
-            indices_[entry.first] = {0, 0};
+            indices_[entry.first] = 0;
         }
     }
 
@@ -742,17 +742,17 @@ public:
         }
     }
 
-    const absl::flat_hash_map<size_t, std::vector<std::vector<CkptTsEntry>>> &
-    EntriesRef() const
+    const absl::flat_hash_map<size_t, std::vector<CkptTsEntry>>
+        &EntriesRef() const
     {
         return cce_entries_;
     }
 
 private:
-    absl::flat_hash_map<size_t, std::vector<std::vector<CkptTsEntry>>>
-        cce_entries_;
-    // key: core_idx, value: pair<vec_idx, entry_index>
-    absl::flat_hash_map<size_t, std::pair<size_t, size_t>> indices_;
+    absl::flat_hash_map<size_t, std::vector<CkptTsEntry>>
+        &cce_entries_;
+    // key: core_idx, value: entry_index
+    absl::flat_hash_map<size_t, size_t> indices_;
 
     size_t unfinished_core_cnt_;
     NodeGroupId node_group_id_;

--- a/include/cc/cc_req_misc.h
+++ b/include/cc/cc_req_misc.h
@@ -703,11 +703,8 @@ public:
     UpdateCceCkptTsCc(
         NodeGroupId node_group_id,
         int64_t term,
-        absl::flat_hash_map<size_t, std::vector<CkptTsEntry>>
-            &cce_entries)
-        : cce_entries_(cce_entries),
-          node_group_id_(node_group_id),
-          term_(term)
+        absl::flat_hash_map<size_t, std::vector<CkptTsEntry>> &cce_entries)
+        : cce_entries_(cce_entries), node_group_id_(node_group_id), term_(term)
     {
         unfinished_core_cnt_ = cce_entries_.size();
         assert(unfinished_core_cnt_ > 0);
@@ -742,15 +739,14 @@ public:
         }
     }
 
-    const absl::flat_hash_map<size_t, std::vector<CkptTsEntry>>
-        &EntriesRef() const
+    const absl::flat_hash_map<size_t, std::vector<CkptTsEntry>> &EntriesRef()
+        const
     {
         return cce_entries_;
     }
 
 private:
-    absl::flat_hash_map<size_t, std::vector<CkptTsEntry>>
-        &cce_entries_;
+    absl::flat_hash_map<size_t, std::vector<CkptTsEntry>> &cce_entries_;
     // key: core_idx, value: entry_index
     absl::flat_hash_map<size_t, size_t> indices_;
 

--- a/include/cc/cc_request.h
+++ b/include/cc/cc_request.h
@@ -3500,16 +3500,16 @@ public:
 
             accumulated_scan_cnt_.at(i) = 0;
             accumulated_flush_data_size_.at(i) = 0;
+            if (scan_heap_is_full_[i] == 1)
+            {
+                // vec has been cleared during ReleaseDataSyncScanHeapCc,
+                // resize to prepared size
+                data_sync_vec_[i].resize(scan_batch_size_);
+                scan_heap_is_full_[i] = 0;
+            }
         }
 
-        if (scan_heap_is_full_)
-        {
-            // vec has been cleared during ReleaseDataSyncScanHeapCc,
-            // resize to prepared size
-            data_sync_vec_[0].resize(scan_batch_size_);
-        }
         err_ = CcErrorCode::NO_ERROR;
-        scan_heap_is_full_ = false;
         op_type_ = op_type;
     }
 
@@ -3639,9 +3639,9 @@ public:
 
     std::vector<size_t> accumulated_scan_cnt_;
     std::vector<uint64_t> accumulated_flush_data_size_;
-    // TODO(liunyl): make this a vector and return early when scan mem is full
-    // in range partitioned scan.
-    bool scan_heap_is_full_{false};
+
+    // std::vector<bool> is not safe to use in multi-threaded environment,
+    std::vector<uint32_t> scan_heap_is_full_{0};
 
     size_t scan_count_{0};
 

--- a/include/cc/cc_request.h
+++ b/include/cc/cc_request.h
@@ -3672,6 +3672,9 @@ private:
 #endif
     size_t scan_batch_size_;
 
+    // TODO(liunyl): make it configurable based on total memory size
+    size_t max_pending_flush_size_{64 * 1024 * 1024};
+
     CcErrorCode err_{CcErrorCode::NO_ERROR};
     uint32_t unfinished_cnt_;
     std::mutex mux_;

--- a/include/cc/cc_request.h
+++ b/include/cc/cc_request.h
@@ -3388,6 +3388,7 @@ public:
 #endif
             accumulated_scan_cnt_.emplace_back(0);
             accumulated_flush_data_size_.emplace_back(0);
+            scan_heap_is_full_.emplace_back(0);
         }
 
 #ifdef RANGE_PARTITION_ENABLED

--- a/include/cc/cc_request.h
+++ b/include/cc/cc_request.h
@@ -4341,6 +4341,8 @@ public:
                     break;
                 default:
                     // Should not have meta table in data log.
+                    table_type = TableType::Primary;
+                    LOG(FATAL) << "Invalid table type in data log: " << table_type_number;
                     assert(false);
                     break;
                 }

--- a/include/cc/cc_shard.h
+++ b/include/cc/cc_shard.h
@@ -359,11 +359,7 @@ public:
      */
     std::pair<size_t, bool> Clean();
 
-    bool FlushEntryForTest(const TableName &tbl_name,
-                           const TableSchema *tbl_schema,
-                           std::vector<FlushRecord> &ckpt_vec,
-                           std::vector<FlushRecord> &archives,
-                           bool only_archives);
+    bool FlushEntryForTest(std::unordered_map<std::string_view, std::vector<std::unique_ptr<FlushTaskEntry>>> &flush_task_entries, bool only_archives);
 
     void NotifyCkpt(bool request_ckpt = true);
 

--- a/include/cc/local_cc_shards.h
+++ b/include/cc/local_cc_shards.h
@@ -73,6 +73,7 @@ struct DataMigrationOp;
 struct InvalidateTableCacheCompositeOp;
 class SkGenerator;
 class UploadBatchSlicesClosure;
+struct FlushDataTask;
 
 struct DataMigrationStatus
 {
@@ -1842,6 +1843,8 @@ private:
                                  ,
                                  uint16_t worker_idx
 #endif
+,
+                                bool is_scan_task = true
     );
 
     const uint32_t node_id_;
@@ -2093,7 +2096,7 @@ private:
 
     struct DataSyncMemoryController
     {
-        explicit DataSyncMemoryController(uint64_t mem_quota)
+        DataSyncMemoryController(uint64_t mem_quota)
             : flush_data_mem_usage_(0), flush_data_mem_quota_(mem_quota)
         {
         }
@@ -2132,6 +2135,15 @@ private:
 
                 return false;
             };
+
+            if (!has_enough_memory())
+            {
+                DLOG(INFO) << "Flush data memory quota is full "
+                             << flush_data_mem_usage_
+                             << " ,request quota: " << quota
+                             << " total quota: " << flush_data_mem_quota_;
+                Sharder::Instance().GetLocalCcShards()->FlushCurrentFlushBuffer();
+            }
 
             // Wait until enough memory is available
             while (!has_enough_memory())
@@ -2180,10 +2192,10 @@ private:
         bthread::ConditionVariable mem_cv_;
         // Memory usage tracking
         uint64_t flush_data_mem_usage_{0};
-        const uint64_t flush_data_mem_quota_{0};
+        uint64_t flush_data_mem_quota_{0};
     };
 
-    std::vector<DataSyncMemoryController> data_sync_mem_controllers_;
+    DataSyncMemoryController data_sync_mem_controller_;
 
     struct DataSyncTaskLimiter
     {
@@ -2365,46 +2377,61 @@ private:
                           const TxKey *end_key,
                           bool flush_res);
 
-    /**
-     * FlushData Operation Interface
-     */
-    struct FlushDataTask
-    {
-    public:
-        FlushDataTask(
-            std::shared_ptr<DataSyncTask> data_sync_task,
-            std::shared_ptr<const TableSchema> schema,
-            std::unique_ptr<std::vector<FlushRecord>> data_sync_vec,
-            std::unique_ptr<std::vector<FlushRecord>> archive_vec,
-            std::unique_ptr<std::vector<std::pair<TxKey, int32_t>>> mv_base_vec,
-            uint64_t vec_mem_usage,
-            TransactionExecution *data_sync_txm,
-            size_t scan_task_worker_idx)
-            : schema_(schema),
-              data_sync_vec_(std::move(data_sync_vec)),
-              archive_vec_(std::move(archive_vec)),
-              mv_base_vec_(std::move(mv_base_vec)),
-              vec_mem_usage_(vec_mem_usage),
-              scan_task_worker_idx_(scan_task_worker_idx),
-              data_sync_task_(data_sync_task),
-              data_sync_txm_(data_sync_txm)
-        {
-        }
+    // /**
+    //  * FlushData Operation Interface
+    //  */
+    // struct FlushDataTask
+    // {
+    // public:
+    //     FlushDataTask(
+    //         std::shared_ptr<DataSyncTask> data_sync_task,
+    //         std::shared_ptr<const TableSchema> schema,
+    //         std::unique_ptr<std::vector<FlushRecord>> data_sync_vec,
+    //         std::unique_ptr<std::vector<FlushRecord>> archive_vec,
+    //         std::unique_ptr<std::vector<std::pair<TxKey, int32_t>>>
+    //         mv_base_vec, uint64_t vec_mem_usage, TransactionExecution
+    //         *data_sync_txm, size_t scan_task_worker_idx) : schema_(schema),
+    //           data_sync_vec_(std::move(data_sync_vec)),
+    //           archive_vec_(std::move(archive_vec)),
+    //           mv_base_vec_(std::move(mv_base_vec)),
+    //           vec_mem_usage_(vec_mem_usage),
+    //           scan_task_worker_idx_(scan_task_worker_idx),
+    //           data_sync_task_(data_sync_task),
+    //           data_sync_txm_(data_sync_txm)
+    //     {
+    //     }
 
-        std::shared_ptr<const TableSchema> schema_{nullptr};
-        std::unique_ptr<std::vector<FlushRecord>> data_sync_vec_{nullptr};
-        std::unique_ptr<std::vector<FlushRecord>> archive_vec_{nullptr};
-        std::unique_ptr<std::vector<std::pair<TxKey, int32_t>>> mv_base_vec_{
-            nullptr};
-        uint64_t vec_mem_usage_{0};
-        size_t scan_task_worker_idx_{0};
-        // Increased by worker after finishing the retrieved work.
-        std::shared_ptr<DataSyncTask> data_sync_task_{nullptr};
-        TransactionExecution *data_sync_txm_{nullptr};
-    };
+    //     std::shared_ptr<const TableSchema> schema_{nullptr};
+    //     std::unique_ptr<std::vector<FlushRecord>> data_sync_vec_{nullptr};
+    //     std::unique_ptr<std::vector<FlushRecord>> archive_vec_{nullptr};
+    //     std::unique_ptr<std::vector<std::pair<TxKey, int32_t>>> mv_base_vec_{
+    //         nullptr};
+    //     uint64_t vec_mem_usage_{0};
+    //     size_t scan_task_worker_idx_{0};
+    //     // Increased by worker after finishing the retrieved work.
+    //     std::shared_ptr<DataSyncTask> data_sync_task_{nullptr};
+    //     TransactionExecution *data_sync_txm_{nullptr};
+    // };
     // For flush data work
+
+    /**
+     * @brief Add a flush task entry to the flush task. If the there's no
+     * pending flush task, create a new flush task and add the entry to it.
+     * Otherwise, add the entry to the current flush task. If the current flush
+     * task is full, append it to pending_flush_work_ and create a new flush
+     * task.
+     */
+    void AddFlushTaskEntry(std::unique_ptr<FlushTaskEntry> &&entry);
+
+    void FlushCurrentFlushBuffer();
+
+    // The flush task that has not reached the max pending flush size.
+    // New flush task entry will be added to this buffer. This task will
+    // be appended to pending_flush_work_ when it reaches the max pending flush
+    // size, which will then be processed by flush data worker.
+    std::unique_ptr<FlushDataTask> cur_flush_buffer_;
     WorkerThreadContext flush_data_worker_ctx_;
-    // Flush work from data sync, and split range
+    // Flush task queue for flush data worker to process.
     std::vector<std::unique_ptr<FlushDataTask>> pending_flush_work_;
 
     void FlushDataWorker();

--- a/include/cc/local_cc_shards.h
+++ b/include/cc/local_cc_shards.h
@@ -2429,6 +2429,8 @@ private:
     // New flush task entry will be added to this buffer. This task will
     // be appended to pending_flush_work_ when it reaches the max pending flush
     // size, which will then be processed by flush data worker.
+
+    //TODO(liunyl): protect with mutex
     std::unique_ptr<FlushDataTask> cur_flush_buffer_;
     WorkerThreadContext flush_data_worker_ctx_;
     // Flush task queue for flush data worker to process.

--- a/include/cc/local_cc_shards.h
+++ b/include/cc/local_cc_shards.h
@@ -1845,9 +1845,8 @@ private:
                                  ,
                                  uint16_t worker_idx
 #endif
-,
-                                bool is_scan_task = true
-    );
+                                 ,
+                                 bool is_scan_task = true);
 
     const uint32_t node_id_;
     // Native node group
@@ -2141,10 +2140,12 @@ private:
             if (!has_enough_memory())
             {
                 DLOG(INFO) << "Flush data memory quota is full "
-                             << flush_data_mem_usage_
-                             << " ,request quota: " << quota
-                             << " total quota: " << flush_data_mem_quota_;
-                Sharder::Instance().GetLocalCcShards()->FlushCurrentFlushBuffer();
+                           << flush_data_mem_usage_
+                           << " ,request quota: " << quota
+                           << " total quota: " << flush_data_mem_quota_;
+                Sharder::Instance()
+                    .GetLocalCcShards()
+                    ->FlushCurrentFlushBuffer();
             }
 
             // Wait until enough memory is available
@@ -2197,7 +2198,6 @@ private:
         uint64_t flush_data_mem_quota_{0};
     };
 
-    DataSyncMemoryController data_sync_mem_controller_;
 
     struct DataSyncTaskLimiter
     {
@@ -2436,6 +2436,9 @@ private:
 
     void FlushDataWorker();
     void FlushData(std::unique_lock<std::mutex> &flush_worker_lk);
+
+    // Memory controller for data sync.
+    DataSyncMemoryController data_sync_mem_controller_;
 
     WorkerThreadContext statistics_worker_ctx_;
     void SyncTableStatisticsWorker();

--- a/include/cc/local_cc_shards.h
+++ b/include/cc/local_cc_shards.h
@@ -1702,6 +1702,8 @@ public:
 
     void PostProcessCkpt(std::shared_ptr<DataSyncTask> &task, bool flush_ret);
 
+    void FlushCurrentFlushBuffer();
+
     store::DataStoreHandler *const store_hd_;
 
     /*
@@ -2422,8 +2424,6 @@ private:
      * task.
      */
     void AddFlushTaskEntry(std::unique_ptr<FlushTaskEntry> &&entry);
-
-    void FlushCurrentFlushBuffer();
 
     // The flush task that has not reached the max pending flush size.
     // New flush task entry will be added to this buffer. This task will

--- a/include/cc/range_slice.h
+++ b/include/cc/range_slice.h
@@ -576,7 +576,7 @@ class StoreRange
 public:
     /**
      * @brief Max number of slices in range. The total size of a range
-     * is (8*1024) * (16*1024) = 128MB
+     * is (16*1024) * (16*1024) = 256MB
      *
      */
 #ifdef SMALL_RANGE

--- a/include/cc/template_cc_map.h
+++ b/include/cc/template_cc_map.h
@@ -5822,19 +5822,20 @@ public:
             {
                 assert(cce->entry_info_.DataStoreSize() != INT32_MAX);
                 uint64_t flush_size = 0;
-                auto export_result = ExportForCkpt(cce,
-                              *key,
-                              req.DataSyncVec(shard_->core_id_),
-                              req.ArchiveVec(shard_->core_id_),
-                              req.MoveBaseIdxVec(shard_->core_id_),
-                              req.data_sync_ts_,
-                              recycle_ts,
-                              shard_->EnableMvcc(),
-                              req.accumulated_scan_cnt_[shard_->core_id_],
-                              req.export_base_table_item_,
-                              req.export_base_table_item_only_,
-                              export_persisted_key_only,
-                              flush_size);
+                auto export_result =
+                    ExportForCkpt(cce,
+                                  *key,
+                                  req.DataSyncVec(shard_->core_id_),
+                                  req.ArchiveVec(shard_->core_id_),
+                                  req.MoveBaseIdxVec(shard_->core_id_),
+                                  req.data_sync_ts_,
+                                  recycle_ts,
+                                  shard_->EnableMvcc(),
+                                  req.accumulated_scan_cnt_[shard_->core_id_],
+                                  req.export_base_table_item_,
+                                  req.export_base_table_item_only_,
+                                  export_persisted_key_only,
+                                  flush_size);
 
                 req.accumulated_flush_data_size_[shard_->core_id_] +=
                     flush_size;
@@ -6159,7 +6160,8 @@ public:
                                       false,
                                       false,
                                       flush_data_size);
-                    req.accumulated_flush_data_size_[vec_idx] += flush_data_size;
+                    req.accumulated_flush_data_size_[vec_idx] +=
+                        flush_data_size;
 
                     if (export_result.second)
                     {

--- a/include/cc/template_cc_map.h
+++ b/include/cc/template_cc_map.h
@@ -7208,7 +7208,15 @@ public:
                             nullptr,
                             false,
                             false,
-                            nullptr);
+                            nullptr
+#ifndef RANGE_PARTITION_ENABLED
+                            ,
+                            nullptr,
+                            false,
+                            false,
+                            shard_->core_id_
+#endif
+                        );
 
                     std::unique_ptr<FlushTaskEntry> flush_task_entry =
                         std::make_unique<FlushTaskEntry>(

--- a/include/checkpointer.h
+++ b/include/checkpointer.h
@@ -65,13 +65,15 @@ public:
      * @brief Checkpoint one Entry to KvStore synchronously.
      * Now, only used for test.
      */
-    bool CkptEntryForTest(const TableName &tbl_name,
-                          const TableSchema *tbl_schema,
-                          std::vector<FlushRecord> &ckpt_vec);
+    bool CkptEntryForTest(
+        std::unordered_map<std::string_view,
+                           std::vector<std::unique_ptr<FlushTaskEntry>>>
+            &flush_task_entries);
 
-    bool FlushArchiveForTest(const TableName &tbl_name,
-                             const TableSchema *tbl_schema,
-                             std::vector<FlushRecord> &archives);
+    bool FlushArchiveForTest(
+        std::unordered_map<std::string_view,
+                           std::vector<std::unique_ptr<FlushTaskEntry>>>
+            &flush_task_entries);
 
     void Run();
 

--- a/include/data_sync_task.h
+++ b/include/data_sync_task.h
@@ -157,6 +157,8 @@ public:
 
     void SetError(CcErrorCode err_code = CcErrorCode::DATA_STORE_ERR);
 
+    void SetScanTaskFinished();
+
     void SetErrorCode(CcErrorCode err_code)
     {
         std::unique_lock<std::mutex> lk(status_->mux_);
@@ -231,7 +233,7 @@ public:
     absl::flat_hash_map<size_t, std::vector<UpdateCceCkptTsCc::CkptTsEntry>>
         cce_entries_;
 
-    bool need_update_ckpt_ts_{false};
+    bool need_update_ckpt_ts_{true};
 };
 
 struct FlushTaskEntry

--- a/include/data_sync_task.h
+++ b/include/data_sync_task.h
@@ -239,13 +239,14 @@ public:
 struct FlushTaskEntry
 {
 public:
-    FlushTaskEntry(std::unique_ptr<std::vector<FlushRecord>> &&data_sync_vec,
-                   std::unique_ptr<std::vector<FlushRecord>> &&archive_vec,
-                   std::unique_ptr<std::vector<std::pair<TxKey, int32_t>>> &&mv_base_vec,
-                   TransactionExecution *data_sync_txm,
-                   std::shared_ptr<DataSyncTask> data_sync_task,
-                   std::shared_ptr<const TableSchema> table_schema,
-                   size_t size)
+    FlushTaskEntry(
+        std::unique_ptr<std::vector<FlushRecord>> &&data_sync_vec,
+        std::unique_ptr<std::vector<FlushRecord>> &&archive_vec,
+        std::unique_ptr<std::vector<std::pair<TxKey, int32_t>>> &&mv_base_vec,
+        TransactionExecution *data_sync_txm,
+        std::shared_ptr<DataSyncTask> data_sync_task,
+        std::shared_ptr<const TableSchema> table_schema,
+        size_t size)
         : data_sync_vec_(std::move(data_sync_vec)),
           archive_vec_(std::move(archive_vec)),
           mv_base_vec_(std::move(mv_base_vec)),
@@ -284,7 +285,9 @@ public:
     {
         std::lock_guard<bthread::Mutex> lk(flush_task_entries_mux_);
         pending_flush_size_ += entry->size_;
-        auto table_flush_entries_it = flush_task_entries_.try_emplace(entry->table_schema_->GetKVCatalogInfo()->GetKvTableName(entry->data_sync_task_->table_name_));
+        auto table_flush_entries_it = flush_task_entries_.try_emplace(
+            entry->table_schema_->GetKVCatalogInfo()->GetKvTableName(
+                entry->data_sync_task_->table_name_));
         table_flush_entries_it.first->second.emplace_back(std::move(entry));
     }
 
@@ -298,7 +301,9 @@ public:
         return pending_flush_size_ == 0;
     }
 
-    std::unordered_map<std::string_view, std::vector<std::unique_ptr<FlushTaskEntry>>> flush_task_entries_;
+    std::unordered_map<std::string_view,
+                       std::vector<std::unique_ptr<FlushTaskEntry>>>
+        flush_task_entries_;
     size_t pending_flush_size_{0};
     size_t max_pending_flush_size_{0};
     bthread::Mutex flush_task_entries_mux_;

--- a/include/data_sync_task.h
+++ b/include/data_sync_task.h
@@ -157,6 +157,8 @@ public:
 
     void SetError(CcErrorCode err_code = CcErrorCode::DATA_STORE_ERR);
 
+    // TODO(liunyl)Put this into post process data sync task? SetFinish/SetError should not be called in
+    // DataSync(). It should only call post process data sync task, which handles everything.
     void SetScanTaskFinished();
 
     void SetErrorCode(CcErrorCode err_code)

--- a/include/schema.h
+++ b/include/schema.h
@@ -27,6 +27,7 @@
 #include <string>
 #include <utility>
 
+#include "glog/logging.h"
 #include "type.h"
 
 namespace txservice
@@ -158,7 +159,7 @@ struct TableKeySchemaTs
         pk_schema_ts_ = std::stoull(schemas_ts.at(0));
         for (size_t idx = 1; idx < schemas_ts.size(); ++idx)
         {
-            txservice::TableType table_type;
+            txservice::TableType table_type = txservice::TableType::Secondary;
             if (schemas_ts[idx].find(txservice::UNIQUE_INDEX_NAME_PREFIX) !=
                 std::string::npos)
             {
@@ -171,6 +172,7 @@ struct TableKeySchemaTs
             }
             else
             {
+                LOG(FATAL) << "Unknown secondary key type: " << schemas_ts[idx];
                 assert(false && "Unknown secondary key type.");
             }
             txservice::TableName table_name(
@@ -243,7 +245,7 @@ struct TableKeySchemaTs
             std::vector<std::string> sk_iter(sk_b, sk_e);
             for (auto it = sk_iter.begin(); it != sk_iter.end(); ++it)
             {
-                txservice::TableType table_type;
+                txservice::TableType table_type = txservice::TableType::Secondary;
                 if (it->find(txservice::UNIQUE_INDEX_NAME_PREFIX) !=
                     std::string::npos)
                 {
@@ -256,6 +258,7 @@ struct TableKeySchemaTs
                 }
                 else
                 {
+                    LOG(FATAL) << "Unknown secondary key type: " << *it;
                     assert(false && "Unknown secondary key type.");
                 }
                 txservice::TableName table_name(*it, table_type, table_engine_);

--- a/include/store/data_store_handler.h
+++ b/include/store/data_store_handler.h
@@ -99,12 +99,11 @@ public:
 
     virtual void ScheduleTimerTasks() {};
     /**
-     * @brief flush entries in \@param batch to base table or skindex table in
-     * data store, stop and return false if node_group is not longer leader.
-     * @param batch
-     * @param table_name base table name or sk index name
-     * @param table_schema
-     * @param node_group
+     * @brief flush entries in \@param flush_task to base table or skindex table in
+     * data store, stop and return false if the flush failed after max retry times.
+     * @param flush_task - the flush task to be flushed. Map key is the kv table name,
+     * value is the vector of flush task entries. PutAll only flushes the data_sync_vec_
+     * in each flush task entry.
      * @return whether all entries are written to data store successfully
      */
     virtual bool PutAll(std::unordered_map<std::string_view,

--- a/include/store/data_store_handler.h
+++ b/include/store/data_store_handler.h
@@ -52,6 +52,7 @@ struct SliceDataItem;
 class StoreSlice;
 struct FetchRecordCc;
 struct FlushRecord;
+struct FlushTaskEntry;
 
 namespace store
 {
@@ -106,11 +107,10 @@ public:
      * @param node_group
      * @return whether all entries are written to data store successfully
      */
-    virtual bool PutAll(std::vector<txservice::FlushRecord> &batch,
-                        const txservice::TableName &table_name,
-                        const txservice::TableSchema *table_schema,
-                        uint32_t node_group) = 0;
-
+    virtual bool PutAll(std::unordered_map<std::string_view,
+                       std::vector<std::unique_ptr<txservice::FlushTaskEntry>>>
+        &flush_task) = 0;
+        
     /**
      * @brief indicate end of flush entries in a single ckpt for \@param batch
      * to base table or skindex table in data store, stop and return false if
@@ -271,18 +271,16 @@ public:
     /**
      * @brief Write batch historical versions into DataStore.
      */
-    virtual bool PutArchivesAll(uint32_t node_group,
-                                const txservice::TableName &table_name,
-                                const txservice::KVCatalogInfo *kv_info,
-                                std::vector<txservice::FlushRecord> &batch) = 0;
+    virtual bool PutArchivesAll(std::unordered_map<std::string_view,
+                       std::vector<std::unique_ptr<txservice::FlushTaskEntry>>>
+        &flush_task) = 0;
     /**
      * @brief Copy record from base/sk table to mvcc_archives.
      */
     virtual bool CopyBaseToArchive(
-        std::vector<std::pair<TxKey, int32_t>> &batch,
-        uint32_t node_group,
-        const txservice::TableName &table_name,
-        const txservice::TableSchema *table_schema) = 0;
+        std::unordered_map<std::string_view,
+                       std::vector<std::unique_ptr<txservice::FlushTaskEntry>>>
+        &flush_task) = 0;
 
     /**
      * @brief  Get the latest visible(commit_ts <= upper_bound_ts) historical

--- a/include/store/int_mem_store.h
+++ b/include/store/int_mem_store.h
@@ -55,34 +55,35 @@ public:
      * @param node_group
      * @return whether all entries are written to data store successfully
      */
-    bool PutAll(std::vector<txservice::FlushRecord> &batch,
-                const txservice::TableName &table_name,
-                const txservice::TableSchema *table_schema,
-                uint32_t node_group) override
+    bool PutAll(std::unordered_map<
+                std::string_view,
+                std::vector<std::unique_ptr<txservice::FlushTaskEntry>>>
+                    &flush_task) override
     {
-        for (const auto &ref : batch)
-        {
-            const CompositeKey<int> *key =
-                ref.Key().GetKey<CompositeKey<int>>();
+        assert(false);
+        // for (const auto &ref : batch)
+        // {
+        //     const CompositeKey<int> *key =
+        //         ref.Key().GetKey<CompositeKey<int>>();
 
-            const CompositeRecord<int> &rec = *ref.Payload();
+        //     const CompositeRecord<int> &rec = *ref.Payload();
 
-            int key_val = std::get<0>(key->Tuple());
-            if (ref.payload_status_ == RecordStatus::Deleted)
-            {
-                int_store_.erase(key_val);
-            }
-            else
-            {
-                int rec_val = std::get<0>(rec.Tuple());
-                int_store_.insert_or_assign(key_val, rec_val);
-            }
+        //     int key_val = std::get<0>(key->Tuple());
+        //     if (ref.payload_status_ == RecordStatus::Deleted)
+        //     {
+        //         int_store_.erase(key_val);
+        //     }
+        //     else
+        //     {
+        //         int rec_val = std::get<0>(rec.Tuple());
+        //         int_store_.insert_or_assign(key_val, rec_val);
+        //     }
 
-            if (int_store_.size() > 1000)
-            {
-                int_store_.erase(int_store_.begin());
-            }
-        }
+        //     if (int_store_.size() > 1000)
+        //     {
+        //         int_store_.erase(int_store_.begin());
+        //     }
+        // }
 
         return true;
     }
@@ -251,10 +252,10 @@ public:
      * @brief Write batch historical versions into DataStore.
      *
      */
-    bool PutArchivesAll(uint32_t node_group,
-                        const txservice::TableName &table_name,
-                        const txservice::KVCatalogInfo *kv_info,
-                        std::vector<txservice::FlushRecord> &batch) override
+    bool PutArchivesAll(std::unordered_map<
+                        std::string_view,
+                        std::vector<std::unique_ptr<txservice::FlushTaskEntry>>>
+                            &flush_task) override
     {
         assert(false);
         return true;
@@ -262,10 +263,11 @@ public:
     /**
      * @brief Copy record from base/sk table to mvcc_archives.
      */
-    bool CopyBaseToArchive(std::vector<std::pair<TxKey, int32_t>> &batch,
-                           uint32_t node_group,
-                           const txservice::TableName &table_name,
-                           const txservice::TableSchema *table_schema) override
+    bool CopyBaseToArchive(
+        std::unordered_map<
+            std::string_view,
+            std::vector<std::unique_ptr<txservice::FlushTaskEntry>>>
+                &flush_task) override
     {
         assert(false);
         return true;

--- a/include/store/int_mem_store.h
+++ b/include/store/int_mem_store.h
@@ -46,13 +46,11 @@ public:
     }
 
     /**
-     * @brief flush entries in \@param batch to base table or skindex table in
-     * data store, stop and return false if node_group is not longer leader.
-     * @param batch
-     * @param table_name base table name or sk index name
-     * @param table_schema
-     * @param schema_ts
-     * @param node_group
+     * @brief flush entries in \@param flush_task to base table or skindex table in
+     * data store, stop and return false if the flush failed after max retry times.
+     * @param flush_task - the flush task to be flushed. Map key is the kv table name,
+     * value is the vector of flush task entries. PutAll only flushes the data_sync_vec_
+     * in each flush task entry.
      * @return whether all entries are written to data store successfully
      */
     bool PutAll(std::unordered_map<

--- a/include/type.h
+++ b/include/type.h
@@ -447,6 +447,11 @@ struct TableName
         return (pos != std::string_view::npos) ? true : false;
     }
 
+    bool IsHashPartitioned() const
+    {
+        return engine_ == TableEngine::EloqKv;
+    }
+
     bool IsStringOwner() const
     {
         return own_string_;

--- a/src/cc/cc_req_misc.cpp
+++ b/src/cc/cc_req_misc.cpp
@@ -899,11 +899,11 @@ bool UpdateCceCkptTsCc::Execute(CcShard &ccs)
 {
     assert(indices_.count(ccs.core_id_) > 0);
 
-    auto &this_core_current_idxs = indices_[ccs.core_id_];
-    auto &this_core_cce_entries = cce_entries_[ccs.core_id_];
-    assert(this_core_current_idxs.first < this_core_cce_entries.size());
+    auto &index = indices_[ccs.core_id_];
+    auto &records = cce_entries_[ccs.core_id_];
+    assert(index < records.size());
 
-    if (this_core_current_idxs.first >= this_core_cce_entries.size())
+    if (index >= records.size())
     {
         // Set finished. We don't care error code.
         SetFinished();
@@ -919,9 +919,6 @@ bool UpdateCceCkptTsCc::Execute(CcShard &ccs)
         SetFinished();
         return false;
     }
-
-    auto &records = this_core_cce_entries[this_core_current_idxs.first];
-    auto &index = this_core_current_idxs.second;
 
     size_t last_index = std::min(index + SCAN_BATCH_SIZE, records.size());
 
@@ -947,16 +944,7 @@ bool UpdateCceCkptTsCc::Execute(CcShard &ccs)
 
     if (index == records.size())
     {
-        this_core_current_idxs.first++;
-        this_core_current_idxs.second = 0;
-        if (this_core_current_idxs.first >= this_core_cce_entries.size())
-        {
-            SetFinished();
-        }
-        else
-        {
-            ccs.Enqueue(ccs.core_id_, this);
-        }
+        SetFinished();
     }
     else
     {

--- a/src/cc/cc_shard.cpp
+++ b/src/cc/cc_shard.cpp
@@ -1012,21 +1012,21 @@ std::pair<size_t, bool> CcShard::Clean()
  * @brief Flush Entry to KvStore. Now, only used for test.
  *
  */
-bool CcShard::FlushEntryForTest(const TableName &tbl_name,
-                                const TableSchema *tbl_schema,
-                                std::vector<FlushRecord> &ckpt_vec,
-                                std::vector<FlushRecord> &archives,
-                                bool only_archives)
+bool CcShard::FlushEntryForTest(
+    std::unordered_map<std::string_view,
+                       std::vector<std::unique_ptr<FlushTaskEntry>>>
+        &flush_task_entries,
+    bool only_archives)
 {
     // TODO(lzx): Now, only flush archives synchronously for test.
     if (only_archives)
     {
-        return ckpter_->FlushArchiveForTest(tbl_name, tbl_schema, archives);
+        return ckpter_->FlushArchiveForTest(flush_task_entries);
     }
     else
     {
-        return (ckpter_->CkptEntryForTest(tbl_name, tbl_schema, ckpt_vec)) &&
-               (ckpter_->FlushArchiveForTest(tbl_name, tbl_schema, archives));
+        return (ckpter_->CkptEntryForTest(flush_task_entries)) &&
+               (ckpter_->FlushArchiveForTest(flush_task_entries));
     }
 }
 

--- a/src/checkpointer.cpp
+++ b/src/checkpointer.cpp
@@ -333,6 +333,10 @@ void Checkpointer::Ckpt(bool is_last_ckpt)
         {
             std::unique_lock<std::mutex> task_sender_lk(status->mux_);
             status->all_task_started_ = true;
+            if (status->unfinished_scan_tasks_ == 0 && status->unfinished_tasks_ != 0)
+            {
+                local_shards_.FlushCurrentFlushBuffer();
+            }
             if (is_last_ckpt)
             {
                 // Wait for all tasks to be done if this is last checkpoint
@@ -344,8 +348,6 @@ void Checkpointer::Ckpt(bool is_last_ckpt)
 
             if (status->unfinished_tasks_ == 0)
             {
-                status->PersistKV();
-
                 if (status->need_truncate_log_ &&
                     status->err_code_ == CcErrorCode::NO_ERROR)
                 {
@@ -520,7 +522,20 @@ bool Checkpointer::CkptEntryForTest(const TableName &tbl_name,
 {
     bool ckpt_ret = false;
     uint32_t ng = Sharder::Instance().NativeNodeGroup();
-    ckpt_ret = store_hd_->PutAll(ckpt_vec, tbl_name, tbl_schema, ng);
+    std::unordered_map<TableName, std::vector<std::unique_ptr<FlushTaskEntry>>>
+        flush_task_entries;
+    flush_task_entries.try_emplace(
+        tbl_name, std::vector<std::unique_ptr<FlushTaskEntry>>());
+    // flush_task_entries[tbl_name].emplace_back(std::make_unique<FlushTaskEntry>(
+    //     std::make_unique<std::vector<FlushRecord>>(std::move(ckpt_vec)),
+    //     nullptr,
+    //     nullptr,
+    //     nullptr,
+    //     nullptr,
+    //     std::make_shared<TableSchema>(*tbl_schema),
+    //     0));
+
+    // ckpt_ret = store_hd_->PutAll(flush_task_entries);
 
     return ckpt_ret;
 }
@@ -531,8 +546,8 @@ bool Checkpointer::FlushArchiveForTest(const TableName &tbl_name,
 {
     bool ckpt_ret = false;
     uint32_t ng = Sharder::Instance().NativeNodeGroup();
-    ckpt_ret = store_hd_->PutArchivesAll(
-        ng, tbl_name, tbl_schema->GetKVCatalogInfo(), archives);
+    // ckpt_ret = store_hd_->PutArchivesAll(
+    //     ng, tbl_name, tbl_schema->GetKVCatalogInfo(), archives);
     return ckpt_ret;
 }
 }  // namespace txservice

--- a/src/checkpointer.cpp
+++ b/src/checkpointer.cpp
@@ -333,7 +333,8 @@ void Checkpointer::Ckpt(bool is_last_ckpt)
         {
             std::unique_lock<std::mutex> task_sender_lk(status->mux_);
             status->all_task_started_ = true;
-            if (status->unfinished_scan_tasks_ == 0 && status->unfinished_tasks_ != 0)
+            if (status->unfinished_scan_tasks_ == 0 &&
+                status->unfinished_tasks_ != 0)
             {
                 local_shards_.FlushCurrentFlushBuffer();
             }
@@ -516,38 +517,19 @@ void Checkpointer::NotifyLogOfCkptTs(uint32_t node_group,
     }
 }
 
-bool Checkpointer::CkptEntryForTest(const TableName &tbl_name,
-                                    const TableSchema *tbl_schema,
-                                    std::vector<FlushRecord> &ckpt_vec)
+bool Checkpointer::CkptEntryForTest(
+    std::unordered_map<std::string_view,
+                       std::vector<std::unique_ptr<FlushTaskEntry>>>
+        &flush_task_entries)
 {
-    bool ckpt_ret = false;
-    uint32_t ng = Sharder::Instance().NativeNodeGroup();
-    std::unordered_map<TableName, std::vector<std::unique_ptr<FlushTaskEntry>>>
-        flush_task_entries;
-    flush_task_entries.try_emplace(
-        tbl_name, std::vector<std::unique_ptr<FlushTaskEntry>>());
-    // flush_task_entries[tbl_name].emplace_back(std::make_unique<FlushTaskEntry>(
-    //     std::make_unique<std::vector<FlushRecord>>(std::move(ckpt_vec)),
-    //     nullptr,
-    //     nullptr,
-    //     nullptr,
-    //     nullptr,
-    //     std::make_shared<TableSchema>(*tbl_schema),
-    //     0));
-
-    // ckpt_ret = store_hd_->PutAll(flush_task_entries);
-
-    return ckpt_ret;
+    return store_hd_->PutAll(flush_task_entries);
 }
 
-bool Checkpointer::FlushArchiveForTest(const TableName &tbl_name,
-                                       const TableSchema *tbl_schema,
-                                       std::vector<FlushRecord> &archives)
+bool Checkpointer::FlushArchiveForTest(
+    std::unordered_map<std::string_view,
+                       std::vector<std::unique_ptr<FlushTaskEntry>>>
+        &flush_task_entries)
 {
-    bool ckpt_ret = false;
-    uint32_t ng = Sharder::Instance().NativeNodeGroup();
-    // ckpt_ret = store_hd_->PutArchivesAll(
-    //     ng, tbl_name, tbl_schema->GetKVCatalogInfo(), archives);
-    return ckpt_ret;
+    return store_hd_->PutArchivesAll(flush_task_entries);
 }
 }  // namespace txservice

--- a/src/data_sync_task.cpp
+++ b/src/data_sync_task.cpp
@@ -207,6 +207,10 @@ void DataSyncTask::SetScanTaskFinished()
 {
     std::unique_lock<std::mutex> task_sender_lk(status_->mux_);
     status_->unfinished_scan_tasks_--;
+    DLOG(INFO) << "SetScanTaskFinished, unfinished_scan_tasks_: "
+               << status_->unfinished_scan_tasks_ << ", all_task_started_: "
+               << status_->all_task_started_ << ", unfinished_tasks_: "
+               << status_->unfinished_tasks_;
 
     if (status_->unfinished_scan_tasks_ == 0 && status_->all_task_started_ &&
         status_->unfinished_tasks_ != 0)

--- a/src/data_sync_task.cpp
+++ b/src/data_sync_task.cpp
@@ -79,6 +79,12 @@ DataSyncTask::DataSyncTask(const TableName &table_name,
     {
         range_id_ = range_entry_->GetRangeInfo()->GetKeyNewRangeId(start_key_);
     }
+
+    // For a data sync task during range split, we only need to update the ckpt ts
+    // if the new range owner is the current node group.
+    NodeGroupId range_owner =
+        Sharder::Instance().GetLocalCcShards()->GetRangeOwner(range_id_, ng_id)->BucketOwner();
+    need_update_ckpt_ts_ = range_owner == ng_id;
 }
 #endif
 
@@ -101,8 +107,6 @@ void DataSyncTask::SetFinish()
 
     if (status_->unfinished_tasks_ == 0 && status_->all_task_started_)
     {
-        status_->PersistKV();
-
         if (status_->need_truncate_log_)
         {
             if (status_->err_code_ == CcErrorCode::NO_ERROR)
@@ -189,122 +193,12 @@ void DataSyncTask::SetError(CcErrorCode err_code)
 
     if (status_->unfinished_tasks_ == 0 && status_->all_task_started_)
     {
-        status_->PersistKV();
-
         if (task_res_)
         {
             task_res_->SetError(status_->err_code_);
         }
         status_->cv_.notify_all();
     }
-}
-
-void DataSyncStatus::PersistKV()
-{
-    store::DataStoreHandler *store_hd =
-        Sharder::Instance().GetDataStoreHandler();
-    if (store_hd != nullptr && store_hd->NeedPersistKV())
-    {
-        // set `force` flag.
-        bool res = PersistKV("", {}, nullptr, true);
-        if (!res && err_code_ == CcErrorCode::NO_ERROR)
-        {
-            err_code_ = CcErrorCode::DATA_STORE_ERR;
-        }
-    }
-}
-
-bool DataSyncStatus::PersistKV(
-    const std::string &kv_table_name,
-    absl::flat_hash_map<size_t, std::vector<UpdateCceCkptTsCc::CkptTsEntry>>
-        &&cce_entries,
-    std::shared_ptr<DataSyncTask> task,
-    bool all_task_finished)
-{
-    static constexpr uint64_t CKPT_END_BATCH_SIZE = 1000000;
-
-    bool flush_ret = true;
-
-    store::DataStoreHandler *store_hd =
-        Sharder::Instance().GetDataStoreHandler();
-
-    if (store_hd && store_hd->NeedPersistKV())
-    {
-        std::unique_lock<std::mutex> task_lk(task_mux_);
-
-        if (task != nullptr)
-        {
-            tasks_.push_back(std::move(task));
-        }
-
-        if (!kv_table_name.empty())
-        {
-            dedup_kv_table_names_.insert(kv_table_name);
-        }
-
-        for (auto &[core_idx, entry] : cce_entries)
-        {
-            total_entry_cnt_ += entry.size();
-            cce_entries_[core_idx].push_back(std::move(entry));
-        }
-
-        if (total_entry_cnt_ >= CKPT_END_BATCH_SIZE || all_task_finished)
-        {
-            auto tmp_flush_task_entries = std::move(cce_entries_);
-            auto tmp_tasks = std::move(tasks_);
-            std::vector<std::string> kv_table_names(
-                dedup_kv_table_names_.begin(), dedup_kv_table_names_.end());
-
-            size_t entry_cnt = total_entry_cnt_;
-            total_entry_cnt_ = 0;
-            cce_entries_.clear();
-            dedup_kv_table_names_.clear();
-            assert(tasks_.empty());
-            assert(cce_entries_.empty());
-            assert(dedup_kv_table_names_.empty());
-
-            task_lk.unlock();
-
-            if (entry_cnt != 0 && !tmp_flush_task_entries.empty())
-            {
-                flush_ret = store_hd->PersistKV(kv_table_names);
-                DLOG(INFO) << "ckpt_end, res:" << static_cast<int>(flush_ret);
-
-                if (flush_ret)
-                {
-                    UpdateCceCkptTsCc update_cce_ckpt_req(
-                        node_group_id_,
-                        node_group_term_,
-                        std::move(tmp_flush_task_entries));
-
-                    LocalCcShards *local_shards =
-                        Sharder::Instance().GetLocalCcShards();
-
-                    for (const auto &entry : update_cce_ckpt_req.EntriesRef())
-                    {
-                        local_shards->EnqueueToCcShard(entry.first,
-                                                       &update_cce_ckpt_req);
-                    }
-                    update_cce_ckpt_req.Wait();
-
-                    // Reset waiting ckpt flag. Shards should be able to request
-                    // ckpt
-                    // again if no cc entries can be kicked out.
-                    local_shards->SetWaitingCkpt(false);
-                }
-            }
-
-            LocalCcShards *local_shards =
-                Sharder::Instance().GetLocalCcShards();
-
-            for (auto &task : tmp_tasks)
-            {
-                local_shards->PostProcessCkpt(task, flush_ret);
-            }
-        }
-    }
-
-    return flush_ret;
 }
 
 }  // namespace txservice

--- a/src/data_sync_task.cpp
+++ b/src/data_sync_task.cpp
@@ -207,11 +207,6 @@ void DataSyncTask::SetScanTaskFinished()
 {
     std::unique_lock<std::mutex> task_sender_lk(status_->mux_);
     status_->unfinished_scan_tasks_--;
-    DLOG(INFO) << "SetScanTaskFinished, unfinished_scan_tasks_: "
-               << status_->unfinished_scan_tasks_ << ", all_task_started_: "
-               << status_->all_task_started_ << ", unfinished_tasks_: "
-               << status_->unfinished_tasks_;
-
     if (status_->unfinished_scan_tasks_ == 0 && status_->all_task_started_ &&
         status_->unfinished_tasks_ != 0)
     {

--- a/src/data_sync_task.cpp
+++ b/src/data_sync_task.cpp
@@ -80,10 +80,12 @@ DataSyncTask::DataSyncTask(const TableName &table_name,
         range_id_ = range_entry_->GetRangeInfo()->GetKeyNewRangeId(start_key_);
     }
 
-    // For a data sync task during range split, we only need to update the ckpt ts
-    // if the new range owner is the current node group.
-    NodeGroupId range_owner =
-        Sharder::Instance().GetLocalCcShards()->GetRangeOwner(range_id_, ng_id)->BucketOwner();
+    // For a data sync task during range split, we only need to update the ckpt
+    // ts if the new range owner is the current node group.
+    NodeGroupId range_owner = Sharder::Instance()
+                                  .GetLocalCcShards()
+                                  ->GetRangeOwner(range_id_, ng_id)
+                                  ->BucketOwner();
     need_update_ckpt_ts_ = range_owner == ng_id;
 }
 #endif
@@ -206,11 +208,13 @@ void DataSyncTask::SetScanTaskFinished()
     std::unique_lock<std::mutex> task_sender_lk(status_->mux_);
     status_->unfinished_scan_tasks_--;
 
-    if (status_->unfinished_scan_tasks_ == 0 && status_->all_task_started_ && status_->unfinished_tasks_ != 0)
+    if (status_->unfinished_scan_tasks_ == 0 && status_->all_task_started_ &&
+        status_->unfinished_tasks_ != 0)
     {
-        // If all scan tasks are finished, but there are still unfinished data sync task due to pending flush,
-        // flush the current flush buffer.
-        DLOG(INFO) << "Flushing current flush buffer after all scan tasks are finished";
+        // If all scan tasks are finished, but there are still unfinished data
+        // sync task due to pending flush, flush the current flush buffer.
+        DLOG(INFO) << "Flushing current flush buffer after all scan tasks are "
+                      "finished";
         Sharder::Instance().GetLocalCcShards()->FlushCurrentFlushBuffer();
     }
 }

--- a/src/remote/cc_node_service.cpp
+++ b/src/remote/cc_node_service.cpp
@@ -671,7 +671,6 @@ void CcNodeService::FlushDataAll(::google::protobuf::RpcController *controller,
             status->cv_.wait(
                 lk, [&status] { return status->unfinished_tasks_ == 0; });
 
-            status->PersistKV();
             error_code = status->err_code_;
 
             std::unique_lock b_thd_lk(b_thd_mu);

--- a/src/store/snapshot_manager.cpp
+++ b/src/store/snapshot_manager.cpp
@@ -363,8 +363,6 @@ bool SnapshotManager::RunOneRoundCheckpoint(uint32_t node_group,
         [&data_sync_status]
         { return data_sync_status->unfinished_tasks_ == 0; });
 
-    data_sync_status->PersistKV();
-
     return (data_sync_status->err_code_ == CcErrorCode::NO_ERROR);
 }
 

--- a/src/tx_operation.cpp
+++ b/src/tx_operation.cpp
@@ -5430,6 +5430,7 @@ void ObjectCommandOp::Forward(TransactionExecution *txm)
 
             bool force_error = hd_result_.ForceError();
             assert(force_error);
+            (void) force_error;
 
             txm->PostProcess(*this);
             return;


### PR DESCRIPTION
Buffer data from multiple data sync tasks in a flush buffer and flush them all at once.
We do this for the following reasons.
1. For rocksdb, write in a bigger batch then call PersistKv generates less but bigger sst files, which results in smaller compaction pressure on level 0.
2. For eloqstore, write in a bigger batch for each partition improves overall write efficiency.