### PR TITLE
Handle missing secondary index schema in InitCcm.

### DIFF
--- a/src/cc/cc_shard.cpp
+++ b/src/cc/cc_shard.cpp
@@ -1711,7 +1711,15 @@ const CatalogEntry *CcShard::InitCcm(const TableName &table_name,
         }
         else
         {
-            schema_ts = curr_schema->IndexKeySchema(table_name)->SchemaTs();
+            const SecondaryKeySchema *index_schema =
+                curr_schema->IndexKeySchema(table_name);
+            if (index_schema == nullptr)
+            {
+                requester->AbortCcRequest(
+                    CcErrorCode::REQUESTED_INDEX_TABLE_NOT_EXISTS);
+                return nullptr;
+            }
+            schema_ts = index_schema->SchemaTs();
         }
     }
 


### PR DESCRIPTION
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Reference the link of issue using `fixes eloqdb/tx_service#issue_id`
- [ ] Reference the link of RFC if exists
- [ ] Pass `./mtr --suite=mono_main,mono_multi,mono_basic`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Requests referencing missing index tables now fail fast with a clear error, preventing invalid operations.
  * Improved validation during initialization to avoid proceeding with incomplete or incorrect index information.
  * Uses the correct index schema timestamp when available, ensuring consistent behavior.
  * Enhances reliability and user feedback by replacing ambiguous failures with explicit error handling for non-existent index tables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->