### PR TITLE
 Improve hash-partition data sync scheduling and memory control.

### DIFF
--- a/include/cc/cc_map.h
+++ b/include/cc/cc_map.h
@@ -80,7 +80,8 @@ struct EscalateStandbyCcmCc;
 struct RestoreCcMapCc;
 struct InvalidateTableCacheCc;
 struct SampleSubRangeKeysCc;
-struct ScanSliceDeltaSizeCc;
+struct ScanSliceDeltaSizeCcForRangePartition;
+struct ScanDeltaSizeCcForHashPartition;
 
 enum struct ScanType : uint8_t
 {
@@ -203,7 +204,8 @@ public:
     virtual bool Execute(RestoreCcMapCc &req) = 0;
     virtual bool Execute(InvalidateTableCacheCc &req) = 0;
     virtual bool Execute(SampleSubRangeKeysCc &req) = 0;
-    virtual bool Execute(ScanSliceDeltaSizeCc &req) = 0;
+    virtual bool Execute(ScanSliceDeltaSizeCcForRangePartition &req) = 0;
+    virtual bool Execute(ScanDeltaSizeCcForHashPartition &req) = 0;
 
     virtual size_t size() const = 0;
     virtual size_t NormalObjectSize()

--- a/include/cc/object_cc_map.h
+++ b/include/cc/object_cc_map.h
@@ -480,7 +480,8 @@ public:
                     cce->GetOrCreateKeyLock(shard_, this, ccp);
 
                     // Fetch record from storage
-                    int32_t part_id = (look_key->Hash() >> 10) & 0x3FF;
+                    int32_t part_id =
+                        Sharder::MapKeyHashToHashPartitionId(look_key->Hash());
                     auto fetch_ret_status = shard_->FetchRecord(table_name_,
                                                                 table_schema_,
                                                                 TxKey(look_key),
@@ -1852,7 +1853,8 @@ public:
                         // Cannot find a cached version in memory. Fetch
                         // it from kv store if kv is synced with primary.
                         cce->GetOrCreateKeyLock(shard_, this, ccp);
-                        int32_t part_id = (look_key->Hash() >> 10) & 0x3FF;
+                        int32_t part_id = Sharder::MapKeyHashToHashPartitionId(
+                            look_key->Hash());
                         shard_->FetchRecord(table_name_,
                                             table_schema_,
                                             TxKey(look_key),
@@ -2291,7 +2293,8 @@ public:
                     // cmd list so there's no need to put this req back in
                     // queue after record is fetched.
 
-                    int32_t part_id = (key.Hash() >> 10) & 0x3FF;
+                    int32_t part_id =
+                        Sharder::MapKeyHashToHashPartitionId(key.Hash());
                     shard_->FetchRecord(table_name_,
                                         table_schema_,
                                         TxKey(&key),

--- a/include/data_sync_task.h
+++ b/include/data_sync_task.h
@@ -29,6 +29,7 @@
 #include <functional>
 #include <mutex>
 #include <unordered_map>
+#include <utility>
 
 #include "absl/container/flat_hash_map.h"
 #include "catalog_factory.h"
@@ -121,10 +122,10 @@ public:
           node_group_id_(ng_id),
           node_group_term_(ng_term),
           data_sync_ts_(data_sync_ts),
-          filter_lambda_(filter_lambda),
+          filter_lambda_(std::move(filter_lambda)),
           forward_cache_(forward_cache),
           is_standby_node_ckpt_(is_standby_node_ckpt),
-          status_(status),
+          status_(std::move(status)),
           is_dirty_(is_dirty),
           sync_ts_adjustable_(need_adjust_ts),
           task_res_(hres),
@@ -301,6 +302,11 @@ public:
     {
         std::lock_guard<bthread::Mutex> lk(flush_task_entries_mux_);
         return pending_flush_size_;
+    }
+
+    size_t GetFlushBufferSize() const
+    {
+        return max_pending_flush_size_;
     }
 
     std::unique_ptr<FlushDataTask> MoveFlushData(bool force)

--- a/include/sharder.h
+++ b/include/sharder.h
@@ -222,7 +222,8 @@ public:
 
     static inline int32_t MapKeyHashToHashPartitionId(uint64_t hash_code)
     {
-        return (hash_code >> 10) & 0x3FF;
+        static constexpr int32_t kHashPartitions = 1024;
+        return static_cast<int32_t>(hash_code & (kHashPartitions - 1));
     }
 
     uint32_t NativeNodeGroup() const


### PR DESCRIPTION
  - Add per-worker coordination (data_sync_done_, scan_concurrency_) so only a bounded number of hash-partition scans run concurrently, avoiding contention.
  - Split ScanSliceDeltaSizeCc into range/hash variants, letting the hash version track key deltas and per-core memory usage for better sizing.
  - Pull hash partition IDs from hash & 0x3FF, reserve sync buffers, and partition scans according to UpdatedMemory() and flush-buffer capacity to prevent over-allocation.
  - In-place construct FlushRecord payloads and move-owned callbacks/status in DataSyncTask to reduce copies.
  - Requeue failed hash sync tasks instead of dropping them, keeping checkpoint retries reliable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Partition-aware, multi-core data synchronization and a new flush-buffer size report.
- Performance
  - Parallel delta-size scans, improved memory accounting, and optimized key-to-partition mapping.
- Bug Fixes
  - More accurate partition selection and safer lambda captures for stable callbacks.
- Refactor
  - Split range vs. hash partition scan flows and added async coordination for hash-partition scans.
- Style
  - Minor comment typo corrected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->