### PR TITLE
report special error if write on slave node

### DIFF
--- a/include/error_messages.h
+++ b/include/error_messages.h
@@ -83,6 +83,8 @@ enum struct TxErrorCode : uint16_t
 
     DATA_NOT_ON_LOCAL_NODE,
 
+    WRITE_REQUEST_ON_SLAVE_NODE,
+
     // Execute TxRequest on a committed/aborted txn
     TX_REQUEST_TO_COMMITTED_ABORTED_TX,
 
@@ -180,6 +182,7 @@ static const std::unordered_map<TxErrorCode, std::string> tx_error_messages{
     {TxErrorCode::INVALID_CLUSTER_SCALE_REQUEST,
      "Invalid cluster scale request."},
     {TxErrorCode::DATA_NOT_ON_LOCAL_NODE, "Data not on local node."},
+    {TxErrorCode::WRITE_REQUEST_ON_SLAVE_NODE, "Write request on slave node."},
     {TxErrorCode::TX_REQUEST_TO_COMMITTED_ABORTED_TX,
      "Execute TxRequest failed, transaction has committed/aborted"},
     {TxErrorCode::READ_CATALOG_FAIL, "Current db has not been initialized"},
@@ -312,6 +315,8 @@ enum struct CcErrorCode : uint8_t
     // For Redis, if key not on local node, return this error.
     DATA_NOT_ON_LOCAL_NODE,
 
+    WRITE_REQUEST_ON_SLAVE_NODE,
+
     TASK_EXPIRED,
 
     LOG_NOT_TRUNCATABLE,
@@ -400,7 +405,7 @@ static const std::unordered_map<CcErrorCode, std::string> cc_error_messages{
     {CcErrorCode::SYSTEM_HANDLER_ERR, "SYSTEM_HANDLER_ERR"},
 
     {CcErrorCode::DATA_NOT_ON_LOCAL_NODE, "DATA_NOT_ON_LOCAL_NODE"},
-
+    {CcErrorCode::WRITE_REQUEST_ON_SLAVE_NODE, "WRITE_REQUEST_ON_SLAVE_NODE"},
     {CcErrorCode::TASK_EXPIRED, "TASK_EXPIRED"},
 
     {CcErrorCode::LOG_NOT_TRUNCATABLE, "LOG_NOT_TRUNCATABLE"},

--- a/src/tx_execution.cpp
+++ b/src/tx_execution.cpp
@@ -385,6 +385,8 @@ TxErrorCode TransactionExecution::ConvertCcError(CcErrorCode error)
     case CcErrorCode::DATA_NOT_ON_LOCAL_NODE:
         return TxErrorCode::DATA_NOT_ON_LOCAL_NODE;
 
+    case CcErrorCode::WRITE_REQUEST_ON_SLAVE_NODE:
+        return TxErrorCode::WRITE_REQUEST_ON_SLAVE_NODE;
     case CcErrorCode::READ_CATALOG_FAIL:
         return TxErrorCode::READ_CATALOG_FAIL;
 


### PR DESCRIPTION
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Reference the link of issue using `fixes eloqdb/tx_service#issue_id`
- [ ] Reference the link of RFC if exists
- [ ] Pass `./mtr --suite=mono_main,mono_multi,mono_basic`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More specific error reported when a write is attempted on a standby/slave node, distinguishing it from general data-not-local errors.
  * Standby write attempts now immediately return the new specific error and log a warning, prompting redirect to the primary.
  * Transaction error conversions updated so this new error is surfaced consistently to callers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->