### PR TITLE
Update last_read_ts_ of CcShard at ReadCc/ScanSliceCc

### DIFF
--- a/include/cc/cc_entry.h
+++ b/include/cc/cc_entry.h
@@ -1236,9 +1236,7 @@ public:
      * @param ts - snapshot read timestamp
      * @param rec - variable to store result
      */
-    void MvccGet(uint64_t ts,
-                 uint64_t &last_read_ts,
-                 VersionResultRecord<ValueT> &rec)
+    void MvccGet(uint64_t ts, VersionResultRecord<ValueT> &rec)
     {
         assert(VersionedRecord);
         const uint64_t commit_ts = this->CommitTs();
@@ -1256,7 +1254,6 @@ public:
             // writer's commit_ts must be higher than MVCC reader's ts. Or it
             // will break the REPEATABLE READ since the next MVCC read in the
             // same transaction will read the new updated ccentry.
-            last_read_ts = std::max(ts, last_read_ts);
             if (rec_status == RecordStatus::Normal)
             {
                 rec.payload_ptr_ = payload_.VersionedCurrentPayload();

--- a/include/cc/cc_entry.h
+++ b/include/cc/cc_entry.h
@@ -1250,10 +1250,6 @@ public:
         }
         if (commit_ts <= ts)
         {
-            // MVCC update last_read_ts_ of lastest ccentry to tell later
-            // writer's commit_ts must be higher than MVCC reader's ts. Or it
-            // will break the REPEATABLE READ since the next MVCC read in the
-            // same transaction will read the new updated ccentry.
             if (rec_status == RecordStatus::Normal)
             {
                 rec.payload_ptr_ = payload_.VersionedCurrentPayload();

--- a/include/cc/template_cc_map.h
+++ b/include/cc/template_cc_map.h
@@ -1836,6 +1836,11 @@ public:
                 });
                 if (req.Isolation() == IsolationLevel::Snapshot)
                 {
+                    // MVCC update last_read_ts_ of lastest ccentry to tell
+                    // later writer's commit_ts must be higher than MVCC
+                    // reader's ts. Or it will break the REPEATABLE READ since
+                    // the next MVCC read in the same transaction will read the
+                    // new updated ccentry.
                     shard_->UpdateLastReadTs(req.ReadTimestamp());
                 }
                 std::tie(acquired_lock, err_code) =
@@ -4599,6 +4604,11 @@ public:
         {
             if (req.Isolation() == IsolationLevel::Snapshot)
             {
+                // MVCC update last_read_ts_ of lastest ccentry to tell
+                // later writer's commit_ts must be higher than MVCC
+                // reader's ts. Or it will break the REPEATABLE READ since
+                // the next MVCC read in the same transaction will read the
+                // new updated ccentry.
                 shard_->UpdateLastReadTs(req.ReadTimestamp());
             }
 

--- a/include/cc/template_cc_map.h
+++ b/include/cc/template_cc_map.h
@@ -596,7 +596,14 @@ public:
                 RecordStatus new_status =
                     is_del ? RecordStatus::Deleted : RecordStatus::Normal;
                 cce->SetCommitTsPayloadStatus(commit_ts, new_status);
-
+                if (table_name_.StringView() ==
+                    "tpcc.DISTRICT*$$D_W_ID_1_D_ID_1_D_NEXT_O_ID_1_D_TAX_1")
+                {
+                    LOG(INFO) << ">> PostWriteCc txn: " << req.Txn()
+                              << ", cce: " << cce
+                              << ", payload status: " << (int) new_status
+                              << ", commit_ts: " << commit_ts;
+                }
                 if (req.IsInitialInsert())
                 {
                     // Updates the ckpt ts after commit ts is set.
@@ -4069,8 +4076,7 @@ public:
                 (1 + req.PrefetchSize() / shard_->core_cnt_) * 125 / 100);
         }
 
-        auto is_cache_full = [&req, scan_cache, remote_scan_cache]
-        {
+        auto is_cache_full = [&req, scan_cache, remote_scan_cache] {
             return req.IsLocal() ? scan_cache->IsFull()
                                  : remote_scan_cache->IsFull();
         };

--- a/include/cc/template_cc_map.h
+++ b/include/cc/template_cc_map.h
@@ -1834,8 +1834,7 @@ public:
 
                     return false;
                 });
-                if (req.Isolation() == IsolationLevel::Snapshot &&
-                    shard_->LastReadTs() < req.ReadTimestamp())
+                if (req.Isolation() == IsolationLevel::Snapshot)
                 {
                     shard_->UpdateLastReadTs(req.ReadTimestamp());
                 }
@@ -4069,8 +4068,7 @@ public:
                 (1 + req.PrefetchSize() / shard_->core_cnt_) * 125 / 100);
         }
 
-        auto is_cache_full = [&req, scan_cache, remote_scan_cache]
-        {
+        auto is_cache_full = [&req, scan_cache, remote_scan_cache] {
             return req.IsLocal() ? scan_cache->IsFull()
                                  : remote_scan_cache->IsFull();
         };
@@ -4599,8 +4597,7 @@ public:
         }
         else
         {
-            if (req.Isolation() == IsolationLevel::Snapshot &&
-                shard_->LastReadTs() < req.ReadTimestamp())
+            if (req.Isolation() == IsolationLevel::Snapshot)
             {
                 shard_->UpdateLastReadTs(req.ReadTimestamp());
             }

--- a/include/cc/template_cc_map.h
+++ b/include/cc/template_cc_map.h
@@ -596,14 +596,7 @@ public:
                 RecordStatus new_status =
                     is_del ? RecordStatus::Deleted : RecordStatus::Normal;
                 cce->SetCommitTsPayloadStatus(commit_ts, new_status);
-                if (table_name_.StringView() ==
-                    "tpcc.DISTRICT*$$D_W_ID_1_D_ID_1_D_NEXT_O_ID_1_D_TAX_1")
-                {
-                    LOG(INFO) << ">> PostWriteCc txn: " << req.Txn()
-                              << ", cce: " << cce
-                              << ", payload status: " << (int) new_status
-                              << ", commit_ts: " << commit_ts;
-                }
+
                 if (req.IsInitialInsert())
                 {
                     // Updates the ckpt ts after commit ts is set.
@@ -4076,7 +4069,8 @@ public:
                 (1 + req.PrefetchSize() / shard_->core_cnt_) * 125 / 100);
         }
 
-        auto is_cache_full = [&req, scan_cache, remote_scan_cache] {
+        auto is_cache_full = [&req, scan_cache, remote_scan_cache]
+        {
             return req.IsLocal() ? scan_cache->IsFull()
                                  : remote_scan_cache->IsFull();
         };

--- a/src/cc/cc_map.cpp
+++ b/src/cc/cc_map.cpp
@@ -114,6 +114,15 @@ std::pair<LockType, CcErrorCode> CcMap::AcquireCceKeyLock(
             CcMap *lock_ccm = ccm == nullptr ? this : ccm;
             lock = &cce->GetOrCreateKeyLock(shard_, lock_ccm, page);
             lock_op_status = lock->AcquireLock(req, protocol, lock_type);
+            if (lock_ccm->table_name_.StringView() ==
+                    "tpcc.DISTRICT*$$D_W_ID_1_D_ID_1_D_NEXT_O_ID_1_D_TAX_1" &&
+                lock_type != LockType::ReadLock &&
+                lock_type != LockType::ReadIntent)
+            {
+                LOG(INFO) << ">> txn: " << req->Txn() << ", cce: " << cce
+                          << ", lock: " << lock->DebugInfo()
+                          << ", lock_op_status: " << (int) lock_op_status;
+            }
         }
         else
         {
@@ -283,6 +292,15 @@ std::pair<LockType, CcErrorCode> CcMap::LockHandleForResumedRequest(
     }
     else
     {
+        if (table_name_.StringView() ==
+            "tpcc.DISTRICT*$$D_W_ID_1_D_ID_1_D_NEXT_O_ID_1_D_TAX_1")
+        {
+            LOG(INFO) << ">> LockHandleForResumedRequest txn: " << req->Txn()
+                      << ", acquire_lock: " << (int) acquired_lock
+                      << ", iso_level: " << (int) iso_level << ", cce: " << cce
+                      << ", commit_ts: " << commit_ts
+                      << " read_ts: " << read_ts;
+        }
         shard_->UpsertLockHoldingTx(tx_number,
                                     tx_term,
                                     cce,

--- a/src/cc/cc_map.cpp
+++ b/src/cc/cc_map.cpp
@@ -114,15 +114,6 @@ std::pair<LockType, CcErrorCode> CcMap::AcquireCceKeyLock(
             CcMap *lock_ccm = ccm == nullptr ? this : ccm;
             lock = &cce->GetOrCreateKeyLock(shard_, lock_ccm, page);
             lock_op_status = lock->AcquireLock(req, protocol, lock_type);
-            if (lock_ccm->table_name_.StringView() ==
-                    "tpcc.DISTRICT*$$D_W_ID_1_D_ID_1_D_NEXT_O_ID_1_D_TAX_1" &&
-                lock_type != LockType::ReadLock &&
-                lock_type != LockType::ReadIntent)
-            {
-                LOG(INFO) << ">> txn: " << req->Txn() << ", cce: " << cce
-                          << ", lock: " << lock->DebugInfo()
-                          << ", lock_op_status: " << (int) lock_op_status;
-            }
         }
         else
         {
@@ -292,15 +283,6 @@ std::pair<LockType, CcErrorCode> CcMap::LockHandleForResumedRequest(
     }
     else
     {
-        if (table_name_.StringView() ==
-            "tpcc.DISTRICT*$$D_W_ID_1_D_ID_1_D_NEXT_O_ID_1_D_TAX_1")
-        {
-            LOG(INFO) << ">> LockHandleForResumedRequest txn: " << req->Txn()
-                      << ", acquire_lock: " << (int) acquired_lock
-                      << ", iso_level: " << (int) iso_level << ", cce: " << cce
-                      << ", commit_ts: " << commit_ts
-                      << " read_ts: " << read_ts;
-        }
         shard_->UpsertLockHoldingTx(tx_number,
                                     tx_term,
                                     cce,


### PR DESCRIPTION
Assume there are 4 CcShards, and MVCC/snapshot is enabled. The find_and_modify issues a write-intent ScanSliceCc on skey to find the tuples to be modified.

case 1:
- T1 ScanSliceCc acquired write intents on skey0(core0), skey1(core1), skey2(core2).
- T1 AcquireCc acquired write locks on skey0(core0), skey1(core1), skey2(core2), skey3(core3). skey3 is the new skey to be inserted.
- T2 ScansliceCc blocked on acquiring write intents on skey0(core0), skey1(core1), skey2(core2), skey3(core3).

Note that case 1 is fine, because T2 blocked on all CcShards.

case 2:
- T1 ScanSliceCc acquired write intents on skey0(core0), skey1(core1), skey2(core2).
- T2 ScansliceCc blocked on acquiring write intents on skey0(core0), skey1(core1), skey2(core2).
- T1 AcquireCc acquired write locks on skey0(core0), skey1(core1), skey2(core2), skey3(core3). skey3 is the new skey to be inserted.

Note that T2 didn't block on core3, and would return (skey0, skey1, skey2) after resuming. However, T2 should return (skey0, skey1, skey2, skey3) or abort.

Fix case 2 by updating CcShard's last read_ts at ScanSliceCc. Then case 2 will behave as:
- T1 ScanSliceCc acquired write intents on skey0(core0), skey1(core1), skey2(core2). Update each CcShard's last read_ts to t1.
- T2 ScanSliceCc blocked on acquiring write intents on skey0(core0), skey1(core1), skey2(core2). Update each CcShard's last read_ts to t2. t2 is larger than t1.
- T1 AcquireCc acquired write locks on skey0(core0), skey1(core1), skey2(core2), skey3(core3). AcquireCc would return the last read_ts(t2) to Txm, and Txm would use it to deduce commit_ts t3. t3 is larger than t1 definitely.
- T1 committed and T2 resumed from blocking. T2 detected that commit_ts of skey0/skey1/skey2 is larger than T2's read_ts, and then aborts itself.
