### PR TITLE
Fix issues when Eloq module is enabled

### DIFF
--- a/include/tx_request.h
+++ b/include/tx_request.h
@@ -57,7 +57,8 @@ struct TemplateTxRequest : TxRequest
     TemplateTxRequest(const std::function<void()> *yield_fptr,
                       const std::function<void()> *resume_fptr,
                       TransactionExecution *txm = nullptr)
-        : tx_result_(yield_fptr, resume_fptr), txm_(txm)
+        : tx_result_(yield_fptr, resume_fptr),
+          txm_(yield_fptr != nullptr ? txm : nullptr)
     {
     }
 

--- a/include/tx_request.h
+++ b/include/tx_request.h
@@ -140,9 +140,9 @@ struct TemplateTxRequest : TxRequest
             if (txm_ != nullptr)
             {
                 txm_->ExternalForward();
-                tx_result_.Wait();
             }
 #endif
+            tx_result_.Wait();
             result_status = tx_result_.Status();
         } while (result_status == TxResultStatus::Unknown);
     }

--- a/include/tx_service.h
+++ b/include/tx_service.h
@@ -555,7 +555,17 @@ public:
                                           std::memory_order_relaxed);
 
                     std::unique_lock<std::mutex> lk(coordi_->sleep_mux_);
-                    coordi_->sleep_cv_.wait(lk, [this]() { return !IsIdle(); });
+                    coordi_->sleep_cv_.wait(
+                        lk,
+                        [this]()
+                        {
+                            return !IsIdle()
+#ifdef EXT_TX_PROC_ENABLED
+                                   || coordi_->ext_processor_cnt_.load(
+                                          std::memory_order_relaxed) > 0
+#endif
+                                ;
+                        });
 
 #ifdef EXT_TX_PROC_ENABLED
                     local_round_cnt =
@@ -614,7 +624,7 @@ public:
 
     std::function<void(int16_t)> UpdateExtProcFunctor()
     {
-        return [this, coordi = coordi_](int16_t thd_delta) -> void
+        return [coordi = coordi_](int16_t thd_delta) -> void
         { coordi->UpdateExtTxProcessorCnt(thd_delta); };
     }
 

--- a/include/tx_service.h
+++ b/include/tx_service.h
@@ -647,9 +647,10 @@ public:
      */
     bool ForwardTx(TransactionExecution *txm)
     {
-#ifdef ELOQ_MODULE_ENABLED
-        assert(bthread::tls_task_group->group_id_ >= 0);
-        if (bthread::tls_task_group->group_id_ >= 0 &&
+        assert(bthread::tls_task_group == nullptr ||
+               bthread::tls_task_group->group_id_ >= 0);
+        if (bthread::tls_task_group != nullptr &&
+            bthread::tls_task_group->group_id_ >= 0 &&
             bthread::tls_task_group->group_id_ != (int32_t) thd_id_)
         {
             // For redis a tx life cycle can spread across multiple cmds, which
@@ -658,7 +659,7 @@ public:
             // txm.
             return false;
         }
-#endif
+
         TxShardStatus expected = TxShardStatus::Free;
         bool success = coordi_->shard_status_.compare_exchange_weak(
             expected, TxShardStatus::Occupied, std::memory_order_acquire);

--- a/src/remote/cc_stream_receiver.cpp
+++ b/src/remote/cc_stream_receiver.cpp
@@ -22,6 +22,7 @@
 #include "remote/cc_stream_receiver.h"
 
 #include <brpc/controller.h>
+#include <bthread/bthread.h>
 #include <bvar/latency_recorder.h>
 
 #include <atomic>
@@ -323,10 +324,8 @@ void CcStreamReceiver::RecycleScanSliceResp(
 void CcStreamReceiver::PreProcessScanResp(
     std::unique_ptr<ScanSliceResponse> msg)
 {
-    CODE_FAULT_INJECTOR("before_mark_remote_received", {
-        std::this_thread::sleep_for(std::chrono::seconds(15));
-        std::this_thread::yield();
-    });
+    CODE_FAULT_INJECTOR("before_mark_remote_received",
+                        { bthread_usleep(15000000); });
     CcHandlerResult<RangeScanSliceResult> *hd_res = nullptr;
     uint32_t tx_node_id = (msg->tx_number() >> 32L) >> 10;
     int64_t tx_term = msg->tx_term();


### PR DESCRIPTION
1. Change the wait condition for the tx service native thread such that when there is an active worker the native thread should not long sleep.
2. Change std::this_thread::sleep_for() to bthread_usleep() for the stream processing thread.