### PR TITLE
Add [[maybe_unused]] and use assign() for string construction in template_cc_map.h

### DIFF
--- a/include/cc/template_cc_map.h
+++ b/include/cc/template_cc_map.h
@@ -2445,10 +2445,7 @@ public:
                 auto end_cce = static_cast<
                     CcEntry<KeyT, ValueT, VersionedRecord, RangePartitioned> *>(
                     end_lock->GetCcEntry());
-                [[maybe_unused]] auto *end_ccp = static_cast<
-                    CcPage<KeyT, ValueT, VersionedRecord, RangePartitioned> *>(
-                    end_cce->GetCcPage());
-                assert(end_ccp != nullptr);
+                assert(end_cce->GetCcPage() != nullptr);
 
                 // Release read intent lock
                 end_it = Iterator(end_cce, ccp, &neg_inf_);
@@ -3085,10 +3082,7 @@ public:
                 auto end_cce = static_cast<
                     CcEntry<KeyT, ValueT, VersionedRecord, RangePartitioned> *>(
                     end_lock->GetCcEntry());
-                [[maybe_unused]] auto *end_ccp = static_cast<
-                    CcPage<KeyT, ValueT, VersionedRecord, RangePartitioned> *>(
-                    end_cce->GetCcPage());
-                assert(end_ccp != nullptr);
+                assert(end_cce->GetCcPage() != nullptr);
 
                 // Release read intent lock
                 end_it = Iterator(end_cce, ccp, &neg_inf_);


### PR DESCRIPTION
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Reference the link of issue using `fixes eloqdb/tx_service#issue_id`
- [ ] Reference the link of RFC if exists
- [ ] Pass `./mtr --suite=mono_main,mono_multi,mono_basic`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified end-of-iteration checks in template cache logic and standardized how keys are assigned, reducing unnecessary work and improving internal consistency.

* **Chores**
  * Resolved compiler diagnostics and made non-functional improvements to caching and key-handling code paths for more reliable builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->