### PR TITLE
fix TemplateTxRequest::txm_ in EloqKV

### DIFF
--- a/include/tx_request.h
+++ b/include/tx_request.h
@@ -57,8 +57,7 @@ struct TemplateTxRequest : TxRequest
     TemplateTxRequest(const std::function<void()> *yield_fptr,
                       const std::function<void()> *resume_fptr,
                       TransactionExecution *txm = nullptr)
-        : tx_result_(yield_fptr, resume_fptr),
-          txm_(yield_fptr != nullptr ? txm : nullptr)
+        : tx_result_(yield_fptr, resume_fptr), txm_(txm)
     {
     }
 


### PR DESCRIPTION
External txms don't always have yield_fptr and resume_fptr in EloqKV. TxRequest::txm_ should be stored regardless of yield_fptr's emptiness, otherwise the txm will never be forwarded.