### PR TITLE
Notify checkpoint scan workers when raising concurrency

### DIFF
--- a/tx_service/src/cc/local_cc_shards.cpp
+++ b/tx_service/src/cc/local_cc_shards.cpp
@@ -2894,7 +2894,6 @@ void LocalCcShards::DataSyncWorker(size_t worker_idx)
 
             if (need_notify)
             {
-                std::lock_guard<std::mutex> lk(data_sync_worker_ctx_.mux_);
                 data_sync_worker_ctx_.cv_.notify_all();
             }
             continue;
@@ -4658,6 +4657,7 @@ void LocalCcShards::DataSyncForHashPartition(
         scan_concurrency_.store(scan_concurrency, std::memory_order_relaxed);
         if (need_notify)
         {
+            std::lock_guard<std::mutex> lk(data_sync_worker_ctx_.mux_);
             data_sync_worker_ctx_.cv_.notify_all();
         }
     }


### PR DESCRIPTION
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Reference the link of issue using `fixes eloqdb/tx_service#issue_id`
- [ ] Reference the link of RFC if exists
- [ ] Pass `./mtr --suite=mono_main,mono_multi,mono_basic`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Reduced unnecessary worker wake-ups and spurious notifications during data synchronization and concurrent scanning by making notifications conditional and better synchronized, lowering CPU overhead and improving stability under high concurrency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->