### PR TITLE
remove wrong assertion in checkpoint prescan

### DIFF
--- a/include/cc/template_cc_map.h
+++ b/include/cc/template_cc_map.h
@@ -8841,7 +8841,6 @@ public:
 
             if (ccp->last_dirty_commit_ts_ <= req.LastDataSyncTs())
             {
-                assert(!cce->NeedCkpt());
                 // Skip the pages that have no updates since last data sync.
                 if (ccp->next_page_ == PagePosInf())
                 {


### PR DESCRIPTION
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Reference the link of issue using `fixes eloqdb/tx_service#issue_id`
- [ ] Reference the link of RFC if exists
- [ ] Pass `./mtr --suite=mono_main,mono_multi,mono_basic`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved a rare stability issue that could cause unexpected termination during maintenance or synchronization when encountering pages without updates. The process now continues safely in these scenarios, improving reliability under edge cases and reducing unnecessary interruptions. No functional behavior changes are expected for typical users—only improved robustness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->