### PR TITLE
reset (Multi)ObjectCommandOp in PostProcess

### DIFF
--- a/include/cc/template_cc_map.h
+++ b/include/cc/template_cc_map.h
@@ -6522,11 +6522,11 @@ public:
                             // After node escalate to leader, and we've loaded
                             // from kv, there should be no gap in the buffered
                             // cmd list.
-                            assert(false);
                             LOG(ERROR)
                                 << "Buffered cmds found on leader node"
                                 << ", cce CommitTs: " << cce->CommitTs() << "\n"
                                 << buffered_cmds;
+                            assert(false);
                         }
                         else
                         {

--- a/include/tx_operation.h
+++ b/include/tx_operation.h
@@ -1053,6 +1053,8 @@ struct ObjectCommandOp : TransactionOperation
     explicit ObjectCommandOp(
         TransactionExecution *txm,
         CcHandlerResult<ReadKeyResult> *lock_range_bucket_result = nullptr);
+    // Reset to empty state
+    void Reset();
     void Reset(const TableName *table_name,
                const TxKey *key,
                TxCommand *command,
@@ -1078,6 +1080,8 @@ struct MultiObjectCommandOp : TransactionOperation
     explicit MultiObjectCommandOp(
         TransactionExecution *txm,
         CcHandlerResult<ReadKeyResult> *lock_range_bucket_result = nullptr);
+    // Reset to empty state
+    void Reset();
     void Reset(MultiObjectCommandTxRequest *tx_req);
 
     void Forward(TransactionExecution *txm) override;

--- a/src/tx_operation.cpp
+++ b/src/tx_operation.cpp
@@ -5303,18 +5303,12 @@ void ObjectCommandOp::Reset()
     table_name_ = nullptr;
     key_ = nullptr;
     command_ = nullptr;
-    hd_result_.Reset();
-    hd_result_.Value().Reset();
     auto_commit_ = false;
     always_redirect_ = false;
-    if (lock_bucket_result_)
-    {
-        lock_bucket_result_->Value().Reset();
-        lock_bucket_result_->Reset();
-    }
     forward_key_shard_ = UINT32_MAX;
     catalog_read_success_ = false;
     is_running_ = false;
+    // Do not reset the hd_result, which might be used after txn commits.
 }
 
 void ObjectCommandOp::Reset(const TableName *table_name,
@@ -5477,21 +5471,6 @@ bool MultiObjectCommandOp::IsBlockCommand()
 void MultiObjectCommandOp::Reset()
 {
     tx_req_ = nullptr;
-    // Reset existing handler results without clearing vectors (keep capacity)
-    for (auto &hr : vct_hd_result_)
-    {
-        hr.Reset();
-        hr.Value().Reset();
-    }
-
-    // Reset abort results as well (do not clear)
-    for (auto &hr : vct_abort_hd_result_)
-    {
-        hr.Reset();
-        hr.Value().Reset();
-    }
-
-    // Keep vct_key_shard_code_ as-is; next Reset(&req) rebuilds it
 
     // Reset counters and flags
     atm_cnt_.store(0, std::memory_order_relaxed);
@@ -5502,13 +5481,9 @@ void MultiObjectCommandOp::Reset()
 
     // Reset progress and state
     bucket_lock_cur_ = 0;
-    if (lock_bucket_result_)
-    {
-        lock_bucket_result_->Value().Reset();
-        lock_bucket_result_->Reset();
-    }
     catalog_read_success_ = false;
     is_running_ = false;
+    // Do not reset the hd_results, which might be used after txn commits.
 }
 
 void MultiObjectCommandOp::Reset(MultiObjectCommandTxRequest *req)

--- a/src/tx_operation.cpp
+++ b/src/tx_operation.cpp
@@ -5308,7 +5308,7 @@ void ObjectCommandOp::Reset()
     forward_key_shard_ = UINT32_MAX;
     catalog_read_success_ = false;
     is_running_ = false;
-    // Do not reset the hd_result, which might be used after txn commits.
+    // Do not reset the hd_result, which might be used when txn commits.
 }
 
 void ObjectCommandOp::Reset(const TableName *table_name,
@@ -5483,7 +5483,7 @@ void MultiObjectCommandOp::Reset()
     bucket_lock_cur_ = 0;
     catalog_read_success_ = false;
     is_running_ = false;
-    // Do not reset the hd_results, which might be used after txn commits.
+    // Do not reset the hd_results, which might be used when txn commits.
 }
 
 void MultiObjectCommandOp::Reset(MultiObjectCommandTxRequest *req)


### PR DESCRIPTION
Related PR:
https://github.com/eloqdata/eloqkv/pull/182

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Improved stability of single- and multi-object transactions with more reliable commit/abort handling.
  - Eliminated stale internal state after operations, reducing edge-case failures and rare crashes.
  - Ensured error logs are emitted before assertions, improving diagnostics.

- Refactor
  - Unified and streamlined reset behavior for transaction operations.
  - Consolidated auto-commit decision logic for consistent post-processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->