### PR TITLE
TemplateCcMap::BackFill: Remove assert for payload status is not unknown under FetchRecordCc failed

### DIFF
--- a/include/cc/cc_request.h
+++ b/include/cc/cc_request.h
@@ -4002,8 +4002,7 @@ public:
             slices_to_scan_.reserve(old_slices_delta_size->size());
             std::for_each(old_slices_delta_size->begin(),
                           old_slices_delta_size->end(),
-                          [&](decltype(*old_slices_delta_size->begin()) &elem)
-                          {
+                          [&](decltype(*old_slices_delta_size->begin()) &elem) {
                               slices_to_scan_.emplace_back(
                                   std::move(elem.first.GetShallowCopy()));
                           });

--- a/include/cc/template_cc_map.h
+++ b/include/cc/template_cc_map.h
@@ -10144,12 +10144,6 @@ protected:
             {
                 CleanEntry(cce, ccp);
             }
-            else
-            {
-                // No lock should be put on an unknown cce beside
-                // fetch record read intent.
-                assert(cce->PayloadStatus() != RecordStatus::Unknown);
-            }
             return true;
         }
         const uint64_t cce_version = cce->CommitTs();

--- a/include/tx_request.h
+++ b/include/tx_request.h
@@ -1319,6 +1319,7 @@ public:
                        const std::function<void()> *yield_fptr = nullptr,
                        const std::function<void()> *resume_fptr = nullptr,
                        TransactionExecution *txm = nullptr,
+                       bool point_read_on_cache_miss = false,
                        uint64_t corresponding_sk_commit_ts = 0,
                        bool local_cache_checked = false)
         : TemplateTxRequest(yield_fptr, resume_fptr, txm),
@@ -1327,6 +1328,7 @@ public:
           is_for_write_(is_for_write),
           is_for_share_(is_for_share),
           read_local_(read_local),
+          point_read_on_cache_miss_(point_read_on_cache_miss),
           corresponding_sk_commit_ts_(corresponding_sk_commit_ts),
           schema_version_(schema_version),
           local_cache_checked_(local_cache_checked)
@@ -1339,6 +1341,7 @@ public:
              bool is_for_write = false,
              bool is_for_share = false,
              bool read_local = false,
+             bool point_read_on_cache_miss = false,
              uint64_t corresponding_sk_commit_ts = 0)
     {
         tab_name_ = tab_name;
@@ -1346,6 +1349,7 @@ public:
         is_for_write_ = is_for_write;
         is_for_share_ = is_for_share;
         read_local_ = read_local;
+        point_read_on_cache_miss_ = point_read_on_cache_miss;
         corresponding_sk_commit_ts_ = corresponding_sk_commit_ts;
         schema_version_ = schema_version;
         local_cache_checked_ = false;
@@ -1356,6 +1360,7 @@ public:
     bool is_for_write_;  // used for "select ... for update".
     bool is_for_share_;  // used for "select ... lock in share mode".
     bool read_local_;
+    bool point_read_on_cache_miss_;
     uint64_t corresponding_sk_commit_ts_;
     uint64_t schema_version_;
     bool local_cache_checked_;

--- a/src/tx_execution.cpp
+++ b/src/tx_execution.cpp
@@ -7645,25 +7645,25 @@ void TransactionExecution::Process(BatchReadOperation &batch_read_op)
         {
             partition_id = batch_read_op.range_ids_[idx];
         }
-        cc_handler_->Read(table_name,
-                          batch_read_op.batch_read_tx_req_->schema_version_,
-                          key,
-                          sharding_code,
-                          rec,
-                          ReadType::Inside,
-                          TxNumber(),
-                          tx_term_,
-                          CommandId(),
-                          read_batch[idx].version_ts_ > 0
-                              ? read_batch[idx].version_ts_
-                              : read_ts,
-                          batch_read_op.hd_result_vec_[idx],
-                          iso_level,
-                          protocol_,
-                          batch_read_op.batch_read_tx_req_->is_for_write_,
-                          false,
-                          true,
-                          partition_id);
+        cc_handler_->Read(
+            table_name,
+            batch_read_op.batch_read_tx_req_->schema_version_,
+            key,
+            sharding_code,
+            rec,
+            ReadType::Inside,
+            TxNumber(),
+            tx_term_,
+            CommandId(),
+            read_batch[idx].version_ts_ > 0 ? read_batch[idx].version_ts_
+                                            : read_ts,
+            batch_read_op.hd_result_vec_[idx],
+            iso_level,
+            protocol_,
+            batch_read_op.batch_read_tx_req_->is_for_write_,
+            false,  // is_covering_keys
+            batch_read_op.batch_read_tx_req_->point_read_on_cache_miss_,
+            partition_id);
     }
 
     StartTiming();


### PR DESCRIPTION
1. Remove the assertion that the payload status must not be unknown under FetchRecordCc failed. Note that CcShard::FetchRecord adds a pin twice for the first cache miss CcRequest.
2. BatchReadTxRequest: add a point_read_on_cache_miss parameter and defaults to false.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-request cache-miss configuration for batch read transactions, allowing customized behavior on cache misses.

* **Bug Fixes**
  * Removed a strict assertion that could abort on certain post-failure paths; operations now continue gracefully.

* **Style**
  * Minor formatting adjustments for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->