### PR TITLE
Fixing missed CcErrorCode to TxErrorCode mapping

### DIFF
--- a/include/error_messages.h
+++ b/include/error_messages.h
@@ -108,7 +108,7 @@ enum struct TxErrorCode : uint16_t
     NEGOTIATED_TX_UNKNOWN,
     NEGOTIATE_TX_ERR,
     // Scan
-    CRATE_CCM_SCANNER_FAILED,
+    CREATE_CCM_SCANNER_FAILED,
     // log service
     LOG_CLOSURE_RESULT_UNKNOWN_ERR,
     WRITE_LOG_FAILED,
@@ -200,7 +200,7 @@ static const std::unordered_map<TxErrorCode, std::string> tx_error_messages{
      "transaction status is unknown."},
     {TxErrorCode::NEGOTIATE_TX_ERR,
      "Negotiate transaction commit timestamp failed due to error."},
-    {TxErrorCode::CRATE_CCM_SCANNER_FAILED,
+    {TxErrorCode::CREATE_CCM_SCANNER_FAILED,
      "Create in memory data scanner failed."},
     {TxErrorCode::WRITE_LOG_FAILED, "Write log failed."},
     {TxErrorCode::LOG_NODE_NOT_LEADER, "Log node is not leader."},
@@ -267,7 +267,7 @@ enum struct CcErrorCode : uint8_t
     NEGOTIATE_TX_ERR,
 
     // Scan
-    CRATE_CCM_SCANNER_FAILED,
+    CREATE_CCM_SCANNER_FAILED,
 
     // AcquireAllCc, AcquireCc
     DUPLICATE_INSERT_ERR,
@@ -351,7 +351,7 @@ static const std::unordered_map<CcErrorCode, std::string> cc_error_messages{
      "REQUESTED_INDEX_TABLE_NOT_EXISTS"},
     {CcErrorCode::REQUESTED_TABLE_SCHEMA_MISMATCH,
      "REQUESTED_TABLE_SCHEMA_MISMATCH"},
-    {CcErrorCode::CRATE_CCM_SCANNER_FAILED, "CRATE_CCM_SCANNER_FAILED"},
+    {CcErrorCode::CREATE_CCM_SCANNER_FAILED, "CRATE_CCM_SCANNER_FAILED"},
 
     {CcErrorCode::DUPLICATE_INSERT_ERR, "DUPLICATE_INSERT_ERR"},
     {CcErrorCode::ACQUIRE_LOCK_BLOCKED, "ACQUIRE_LOCK_BLOCKED"},

--- a/include/error_messages.h
+++ b/include/error_messages.h
@@ -91,6 +91,42 @@ enum struct TxErrorCode : uint16_t
 
     // Catalog read write conflict, the table(db) is being modified.
     READ_CATALOG_CONFLICT,
+
+    // TemplatedCcRequest Common
+    REQUESTD_TABLE_NOT_EXISTS,
+    REQUESTD_INDEX_TABLE_NOT_EXISTS,
+    REQUESTD_TABLE_SCHEMA_MISMATCH,
+
+    // ReadCc,ScanOpenBatchCc,ScanNextBatchCc,AcquireAllCc,AcquireCc,
+    ACQUIRE_LOCK_BLOCKED,  // (only used by CcMap).
+    // ReadCc,ScanOpenBatchCc,ScanNextBatchCc
+    MVCC_READ_MUST_WAIT_WRITE,     // (only used by CcMap).
+    MVCC_READ_FOR_WRITE_CONFLICT,  // latest version not fits the read timestamp
+    // ReadLocal,ScanLocal
+    TX_NODE_NOT_LEADER,
+    // NegotiateCc
+    NEGOTIATED_TX_UNKNOWN,
+    NEGOTIATE_TX_ERR,
+    // Scan
+    CRATE_CCM_SCANNER_FAILED,
+    // log service
+    LOG_CLOSURE_RESULT_UNKNOWN_ERR,
+    WRITE_LOG_FAILED,
+    LOG_NODE_NOT_LEADER,
+    DUPLICATE_MIGRATION_TX_ERR,
+    DUPLICATE_CLUSTER_SCALE_TX_ERR,
+    ESTABLISH_NODE_CHANNEL_FAILED,
+    // Error when call system handler, like ReloadCacheCc.
+    SYSTEM_HANDLER_ERR,
+    TASK_EXPIRED,
+    LOG_NOT_TRUNCATABLE,
+    // Refuse to receive batch data sent from remote for cache.
+    UPLOAD_BATCH_REJECTED,
+    // RPC failed that can not retry
+    RPC_CALL_ERR,
+    // Update sequence table fail
+    UPDATE_SEQUENCE_TABLE_FAIL,
+
 };
 
 static const std::unordered_map<TxErrorCode, std::string> tx_error_messages{
@@ -147,7 +183,36 @@ static const std::unordered_map<TxErrorCode, std::string> tx_error_messages{
      "Execute TxRequest failed, transaction has committed/aborted"},
     {TxErrorCode::READ_CATALOG_FAIL, "Current db has not been initialized"},
     {TxErrorCode::READ_CATALOG_CONFLICT,
-     "Current db is being modified by FLUSHDB"}};
+     "Read catalog conflict, the table(db) is being modified."},
+    {TxErrorCode::REQUESTD_TABLE_NOT_EXISTS, "Requested table not exists."},
+    {TxErrorCode::REQUESTD_INDEX_TABLE_NOT_EXISTS,
+     "Requested index table not exists."},
+    {TxErrorCode::REQUESTD_TABLE_SCHEMA_MISMATCH,
+     "Requested table schema mismatch."},
+    {TxErrorCode::ACQUIRE_LOCK_BLOCKED, "Acquire lock blocked."},
+    {TxErrorCode::MVCC_READ_MUST_WAIT_WRITE,
+     "MVCC read must wait write to finish."},
+    {TxErrorCode::MVCC_READ_FOR_WRITE_CONFLICT,
+     "MVCC read for write conflict."},
+    {TxErrorCode::TX_NODE_NOT_LEADER, "Transaction node is not leader."},
+    {TxErrorCode::NEGOTIATED_TX_UNKNOWN,
+     "Negotiated transaction commit timestamp failed since conflict "
+     "transaction status is unknown."},
+    {TxErrorCode::NEGOTIATE_TX_ERR,
+     "Negotiate transaction commit timestamp failed due to error."},
+    {TxErrorCode::CRATE_CCM_SCANNER_FAILED,
+     "Create in memory data scanner failed."},
+    {TxErrorCode::WRITE_LOG_FAILED, "Write log failed."},
+    {TxErrorCode::LOG_NODE_NOT_LEADER, "Log node is not leader."},
+    {TxErrorCode::ESTABLISH_NODE_CHANNEL_FAILED,
+     "Establish node channel failed."},
+    {TxErrorCode::SYSTEM_HANDLER_ERR, "System handler error."},
+    {TxErrorCode::TASK_EXPIRED, "Task expired."},
+    {TxErrorCode::LOG_NOT_TRUNCATABLE, "Log not truncatable."},
+    {TxErrorCode::UPLOAD_BATCH_REJECTED, "Upload batch rejected."},
+    {TxErrorCode::RPC_CALL_ERR, "RPC call error."},
+    {TxErrorCode::UPDATE_SEQUENCE_TABLE_FAIL, "Update sequence table fail."},
+};
 
 static inline const std::string &TxErrorMessage(TxErrorCode err_code)
 {
@@ -342,6 +407,8 @@ static const std::unordered_map<CcErrorCode, std::string> cc_error_messages{
     {CcErrorCode::LOG_NODE_NOT_LEADER, "LOG_NODE_NOT_LEADER"},
 
     {CcErrorCode::READ_CATALOG_CONFLICT, "READ_CATALOG_CONFLICT"},
+    {CcErrorCode::RPC_CALL_ERR, "RPC_CALL_ERR"},
+    {CcErrorCode::UPDATE_SEQUENCE_TABLE_FAIL, "UPDATE_SEQUENCE_TABLE_FAIL"},
 
     // NOTICE: please keep this variable at tail.
     {CcErrorCode::LAST_ERROR_CODE, "LAST_ERROR_CODE"},

--- a/src/cc/local_cc_handler.cpp
+++ b/src/cc/local_cc_handler.cpp
@@ -1172,7 +1172,7 @@ void txservice::LocalCcHandler::ScanOpenLocal(
 
     if (ccm_scanner == nullptr)
     {
-        hd_res.SetError(CcErrorCode::CRATE_CCM_SCANNER_FAILED);
+        hd_res.SetError(CcErrorCode::CREATE_CCM_SCANNER_FAILED);
         return;
     }
 

--- a/src/tx_execution.cpp
+++ b/src/tx_execution.cpp
@@ -411,8 +411,8 @@ TxErrorCode TransactionExecution::ConvertCcError(CcErrorCode error)
     case CcErrorCode::NEGOTIATE_TX_ERR:
         return TxErrorCode::NEGOTIATE_TX_ERR;
 
-    case CcErrorCode::CRATE_CCM_SCANNER_FAILED:
-        return TxErrorCode::CRATE_CCM_SCANNER_FAILED;
+    case CcErrorCode::CREATE_CCM_SCANNER_FAILED:
+        return TxErrorCode::CREATE_CCM_SCANNER_FAILED;
 
     case CcErrorCode::LOG_CLOSURE_RESULT_UNKNOWN_ERR:
         return TxErrorCode::LOG_SERVICE_UNREACHABLE;

--- a/src/tx_execution.cpp
+++ b/src/tx_execution.cpp
@@ -344,9 +344,6 @@ TxErrorCode TransactionExecution::ConvertCcError(CcErrorCode error)
     case CcErrorCode::VALIDATION_FAILED_FOR_CONFILICTED_TXS:
         return TxErrorCode::OCC_BREAK_REPEATABLE_READ;
 
-    case CcErrorCode::MVCC_READ_FOR_WRITE_CONFLICT:
-        return TxErrorCode::SI_R4W_ERR_KEY_WAS_UPDATED;
-
     case CcErrorCode::DEAD_LOCK_ABORT:
         return TxErrorCode::DEAD_LOCK_ABORT;
 
@@ -390,6 +387,61 @@ TxErrorCode TransactionExecution::ConvertCcError(CcErrorCode error)
         return TxErrorCode::UNIQUE_CONSTRAINT;
     case CcErrorCode::PACK_SK_ERR:
         return TxErrorCode::CAL_ENGINE_DEFINED_CONSTRAINT;
+
+    case CcErrorCode::REQUESTED_TABLE_NOT_EXISTS:
+        return TxErrorCode::REQUESTD_TABLE_NOT_EXISTS;
+    case CcErrorCode::REQUESTED_INDEX_TABLE_NOT_EXISTS:
+        return TxErrorCode::REQUESTD_INDEX_TABLE_NOT_EXISTS;
+    case CcErrorCode::REQUESTED_TABLE_SCHEMA_MISMATCH:
+        return TxErrorCode::REQUESTD_TABLE_SCHEMA_MISMATCH;
+
+    case CcErrorCode::ACQUIRE_LOCK_BLOCKED:
+        return TxErrorCode::ACQUIRE_LOCK_BLOCKED;
+
+    case CcErrorCode::MVCC_READ_MUST_WAIT_WRITE:
+        return TxErrorCode::MVCC_READ_MUST_WAIT_WRITE;
+    case CcErrorCode::MVCC_READ_FOR_WRITE_CONFLICT:
+        return TxErrorCode::SI_R4W_ERR_KEY_WAS_UPDATED;
+
+    case CcErrorCode::TX_NODE_NOT_LEADER:
+        return TxErrorCode::TX_NODE_NOT_LEADER;
+
+    case CcErrorCode::NEGOTIATED_TX_UNKNOWN:
+        return TxErrorCode::NEGOTIATED_TX_UNKNOWN;
+    case CcErrorCode::NEGOTIATE_TX_ERR:
+        return TxErrorCode::NEGOTIATE_TX_ERR;
+
+    case CcErrorCode::CRATE_CCM_SCANNER_FAILED:
+        return TxErrorCode::CRATE_CCM_SCANNER_FAILED;
+
+    case CcErrorCode::LOG_CLOSURE_RESULT_UNKNOWN_ERR:
+        return TxErrorCode::LOG_SERVICE_UNREACHABLE;
+    case CcErrorCode::WRITE_LOG_FAILED:
+        return TxErrorCode::WRITE_LOG_FAIL;
+    case CcErrorCode::LOG_NODE_NOT_LEADER:
+        return TxErrorCode::LOG_NODE_NOT_LEADER;
+    case CcErrorCode::DUPLICATE_MIGRATION_TX_ERR:
+        return TxErrorCode::DUPLICATE_MIGRATION_TX_ERROR;
+    case CcErrorCode::DUPLICATE_CLUSTER_SCALE_TX_ERR:
+        return TxErrorCode::DUPLICATE_CLUSTER_SCALE_TX_ERROR;
+    case CcErrorCode::ESTABLISH_NODE_CHANNEL_FAILED:
+        return TxErrorCode::ESTABLISH_NODE_CHANNEL_FAILED;
+
+    case CcErrorCode::SYSTEM_HANDLER_ERR:
+        return TxErrorCode::SYSTEM_HANDLER_ERR;
+    case CcErrorCode::TASK_EXPIRED:
+        return TxErrorCode::TASK_EXPIRED;
+    case CcErrorCode::LOG_NOT_TRUNCATABLE:
+        return TxErrorCode::LOG_NOT_TRUNCATABLE;
+
+    case CcErrorCode::UPLOAD_BATCH_REJECTED:
+        return TxErrorCode::UPLOAD_BATCH_REJECTED;
+
+    case CcErrorCode::RPC_CALL_ERR:
+        return TxErrorCode::RPC_CALL_ERR;
+
+    case CcErrorCode::UPDATE_SEQUENCE_TABLE_FAIL:
+        return TxErrorCode::UPDATE_SEQUENCE_TABLE_FAIL;
 
     case CcErrorCode::UNDEFINED_ERR:
     default:


### PR DESCRIPTION
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Reference the link of issue using `fixes eloqdb/tx_service#issue_id`
- [ ] Reference the link of RFC if exists
- [ ] Pass `./mtr --suite=mono_main,mono_multi,mono_basic`
