### PR TITLE
Fix missing backup_files field when FetchBackup

### DIFF
--- a/src/store/snapshot_manager.cpp
+++ b/src/store/snapshot_manager.cpp
@@ -446,8 +446,8 @@ void SnapshotManager::HandleBackupTask(
 
     if (store_hd_->IsSharedStorage())
     {
-#if (defined(ROCKSDB_CLOUD_FS_TYPE) && (ROCKSDB_CLOUD_FS_TYPE == 1 /*S3*/ || \
-                                        ROCKSDB_CLOUD_FS_TYPE == 2 /*GCS*/))
+#if (defined(DATA_STORE_TYPE_ELOQDSS_ROCKSDB_CLOUD_S3) || \
+      defined(DATA_STORE_TYPE_ELOQDSS_ROCKSDB_CLOUD_GCS))
         // For shared storage with cloud filesystem enabled, create snapshot
         std::vector<std::string> snapshot_files;
         bool res = store_hd_->CreateSnapshotForBackup(


### PR DESCRIPTION
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Reference the link of issue using `fixes eloqdb/tx_service#issue_id`
- [ ] Reference the link of RFC if exists
- [ ] Pass `./mtr --suite=mono_main,mono_multi,mono_basic`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Ensures snapshot backups are created when using cloud-backed shared storage (Amazon S3, Google Cloud Storage), resolving cases where backups might not trigger under certain build configurations. Maintains existing error handling and fallback behavior, providing more predictable backup behavior across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->