### PR TITLE
Fix FindSliceKeys crashed for data_sync_vec empty

### DIFF
--- a/src/cc/local_cc_shards.cpp
+++ b/src/cc/local_cc_shards.cpp
@@ -6161,13 +6161,6 @@ void LocalCcShards::RangeCacheSender::FindSliceKeys(
         return;
     }
 
-    if (batch_records.empty())
-    {
-        LOG(WARNING)
-            << "FindSliceKeys: Empty batch records. Skip sending cache.";
-        return;
-    }
-
     TxKey first_key = batch_records[0].Key();
     TxKey last_key = batch_records.at(batch_records.size() - 1).Key();
     std::vector<const StoreSlice *> batch_slices =


### PR DESCRIPTION
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Reference the link of issue using `fixes eloqdb/tx_service#issue_id`
- [ ] Reference the link of RFC if exists
- [ ] Pass `./mtr --suite=mono_main,mono_multi,mono_basic`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved data synchronization robustness by detecting and warning when a merged data batch becomes empty and resetting sync state to avoid silent failures.
  * Abort processing and reset scan context when a batch is empty to prevent invalid downstream updates.
  * Added early-exit guards to skip unnecessary work for empty batches and unavailable channels, reducing wasted processing and noisy errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->