### PR TITLE
ScanSliceCc: Fix orphan lock under error branch

### DIFF
--- a/include/cc/local_cc_handler.h
+++ b/include/cc/local_cc_handler.h
@@ -501,10 +501,14 @@ private:
     CcRequestPool<UploadTxCommandsCc> cmd_commit_pool;
     CcRequestPool<InvalidateTableCacheCc> invalidate_table_cache_pool;
     CcRequestPool<UpdateKeyCacheCc> update_key_cache_pool_;
-    CircularQueue<std::unique_ptr<CcScanner>> pk_forward_scanner_[3]{64, 64, 64};
-    CircularQueue<std::unique_ptr<CcScanner>> pk_backward_scanner_[3]{64, 64, 64};
-    CircularQueue<std::unique_ptr<CcScanner>> sk_forward_scanner_[3]{64, 64, 64};
-    CircularQueue<std::unique_ptr<CcScanner>> sk_backward_scanner_[3]{64, 64, 64};
+    CircularQueue<std::unique_ptr<CcScanner>> pk_forward_scanner_[3]{
+        64, 64, 64};
+    CircularQueue<std::unique_ptr<CcScanner>> pk_backward_scanner_[3]{
+        64, 64, 64};
+    CircularQueue<std::unique_ptr<CcScanner>> sk_forward_scanner_[3]{
+        64, 64, 64};
+    CircularQueue<std::unique_ptr<CcScanner>> sk_backward_scanner_[3]{
+        64, 64, 64};
 
     friend class remote::RemoteCcHandler;
 };

--- a/include/cc/local_cc_shards.h
+++ b/include/cc/local_cc_shards.h
@@ -194,7 +194,7 @@ public:
         uint32_t ng_id,    // = 0,
         const std::map<std::string, uint32_t> &conf,
         CatalogFactory *catalog_factory[4],  // = nullptr,
-        SystemHandler *system_handler,    // = nullptr,
+        SystemHandler *system_handler,       // = nullptr,
         std::unordered_map<uint32_t, std::vector<NodeConfig>>
             *ng_configs,                    // = nullptr,
         uint64_t cluster_config_version,    // = 0,

--- a/include/cc/template_cc_map.h
+++ b/include/cc/template_cc_map.h
@@ -3952,19 +3952,7 @@ public:
         if (req.IsWaitForSnapshot(shard_->core_id_))
         {
             assert(req.WaitForSnapshotCnt(shard_->core_id_) == 0);
-            bool finalized = [&req]
-            {
-                CcErrorCode err = req.GetError();
-                if (err == CcErrorCode::NO_ERROR)
-                {
-                    return req.SetFinish();
-                }
-                else
-                {
-                    return req.SetError(err);
-                }
-            }();
-            if (finalized)
+            if (req.SetFinish())
             {
                 if (req.Result()->Value().is_local_)
                 {

--- a/include/rpc_closure.h
+++ b/include/rpc_closure.h
@@ -364,8 +364,9 @@ public:
                     const std::string *range_end_key_str =
                         &(request_.end_key());
                     bool is_last_scanned_key_str = true;
-                    TableEngine table_engine = remote::ToLocalType::ConvertTableEngine(
-                        request_.table_engine());
+                    TableEngine table_engine =
+                        remote::ToLocalType::ConvertTableEngine(
+                            request_.table_engine());
 
                     // Re-dispatch this range task.
                     if (request_.start_key().size() == 0)

--- a/include/sequences/sequences.h
+++ b/include/sequences/sequences.h
@@ -258,7 +258,6 @@ struct SequenceRecordSchema : public txservice::RecordSchema
 {
 public:
     SequenceRecordSchema() = default;
-
 };
 
 struct SequenceTableSchema : public txservice::TableSchema

--- a/include/store/snapshot_manager.h
+++ b/include/store/snapshot_manager.h
@@ -103,6 +103,5 @@ private:
     txservice::TxWorkerPool backup_worker_{1};
 };
 
-
 }  // namespace store
 }  // namespace txservice

--- a/include/tx_service.h
+++ b/include/tx_service.h
@@ -55,14 +55,13 @@
 #include "local_cc_shards.h"
 #include "sharder.h"
 #include "spinlock.h"
+#include "store/snapshot_manager.h"  // SnapshotManager
 #include "tx_execution.h"
 #include "tx_request.h"
 #include "tx_service_common.h"
 #include "tx_service_metrics.h"
 #include "tx_start_ts_collector.h"
 #include "txlog.h"
-
-#include "store/snapshot_manager.h"  // SnapshotManager
 
 using namespace std::chrono_literals;
 namespace bthread
@@ -640,7 +639,8 @@ public:
     {
 #ifdef ELOQ_MODULE_ENABLED
         assert(bthread::tls_task_group->group_id_ >= 0);
-        if (bthread::tls_task_group->group_id_ >= 0  && bthread::tls_task_group->group_id_ != (int32_t) thd_id_)
+        if (bthread::tls_task_group->group_id_ >= 0 &&
+            bthread::tls_task_group->group_id_ != (int32_t) thd_id_)
         {
             // For redis a tx life cycle can spread across multiple cmds, which
             // might be put into different bthread task group. If the task group

--- a/include/type.h
+++ b/include/type.h
@@ -577,7 +577,7 @@ inline static TableName cluster_config_ccm_name{
 
 // Sequence table is a special table for auto increment id and range partition
 // id. It is used to generate auto increment id and range partition id for
-// tables. 
+// tables.
 inline static TableName sequence_table_name{sequence_table_name_sv.data(),
                                             sequence_table_name_sv.size(),
                                             TableType::Primary,

--- a/src/cc/cc_shard.cpp
+++ b/src/cc/cc_shard.cpp
@@ -90,7 +90,10 @@ CcShard::CcShard(
       clean_start_ccp_(nullptr),
       size_(0),
       ckpter_(nullptr),
-      catalog_factory_{catalog_factory[0], catalog_factory[1], catalog_factory[2], catalog_factory[3]},
+      catalog_factory_{catalog_factory[0],
+                       catalog_factory[1],
+                       catalog_factory[2],
+                       catalog_factory[3]},
       system_handler_(system_handler),
       active_si_txs_()
 {
@@ -1600,10 +1603,14 @@ CcMap *CcShard::CreateOrUpdatePkCcMap(const TableName &table_name,
 {
     if (IsNative(ng_id))
     {
-        auto ccm_it = native_ccms_.try_emplace(
-            table_name,
-            GetCatalogFactory(table_name.Engine())->CreatePkCcMap(
-                table_name, table_schema, ccm_has_full_entries, this, ng_id));
+        auto ccm_it =
+            native_ccms_.try_emplace(table_name,
+                                     GetCatalogFactory(table_name.Engine())
+                                         ->CreatePkCcMap(table_name,
+                                                         table_schema,
+                                                         ccm_has_full_entries,
+                                                         this,
+                                                         ng_id));
         // update table schema for alter table command.
         if (!is_create && !ccm_it.second)
         {
@@ -1618,10 +1625,13 @@ CcMap *CcShard::CreateOrUpdatePkCcMap(const TableName &table_name,
         auto fail_ccm_it = failover_ccms_.try_emplace(table_name).first;
         std::unordered_map<NodeGroupId, CcMap::uptr> &ccms =
             fail_ccm_it->second;
-        auto ccm_it = ccms.try_emplace(
-            ng_id,
-            GetCatalogFactory(table_name.Engine())->CreatePkCcMap(
-                table_name, table_schema, ccm_has_full_entries, this, ng_id));
+        auto ccm_it = ccms.try_emplace(ng_id,
+                                       GetCatalogFactory(table_name.Engine())
+                                           ->CreatePkCcMap(table_name,
+                                                           table_schema,
+                                                           ccm_has_full_entries,
+                                                           this,
+                                                           ng_id));
         // update table schema for alter table command.
         if (!is_create && !ccm_it.second)
         {
@@ -1641,8 +1651,8 @@ CcMap *CcShard::CreateOrUpdateSkCcMap(const TableName &index_name,
     {
         auto ccm_it = native_ccms_.try_emplace(
             index_name,
-            GetCatalogFactory(index_name.Engine())->CreateSkCcMap(
-                index_name, table_schema, this, ng_id));
+            GetCatalogFactory(index_name.Engine())
+                ->CreateSkCcMap(index_name, table_schema, this, ng_id));
         // update table schema for current sk cc map
         if (!is_create && !ccm_it.second)
         {
@@ -1656,10 +1666,10 @@ CcMap *CcShard::CreateOrUpdateSkCcMap(const TableName &index_name,
         auto fail_ccm_it = failover_ccms_.try_emplace(index_name).first;
         std::unordered_map<NodeGroupId, CcMap::uptr> &ccms =
             fail_ccm_it->second;
-        auto ccm_it =
-            ccms.try_emplace(ng_id,
-                             GetCatalogFactory(index_name.Engine())->CreateSkCcMap(
-                                 index_name, table_schema, this, ng_id));
+        auto ccm_it = ccms.try_emplace(
+            ng_id,
+            GetCatalogFactory(index_name.Engine())
+                ->CreateSkCcMap(index_name, table_schema, this, ng_id));
         // update table schema for current sk cc map
         if (!is_create && !ccm_it.second)
         {
@@ -2012,8 +2022,9 @@ void CcShard::CreateOrUpdateRangeCcMap(const TableName &table_name,
     {
         auto ccm_it = native_ccms_.try_emplace(
             range_table_name,
-            GetCatalogFactory(range_table_name.Engine())->CreateRangeMap(
-                range_table_name, table_schema, schema_ts, this, ng_id));
+            GetCatalogFactory(range_table_name.Engine())
+                ->CreateRangeMap(
+                    range_table_name, table_schema, schema_ts, this, ng_id));
         // update table schema for current range cc map
         if (!is_create && !ccm_it.second)
         {
@@ -2029,8 +2040,9 @@ void CcShard::CreateOrUpdateRangeCcMap(const TableName &table_name,
             fail_range_it->second;
         auto ccm_it = range_maps.try_emplace(
             ng_id,
-            GetCatalogFactory(range_table_name.Engine())->CreateRangeMap(
-                range_table_name, table_schema, schema_ts, this, ng_id));
+            GetCatalogFactory(range_table_name.Engine())
+                ->CreateRangeMap(
+                    range_table_name, table_schema, schema_ts, this, ng_id));
         // update table schema for current range cc map
         if (!is_create && !ccm_it.second)
         {

--- a/src/cc/local_cc_shards.cpp
+++ b/src/cc/local_cc_shards.cpp
@@ -90,8 +90,10 @@ LocalCcShards::LocalCcShards(
       ng_id_(ng_id),
       timer_terminate_(false),
       is_waiting_ckpt_(false),
-      catalog_factory_{
-          catalog_factory[0], catalog_factory[1], catalog_factory[2], catalog_factory[3]},
+      catalog_factory_{catalog_factory[0],
+                       catalog_factory[1],
+                       catalog_factory[2],
+                       catalog_factory[3]},
       system_handler_(system_handler),
       tx_service_(tx_service),
       enable_mvcc_(enable_mvcc),
@@ -367,9 +369,10 @@ std::pair<bool, const CatalogEntry *> LocalCcShards::CreateCatalog(
     {
         // A new catalog entry is created in LocalCcShards.
         catalog_entry.InitSchema(
-            catalog_image.empty() ? nullptr
-                                  : GetCatalogFactory(table_name.Engine())->CreateTableSchema(
-                                        table_name, catalog_image, commit_ts),
+            catalog_image.empty()
+                ? nullptr
+                : GetCatalogFactory(table_name.Engine())
+                      ->CreateTableSchema(table_name, catalog_image, commit_ts),
             commit_ts);
     }
     else
@@ -381,8 +384,9 @@ std::pair<bool, const CatalogEntry *> LocalCcShards::CreateCatalog(
             catalog_entry.InitSchema(
                 catalog_image.empty()
                     ? nullptr
-                    : GetCatalogFactory(table_name.Engine())->CreateTableSchema(
-                          table_name, catalog_image, commit_ts),
+                    : GetCatalogFactory(table_name.Engine())
+                          ->CreateTableSchema(
+                              table_name, catalog_image, commit_ts),
                 commit_ts);
         }
         else if (catalog_entry.schema_version_ == commit_ts)
@@ -408,8 +412,8 @@ TableSchema::uptr LocalCcShards::CreateTableSchemaFromImage(
     {
         return nullptr;
     }
-    return GetCatalogFactory(table_name.Engine())->CreateTableSchema(
-        table_name, catalog_image, version);
+    return GetCatalogFactory(table_name.Engine())
+        ->CreateTableSchema(table_name, catalog_image, version);
 }
 
 std::pair<bool, const CatalogEntry *> LocalCcShards::CreateReplayCatalog(
@@ -433,8 +437,9 @@ std::pair<bool, const CatalogEntry *> LocalCcShards::CreateReplayCatalog(
         catalog_entry.InitSchema(
             old_catalog_image.empty()
                 ? nullptr
-                : GetCatalogFactory(table_name.Engine())->CreateTableSchema(
-                      table_name, old_catalog_image, old_schema_ts),
+                : GetCatalogFactory(table_name.Engine())
+                      ->CreateTableSchema(
+                          table_name, old_catalog_image, old_schema_ts),
             old_schema_ts);
     }
 
@@ -446,8 +451,9 @@ std::pair<bool, const CatalogEntry *> LocalCcShards::CreateReplayCatalog(
         catalog_entry.SetDirtySchema(
             new_catalog_image.empty()
                 ? nullptr
-                : GetCatalogFactory(table_name.Engine())->CreateTableSchema(
-                      table_name, new_catalog_image, dirty_schema_ts),
+                : GetCatalogFactory(table_name.Engine())
+                      ->CreateTableSchema(
+                          table_name, new_catalog_image, dirty_schema_ts),
             dirty_schema_ts);
         return {true, &catalog_entry};
     }
@@ -484,9 +490,10 @@ CatalogEntry *LocalCcShards::CreateDirtyCatalog(
         // For idempotency, only installs the dirty version when the input ts is
         // greater than the existing version and dirty version.
         catalog_entry.SetDirtySchema(
-            catalog_image.empty() ? nullptr
-                                  : GetCatalogFactory(table_name.Engine())->CreateTableSchema(
-                                        table_name, catalog_image, commit_ts),
+            catalog_image.empty()
+                ? nullptr
+                : GetCatalogFactory(table_name.Engine())
+                      ->CreateTableSchema(table_name, catalog_image, commit_ts),
             commit_ts);
     }
 
@@ -500,8 +507,10 @@ void LocalCcShards::UpdateDirtyCatalog(const TableName &table_name,
     assert(catalog_entry && !catalog_image.empty());
     std::unique_lock<std::shared_mutex> lk(meta_data_mux_);
     catalog_entry->SetDirtySchema(
-        GetCatalogFactory(table_name.Engine())->CreateTableSchema(
-            table_name, catalog_image, catalog_entry->dirty_schema_version_),
+        GetCatalogFactory(table_name.Engine())
+            ->CreateTableSchema(table_name,
+                                catalog_image,
+                                catalog_entry->dirty_schema_version_),
         catalog_entry->dirty_schema_version_);
 }
 
@@ -1076,7 +1085,9 @@ void LocalCcShards::InitPrebuiltTables(NodeGroupId ng_id, int64_t term)
             if (ng_it.second)
             {
                 ng_it.first->second.InitSchema(
-                    GetCatalogFactory(table.Engine())->CreateTableSchema(table, image, 2), 2);
+                    GetCatalogFactory(table.Engine())
+                        ->CreateTableSchema(table, image, 2),
+                    2);
             }
         }
     }

--- a/src/remote/cc_node_service.cpp
+++ b/src/remote/cc_node_service.cpp
@@ -1957,7 +1957,6 @@ void CcNodeService::CreateClusterBackup(
     auto *brpc_cntl = static_cast<brpc::Controller *>(controller);
     brpc_cntl->set_always_print_primitive_fields(true);
 
-
     const std::string &backup_name = request->backup_name();
     const std::string &dest_path = request->dest_path();
     const std::string &dest_user = request->dest_user();

--- a/src/sk_generator.cpp
+++ b/src/sk_generator.cpp
@@ -204,7 +204,9 @@ void SkGenerator::ProcessTask()
     {
         if (start_key_str_->size() == 0)
         {
-            range_start_key = cc_shards->GetCatalogFactory(base_table_name_->Engine())->NegativeInfKey();
+            range_start_key =
+                cc_shards->GetCatalogFactory(base_table_name_->Engine())
+                    ->NegativeInfKey();
             read_range_req.Set(&range_table_name,
                                0,
                                &range_start_key,

--- a/src/store/snapshot_manager.cpp
+++ b/src/store/snapshot_manager.cpp
@@ -31,7 +31,6 @@ namespace txservice
 namespace store
 {
 
-
 void SnapshotManager::Start()
 {
     standby_sync_worker_ = std::thread([this] { StandbySyncWorker(); });

--- a/src/tx_index_operation.cpp
+++ b/src/tx_index_operation.cpp
@@ -1978,7 +1978,8 @@ void UpsertTableIndexOp::DispatchRangeTask(
     uint64_t tx_number = upsert_index_txm->TxNumber();
     int64_t tx_term = upsert_index_txm->TxTerm();
     TxKey target_range_end_key =
-        cc_shards->GetCatalogFactory(base_table_name.Engine())->PositiveInfKey();
+        cc_shards->GetCatalogFactory(base_table_name.Engine())
+            ->PositiveInfKey();
     TxKey target_range_start_key = last_scanned_end_key_.GetShallowCopy();
 
     uint32_t node_group_cnt = 0;
@@ -2114,12 +2115,14 @@ void UpsertTableIndexOp::DispatchRangeTask(
             if (curr_range_start_key.KeyPtr() == nullptr)
             {
                 curr_range_start_key =
-                    cc_shards->GetCatalogFactory(base_table_name.Engine())->NegativeInfKey();
+                    cc_shards->GetCatalogFactory(base_table_name.Engine())
+                        ->NegativeInfKey();
             }
             if (curr_range_end_key.KeyPtr() == nullptr)
             {
                 curr_range_end_key =
-                    cc_shards->GetCatalogFactory(base_table_name.Engine())->PositiveInfKey();
+                    cc_shards->GetCatalogFactory(base_table_name.Engine())
+                        ->PositiveInfKey();
             }
 
             HandleRangeTask(base_table_name,


### PR DESCRIPTION
1. ScanSliceCc. The return block for the error condition should call `CommitAtCore`, `SendResponseIfFinished`, and so on.
2. clang-format.