### PR TITLE
Fix build error of missing kv_table_name_

### DIFF
--- a/include/cc/cc_req_misc.h
+++ b/include/cc/cc_req_misc.h
@@ -547,6 +547,7 @@ public:
     const TableSchema *table_schema_{nullptr};
 #if defined(DATA_STORE_TYPE_ELOQDSS_ROCKSDB_CLOUD_S3) ||  \
     defined(DATA_STORE_TYPE_ELOQDSS_ROCKSDB_CLOUD_GCS) || \
+    defined(DATA_STORE_TYPE_ELOQDSS_ROCKSDB) ||           \
     defined(DATA_STORE_TYPE_ELOQDSS_ELOQSTORE)
     std::string kv_table_name_;
 #endif


### PR DESCRIPTION
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Reference the link of issue using `fixes eloqdb/tx_service#issue_id`
- [ ] Reference the link of RFC if exists
- [ ] Pass `./mtr --suite=mono_main,mono_multi,mono_basic`
