### PR TITLE
add missing hres.SetToBlock() for standby txns

### DIFF
--- a/src/cc/local_cc_handler.cpp
+++ b/src/cc/local_cc_handler.cpp
@@ -327,6 +327,9 @@ txservice::CcReqStatus txservice::LocalCcHandler::PostRead(
             &cce_addr, tx_number, tx_term, commit_ts, key_ts, gap_ts, &hres);
         TX_TRACE_ACTION(this, req);
         TX_TRACE_DUMP(req);
+#ifdef EXT_TX_PROC_ENABLED
+        hres.SetToBlock();
+#endif
         cc_shards_.EnqueueCcRequest(thd_id_, cce_addr.CoreId(), req);
         return CcReqStatus::SentLocal;
     }


### PR DESCRIPTION
Fixes https://github.com/eloqdata/eloqkv/issues/229

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced transaction processing reliability by improving standby transaction handling and sequencing behavior under specific configuration conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->