### PR TITLE
ScanSliceCc: Snapshot scan skip unknown cce

### DIFF
--- a/include/cc/cc_request.h
+++ b/include/cc/cc_request.h
@@ -1588,7 +1588,6 @@ public:
                bool is_covering_keys,
                bool is_require_keys,
                bool is_require_recs,
-               bool is_require_sort,
                bool is_include_floor_cce = false,
                int32_t obj_type = -1,
                const std::string_view &scan_pattern = {})
@@ -1609,7 +1608,6 @@ public:
         is_include_floor_cce_ = is_include_floor_cce;
         is_require_keys_ = is_require_keys;
         is_require_recs_ = is_require_recs;
-        is_require_sort_ = is_require_sort;
         cce_ptr_ = nullptr;
         cce_ptr_scan_type_ = ScanType::ScanUnknow;
         obj_type_ = obj_type;
@@ -1662,11 +1660,6 @@ public:
     bool IsRequireRecs() const
     {
         return is_require_recs_;
-    }
-
-    bool IsRequireSort() const
-    {
-        return is_require_sort_;
     }
 
     uint64_t ReadTimestamp() const
@@ -1729,7 +1722,6 @@ private:
     bool is_covering_keys_{false};
     bool is_require_keys_{true};
     bool is_require_recs_{true};
-    bool is_require_sort_{true};
     bool is_ckpt_delta_{false};
     // If always include floor_cce in scan result
     bool is_include_floor_cce_{false};
@@ -1822,7 +1814,6 @@ public:
                bool is_covering_keys,
                bool is_require_keys,
                bool is_require_recs,
-               bool is_require_sort,
                int32_t obj_type = -1,
                const std::string_view &scan_pattern = {})
     {
@@ -1836,7 +1827,6 @@ public:
         is_covering_keys_ = is_covering_keys;
         is_require_keys_ = is_require_keys;
         is_require_recs_ = is_require_recs;
-        is_require_sort_ = is_require_sort;
         cce_ptr_ = nullptr;
         cce_ptr_scan_type_ = ScanType::ScanUnknow;
 
@@ -1865,11 +1855,6 @@ public:
     bool IsRequireRecs() const
     {
         return is_require_recs_;
-    }
-
-    bool IsRequireSort() const
-    {
-        return is_require_sort_;
     }
 
     uint64_t ReadTimestamp() const
@@ -1926,7 +1911,6 @@ private:
     bool is_ckpt_delta_{false};
     bool is_require_keys_{true};
     bool is_require_recs_{true};
-    bool is_require_sort_{true};
     // Record the scan type of the blocked cce
     ScanType cce_ptr_scan_type_{ScanType::ScanUnknow};
 
@@ -2021,7 +2005,6 @@ public:
              bool is_covering_keys,
              bool is_require_keys,
              bool is_require_recs,
-             bool is_require_sort,
              uint32_t prefetch_size)
     {
         assert(hd_res.Value().is_local_);
@@ -2055,7 +2038,6 @@ public:
         is_covering_keys_ = is_covering_keys;
         is_require_keys_ = is_require_keys;
         is_require_recs_ = is_require_recs;
-        is_require_sort_ = is_require_sort;
 
         unfinished_core_cnt_.store(1, std::memory_order_relaxed);
         range_slice_id_.Reset();
@@ -2085,7 +2067,6 @@ public:
              bool is_covering_keys,
              bool is_require_keys,
              bool is_require_recs,
-             bool is_require_sort,
              uint32_t prefetch_size)
     {
         assert(!hd_res.Value().is_local_);
@@ -2119,7 +2100,6 @@ public:
         is_covering_keys_ = is_covering_keys;
         is_require_keys_ = is_require_keys;
         is_require_recs_ = is_require_recs;
-        is_require_sort_ = is_require_sort;
         prefetch_size_ = prefetch_size;
 
         unfinished_core_cnt_.store(1, std::memory_order_relaxed);
@@ -2545,11 +2525,6 @@ public:
         return is_require_recs_;
     }
 
-    bool IsRequireSort() const
-    {
-        return is_require_sort_;
-    }
-
     /**
      * @brief Returns the number of slices to prefetch when loading a cache-miss
      * slice.
@@ -2664,7 +2639,6 @@ private:
      */
     bool is_require_keys_{true};
     bool is_require_recs_{true};
-    bool is_require_sort_{true};
 
     uint32_t range_id_{0};
 

--- a/include/cc/template_cc_map.h
+++ b/include/cc/template_cc_map.h
@@ -11057,17 +11057,15 @@ protected:
             VersionResultRecord<ValueT> v_rec;
             cce->MvccGet(read_ts, v_rec);
 
-            // For snapshot reads, only if the visible version's record
-            // status is deleted and no lock has been put on it, should
-            // the record be skipped in the result set. Note that if the
-            // visible version is mising in memory, the key still needs
-            // to be returned. Runtime will use the key to retrieve the
-            // visible version from the data store.
-            if (v_rec.payload_status_ == RecordStatus::Deleted && !keep_deleted)
+            if (v_rec.payload_status_ == RecordStatus::Normal ||
+                v_rec.payload_status_ == RecordStatus::Deleted && keep_deleted)
+            {
+                tuple = typed_cache->AddScanTuple();
+            }
+            else
             {
                 return;
             }
-            tuple = typed_cache->AddScanTuple();
 
             if (is_require_keys ||
                 v_rec.payload_status_ != RecordStatus::Normal)
@@ -11221,13 +11219,9 @@ protected:
             VersionResultRecord<ValueT> v_rec;
             cce->MvccGet(read_ts, v_rec);
 
-            // For snapshot reads, only if the visible version's record
-            // status is deleted and no lock has been put on it, should
-            // the record be skipped in the result set. Note that if the
-            // visible version is mising in memory, the key still needs
-            // to be returned. Runtime will use the key to retrieve the
-            // visible version from the data store.
-            if (v_rec.payload_status_ == RecordStatus::Deleted && !keep_deleted)
+            if (!(v_rec.payload_status_ == RecordStatus::Normal ||
+                  v_rec.payload_status_ == RecordStatus::Deleted &&
+                      keep_deleted))
             {
                 return;
             }
@@ -11382,16 +11376,13 @@ protected:
             VersionResultRecord<ValueT> v_rec;
             cce->MvccGet(read_ts, v_rec);
 
-            // For snapshot reads, only if the visible version's record
-            // status is deleted and no lock has been put on it, should
-            // the record be skipped in the result set. Note that if the
-            // visible version is mising in memory, the key still needs
-            // to be returned. Runtime will use the key to retrieve the
-            // visible version from the data store.
-            if (v_rec.payload_status_ == RecordStatus::Deleted && !keep_deleted)
+            if (!(v_rec.payload_status_ == RecordStatus::Normal ||
+                  v_rec.payload_status_ == RecordStatus::Deleted &&
+                      keep_deleted))
             {
                 return;
             }
+
             tuple = remote_cache->cache_msg_->add_scan_tuple();
             if (is_require_keys)
             {

--- a/include/proto/cc_request.proto
+++ b/include/proto/cc_request.proto
@@ -974,7 +974,6 @@ message ScanOpenRequest {
     uint64 schema_version = 19;
     bool is_require_keys = 20;
     bool is_require_recs = 21;
-    bool is_require_sort = 22;
 }
 
 message ScanCache_msg {
@@ -1003,7 +1002,6 @@ message ScanNextRequest {
     string scan_pattern = 13; // Only used for redis scan command
     bool is_require_keys = 14;
     bool is_require_recs = 15;
-    bool is_require_sort = 16;
 }
 
 message ScanNextResponse {
@@ -1036,9 +1034,8 @@ message ScanSliceRequest {
     bool is_covering_keys = 18;
     bool is_require_keys = 19;
     bool is_require_recs = 20;
-    bool is_require_sort = 21;
-    uint32 prefetch_size = 22;
-    uint64 schema_version = 23;
+    uint32 prefetch_size = 21;
+    uint64 schema_version = 22;
 }
 
 message ScanSliceResponse {

--- a/include/remote/remote_cc_handler.h
+++ b/include/remote/remote_cc_handler.h
@@ -156,7 +156,6 @@ public:
                   bool is_covering_keys = false,
                   bool is_require_keys = true,
                   bool is_require_recs = true,
-                  bool is_require_sort = true,
                   int32_t obj_type = -1,
                   const std::string_view &scan_pattern = {});
 
@@ -175,7 +174,6 @@ public:
                   bool is_covering_keys = false,
                   bool is_require_keys = true,
                   bool is_require_recs = true,
-                  bool is_require_sort = true,
                   int32_t obj_type = -1,
                   const std::string_view &scan_pattern = {});
 

--- a/include/remote/remote_cc_request.h
+++ b/include/remote/remote_cc_request.h
@@ -432,7 +432,6 @@ private:
     bool is_covering_keys_{false};
     bool is_require_keys_{true};
     bool is_require_recs_{true};
-    bool is_require_sort_{true};
     uint64_t snapshot_ts_{0};
     std::vector<bool> is_wait_for_post_write_;
 
@@ -549,7 +548,6 @@ private:
     bool is_covering_keys_{false};
     bool is_require_keys_{true};
     bool is_require_recs_{true};
-    bool is_require_sort_{true};
     bool is_wait_for_post_write_{false};
     // scan type for above cce_ptr_
     ScanType cce_ptr_scan_type_{ScanType::ScanUnknow};

--- a/src/cc/local_cc_handler.cpp
+++ b/src/cc/local_cc_handler.cpp
@@ -1043,7 +1043,6 @@ void txservice::LocalCcHandler::ScanOpen(
                            is_covering_keys,
                            is_require_keys,
                            is_require_recs,
-                           is_require_sort,
                            false,
                            obj_type,
                            scan_pattern);
@@ -1087,7 +1086,6 @@ void txservice::LocalCcHandler::ScanOpen(
                                 is_covering_keys,
                                 is_require_keys,
                                 is_require_recs,
-                                is_require_sort,
                                 obj_type,
                                 scan_pattern);
         }
@@ -1217,8 +1215,7 @@ void txservice::LocalCcHandler::ScanOpenLocal(
                             scanner_ptr->is_ckpt_delta_,
                             scanner_ptr->is_covering_keys_,
                             scanner_ptr->is_require_keys_,
-                            scanner_ptr->is_require_recs_,
-                            scanner_ptr->is_require_sort_);
+                            scanner_ptr->is_require_recs_);
 
     TX_TRACE_ACTION(this, scan_open_cc_req);
     TX_TRACE_DUMP(scan_open_cc_req);
@@ -1285,7 +1282,6 @@ void txservice::LocalCcHandler::ScanNextBatch(
                    scanner.is_covering_keys_,
                    scanner.is_require_keys_,
                    scanner.is_require_recs_,
-                   scanner.is_require_sort_,
                    obj_type,
                    scan_pattern);
 
@@ -1311,7 +1307,6 @@ void txservice::LocalCcHandler::ScanNextBatch(
                             scanner.is_covering_keys_,
                             scanner.is_require_keys_,
                             scanner.is_require_recs_,
-                            scanner.is_require_sort_,
                             obj_type,
                             scan_pattern);
     }
@@ -1367,7 +1362,6 @@ void txservice::LocalCcHandler::ScanNextBatch(
                  scanner.is_covering_keys_,
                  scanner.is_require_keys_,
                  scanner.is_require_recs_,
-                 scanner.is_require_sort_,
                  prefetch_size);
 
         uint32_t core_cnt = cc_shards_.Count();
@@ -1450,8 +1444,7 @@ void txservice::LocalCcHandler::ScanNextBatchLocal(
                scanner.is_ckpt_delta_,
                scanner.is_covering_keys_,
                scanner.is_require_keys_,
-               scanner.is_require_recs_,
-               scanner.is_require_sort_);
+               scanner.is_require_recs_);
     TX_TRACE_ACTION(this, req);
     TX_TRACE_DUMP(req);
 #ifdef EXT_TX_PROC_ENABLED

--- a/src/remote/remote_cc_handler.cpp
+++ b/src/remote/remote_cc_handler.cpp
@@ -452,7 +452,6 @@ void txservice::remote::RemoteCcHandler::ScanOpen(
     bool is_covering_keys,
     bool is_require_keys,
     bool is_require_recs,
-    bool is_require_sort,
     int32_t obj_type,
     const std::string_view &scan_pattern)
 {
@@ -499,7 +498,6 @@ void txservice::remote::RemoteCcHandler::ScanOpen(
     scan_open->set_is_covering_keys(is_covering_keys);
     scan_open->set_is_require_keys(is_require_keys);
     scan_open->set_is_require_recs(is_require_recs);
-    scan_open->set_is_require_sort(is_require_sort);
     scan_open->set_obj_type(obj_type);
     scan_open->set_scan_pattern(std::string(scan_pattern));
     scan_open->set_schema_version(schema_version);
@@ -523,7 +521,6 @@ void txservice::remote::RemoteCcHandler::ScanNext(
     bool is_covering_keys,
     bool is_require_keys,
     bool is_require_recs,
-    bool is_require_sort,
     int32_t obj_type,
     const std::string_view &scan_pattern)
 {
@@ -557,7 +554,6 @@ void txservice::remote::RemoteCcHandler::ScanNext(
     scan_next->set_is_covering_keys(is_covering_keys);
     scan_next->set_is_require_keys(is_require_keys);
     scan_next->set_is_require_recs(is_require_recs);
-    scan_next->set_is_require_sort(is_require_sort);
     scan_next->set_obj_type(obj_type);
     scan_next->set_scan_pattern(std::string(scan_pattern));
 
@@ -649,7 +645,6 @@ void txservice::remote::RemoteCcHandler::ScanNext(
     scan_slice->set_is_covering_keys(scanner.is_covering_keys_);
     scan_slice->set_is_require_keys(scanner.is_require_keys_);
     scan_slice->set_is_require_recs(scanner.is_require_recs_);
-    scan_slice->set_is_require_sort(scanner.is_require_sort_);
     scan_slice->set_prefetch_size(prefetch_size);
     stream_sender_.SendMessageToNg(cc_ng_id, send_msg, &hd_res);
 }

--- a/src/remote/remote_cc_request.cpp
+++ b/src/remote/remote_cc_request.cpp
@@ -801,7 +801,6 @@ void txservice::remote::RemoteScanOpen::Reset(
     is_covering_keys_ = scan_open.is_covering_keys();
     is_require_keys_ = scan_open.is_require_keys();
     is_require_recs_ = scan_open.is_require_recs();
-    is_require_sort_ = scan_open.is_require_sort();
     isolation_level_ = ToLocalType::ConvertIsolation(scan_open.iso_level());
     proto_ = ToLocalType::ConvertProtocol(scan_open.protocol());
     tx_number_ = input_msg->tx_number();
@@ -974,7 +973,6 @@ void txservice::remote::RemoteScanNextBatch::Reset(
     is_covering_keys_ = scan_next.is_covering_keys();
     is_require_keys_ = scan_next.is_require_keys();
     is_require_recs_ = scan_next.is_require_recs();
-    is_require_sort_ = scan_next.is_require_sort();
     isolation_level_ = ToLocalType::ConvertIsolation(scan_next.iso_level());
     proto_ = ToLocalType::ConvertProtocol(scan_next.protocol());
     tx_number_ = input_msg->tx_number();
@@ -1199,7 +1197,6 @@ void txservice::remote::RemoteScanSlice::Reset(
                      scan_slice_req.is_covering_keys(),
                      scan_slice_req.is_require_keys(),
                      scan_slice_req.is_require_recs(),
-                     scan_slice_req.is_require_sort(),
                      scan_slice_req.prefetch_size());
 
     output_msg_.set_tx_number(input_msg->tx_number());


### PR DESCRIPTION
1. ScanSliceCc: Scan under snapshot isolation level should skip unknown cce. The unknown cce is created by AcquireCc.
2. Remove unused ScanSliceCc::is_require_sort_.