### PR TITLE
 Avoid forcing checkpoint flush when data sync memory quota is full

### DIFF
--- a/include/cc/local_cc_shards.h
+++ b/include/cc/local_cc_shards.h
@@ -2136,17 +2136,6 @@ private:
                 return false;
             };
 
-            if (!has_enough_memory())
-            {
-                DLOG(INFO) << "Flush data memory quota is full "
-                           << flush_data_mem_usage_
-                           << " ,request quota: " << quota
-                           << " total quota: " << flush_data_mem_quota_;
-                Sharder::Instance()
-                    .GetLocalCcShards()
-                    ->FlushCurrentFlushBuffer();
-            }
-
             // Wait until enough memory is available
             while (!has_enough_memory())
             {

--- a/src/store/snapshot_manager.cpp
+++ b/src/store/snapshot_manager.cpp
@@ -447,7 +447,7 @@ void SnapshotManager::HandleBackupTask(
     if (store_hd_->IsSharedStorage())
     {
 #if (defined(DATA_STORE_TYPE_ELOQDSS_ROCKSDB_CLOUD_S3) || \
-      defined(DATA_STORE_TYPE_ELOQDSS_ROCKSDB_CLOUD_GCS))
+     defined(DATA_STORE_TYPE_ELOQDSS_ROCKSDB_CLOUD_GCS))
         // For shared storage with cloud filesystem enabled, create snapshot
         std::vector<std::string> snapshot_files;
         bool res = store_hd_->CreateSnapshotForBackup(


### PR DESCRIPTION
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Reference the link of issue using `fixes eloqdb/tx_service#issue_id`
- [ ] Reference the link of RFC if exists
- [ ] Pass `./mtr --suite=mono_main,mono_multi,mono_basic`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified memory allocation behavior to rely on existing synchronization mechanisms rather than proactive flushing.

* **Style**
  * Applied minor formatting adjustments to improve code consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->