### PR TITLE
Make hash partition checkpoint workers use a single heap

### DIFF
--- a/include/cc/local_cc_shards.h
+++ b/include/cc/local_cc_shards.h
@@ -416,6 +416,12 @@ public:
         }
     }
 
+    void InitializeHashPartitionCkptHeap()
+    {
+        hash_partition_ckpt_heap_ = mi_heap_new();
+        hash_partition_main_thread_id_ = mi_thread_id();
+    }
+
     mi_threadid_t GetTableRangesHeapThreadId() const
     {
         return table_ranges_thread_id_;
@@ -2375,6 +2381,8 @@ private:
     WorkerThreadContext kickout_data_test_worker_ctx_;
     void KickoutDataForTest();
 
+    void ReportHashPartitionCkptHeapUsage();
+
     /**
      * Generate sk from pk
      */
@@ -2415,6 +2423,10 @@ private:
         std::vector<std::atomic<int32_t> *> mux_ptrs_;
         std::shared_mutex &meta_data_mux_;
     } fast_meta_data_mux_;
+
+    mi_heap_t *hash_partition_ckpt_heap_{nullptr};
+    mi_threadid_t hash_partition_main_thread_id_{0};
+    std::shared_mutex hash_partition_ckpt_heap_mux_;
 
     friend class LocalCcHandler;
     friend class remote::RemoteCcHandler;

--- a/include/store/data_store_handler.h
+++ b/include/store/data_store_handler.h
@@ -72,7 +72,7 @@ public:
 
     virtual bool Connect() = 0;
 
-    virtual void ScheduleTimerTasks(){};
+    virtual void ScheduleTimerTasks() {};
     /**
      * @brief flush entries in \@param flush_task to base table or skindex table
      * in data store, stop and return false if the flush failed after max retry


### PR DESCRIPTION
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Reference the link of issue using `fixes eloqdb/tx_service#issue_id`
- [ ] Reference the link of RFC if exists
- [ ] Pass `./mtr --suite=mono_main,mono_multi,mono_basic`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added heap usage monitoring and reporting for checkpoint operations. A new configuration flag enables detailed memory metrics during checkpoint processing to track resource utilization.

* **Chores**
  * Minor code formatting improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->