### PR TITLE
Fix incorrect lock bucket with hash partition

### DIFF
--- a/src/tx_operation.cpp
+++ b/src/tx_operation.cpp
@@ -678,30 +678,28 @@ void LockWriteRangeBucketsOp::Advance(TransactionExecution *txm)
             bucket_info = txm->FastToGetBucket(bucket_id);
             if (bucket_info != nullptr)
             {
+                NodeGroupId bucket_ng = bucket_info->BucketOwner();
+                NodeGroupId new_bucket_ng = bucket_info->DirtyBucketOwner();
+
+                // Updates the sharding codes of this key according to bucket
+                // info.
+                const TxKey &write_tx_key = write_key_it_->first;
+                size_t hash = write_tx_key.Hash();
+                WriteSetEntry &write_entry = write_key_it_->second;
+                write_entry.key_shard_code_ =
+                    (bucket_ng << 10) | (hash & 0x3FF);
+                // If current bucket is migrating, forward to new range owner.
+                if (new_bucket_ng != UINT32_MAX)
+                {
+                    write_entry.forward_addr_.try_emplace(
+                        (new_bucket_ng << 10) | (hash & 0x3FF));
+                    txm->rw_set_.IncreaseFowardWriteCnt(1);
+                }
                 write_key_it_++;
             }
             else
             {
                 break;
-            }
-        }
-        if (write_key_it_ != write_key_end_)
-        {
-            assert(bucket_info != nullptr);
-            NodeGroupId bucket_ng = bucket_info->BucketOwner();
-            NodeGroupId new_bucket_ng = bucket_info->DirtyBucketOwner();
-
-            // Updates the sharding codes of this key according to bucket info.
-            const TxKey &write_tx_key = write_key_it_->first;
-            size_t hash = write_tx_key.Hash();
-            WriteSetEntry &write_entry = write_key_it_->second;
-            write_entry.key_shard_code_ = (bucket_ng << 10) | (hash & 0x3FF);
-            // If current bucket is migrating, forward to new range owner.
-            if (new_bucket_ng != UINT32_MAX)
-            {
-                write_entry.forward_addr_.try_emplace((new_bucket_ng << 10) |
-                                                      (hash & 0x3FF));
-                txm->rw_set_.IncreaseFowardWriteCnt(1);
             }
         }
     }


### PR DESCRIPTION
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Reference the link of issue using `fixes eloqdb/tx_service#issue_id`
- [ ] Reference the link of RFC if exists
- [ ] Pass `./mtr --suite=mono_main,mono_multi,mono_basic`
