### PR TITLE
Update cluster backup rpc interface

### DIFF
--- a/include/proto/cc_request.proto
+++ b/include/proto/cc_request.proto
@@ -436,11 +436,6 @@ message CreateBackupRequest{
     BackupTaskStatus status = 9;
 }
 
-message CreateBackupResponse{
-    uint32 ng_id = 1;
-    BackupTaskStatus status = 4;
-}
-
 message FetchBackupRequest{
     uint32 ng_id = 1;
     string backup_name = 2;
@@ -480,7 +475,7 @@ message ClusterBackupResponse{
     string backup_name = 1;
     // failed, finished, running.
     string result = 2;
-    repeated BackupInfo backup_infos = 3;
+    repeated FetchBackupResponse backup_infos = 3;
 }
 
 message FetchClusterBackupRequest{
@@ -519,7 +514,7 @@ service CcRpcService {
     rpc OnSnapshotSynced(OnSnapshotSyncedRequest) returns (OnSnapshotSyncedResponse);
     rpc FetchNodeInfo(FetchNodeInfoRequest) returns (FetchNodeInfoResponse);
     rpc ResetStandbySequenceId(ResetStandbySequenceIdRequest) returns (ResetStandbySequenceIdResponse);
-    rpc CreateBackup(CreateBackupRequest) returns (CreateBackupResponse);
+    rpc CreateBackup(CreateBackupRequest) returns (FetchBackupResponse);
     rpc FetchBackup(FetchBackupRequest) returns (FetchBackupResponse);
     rpc TerminateBackup(TerminateBackupRequest) returns (TerminateBackupResponse);
     rpc CreateClusterBackup(CreateClusterBackupRequest) returns (ClusterBackupResponse);

--- a/include/remote/cc_node_service.h
+++ b/include/remote/cc_node_service.h
@@ -197,7 +197,7 @@ public:
 
     void CreateBackup(::google::protobuf::RpcController *controller,
                       const ::txservice::remote::CreateBackupRequest *request,
-                      ::txservice::remote::CreateBackupResponse *response,
+                      ::txservice::remote::FetchBackupResponse *response,
                       ::google::protobuf::Closure *done) override;
 
     void FetchBackup(::google::protobuf::RpcController *controller,


### PR DESCRIPTION
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Reference the link of issue using `fixes eloqdb/tx_service#issue_id`
- [ ] Reference the link of RFC if exists
- [ ] Pass `./mtr --suite=mono_main,mono_multi,mono_basic`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * CreateBackup and related cluster backup endpoints now return richer per-node responses that include status, backup files and timestamps instead of simple status-only payloads.
  * Cluster backup flows and utilities updated to aggregate and propagate these detailed per-node responses so backup creation and status queries return consolidated backup details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->