### PR TITLE
Change bucket num to 1024 and dss support multi-shards

### DIFF
--- a/include/cc/local_cc_shards.h
+++ b/include/cc/local_cc_shards.h
@@ -222,7 +222,7 @@ public:
                           uint32_t shard_code,
                           CcRequestBase *req)
     {
-        uint32_t residual = Sharder::MapKeyHashToHashPartitionId(shard_code);
+        uint32_t residual = shard_code & 0x3FF;
         size_t core_idx = residual % cc_shards_.size();
 
         cc_shards_[core_idx]->Enqueue(thd_id, req);
@@ -230,8 +230,8 @@ public:
 
     void EnqueueCcRequest(uint32_t shard_code, CcRequestBase *req)
     {
-        size_t core_idx = Sharder::MapKeyHashToHashPartitionId(shard_code) %
-                          cc_shards_.size();
+        uint32_t residual = shard_code & 0x3FF;
+        size_t core_idx = residual % cc_shards_.size();
         cc_shards_.at(core_idx)->Enqueue(req);
     }
 

--- a/include/sharder.h
+++ b/include/sharder.h
@@ -222,9 +222,7 @@ public:
 
     static inline int32_t MapKeyHashToHashPartitionId(uint64_t hash_code)
     {
-        static constexpr int32_t kHashPartitions = 1024;
-        return static_cast<int32_t>(MapKeyHashToBucketId(hash_code) &
-                                    (kHashPartitions - 1));
+        return static_cast<int32_t>(hash_code % total_hash_partitions);
     }
 
     static inline uint16_t TotalRangeBuckets()
@@ -232,9 +230,15 @@ public:
         return total_range_buckets;
     }
 
-    static inline int32_t MapBucketIdToKvPartitionId(uint16_t bucket_id)
+    static inline int32_t MapBucketIdToHashPartitionId(uint16_t bucket_id)
     {
-        return bucket_id & 0x3FF;
+        assert(total_hash_partitions <= total_range_buckets);
+        return bucket_id % total_hash_partitions;
+    }
+
+    static inline uint32_t MapHashPartitionIdToBucketId(int32_t partition_id)
+    {
+        return static_cast<uint32_t>(partition_id % total_range_buckets);
     }
 
     uint32_t NativeNodeGroup() const

--- a/include/store/data_store_handler.h
+++ b/include/store/data_store_handler.h
@@ -383,19 +383,20 @@ public:
         return true;
     }
 
-    virtual void OnStartFollowing(uint32_t node_id,
+    virtual void OnStartFollowing(uint32_t ng_id,
+                                  uint32_t leader_node_id,
                                   int64_t term,
                                   int64_t standby_term,
                                   bool resubscribe)
     {
     }
 
-    virtual bool OnLeaderStart(uint32_t *next_leader_node)
+    virtual bool OnLeaderStart(uint32_t ng_id, uint32_t *next_leader_node)
     {
         return true;
     }
 
-    virtual bool OnLeaderStop(int64_t term)
+    virtual bool OnLeaderStop(uint32_t ng_id, int64_t term)
     {
         return true;
     }

--- a/include/type.h
+++ b/include/type.h
@@ -593,8 +593,9 @@ inline static TableName sequence_table_name{sequence_table_name_sv.data(),
                                             TableType::Primary,
                                             TableEngine::InternalHash};
 
-// Set buckets count to be the same as the slots count. (16384)
-inline static const uint16_t total_range_buckets = 0x4000;
+// Set buckets count to be the same as the hash partition count.
+inline static const uint16_t total_range_buckets = 0x400;  // 1024
+inline static const uint16_t total_hash_partitions = 0x400;
 
 enum struct SlicePosition
 {

--- a/src/fault/cc_node.cpp
+++ b/src/fault/cc_node.cpp
@@ -352,7 +352,8 @@ bool CcNode::OnLeaderStart(int64_t term,
 
     if (!txservice_skip_kv)
     {
-        if (!local_cc_shards_.store_hd_->OnLeaderStart(next_leader_node))
+        if (!local_cc_shards_.store_hd_->OnLeaderStart(ng_id_,
+                                                       next_leader_node))
         {
             retry = false;
             return false;
@@ -494,7 +495,7 @@ bool CcNode::OnLeaderStop(int64_t term)
 
     if (!txservice_skip_kv)
     {
-        if (!local_cc_shards_.store_hd_->OnLeaderStop(term))
+        if (!local_cc_shards_.store_hd_->OnLeaderStop(ng_id_, term))
         {
             // Keep retrying
             return false;
@@ -974,7 +975,7 @@ void CcNode::SubscribePrimaryNode(uint32_t leader_node_id,
     if (!txservice_skip_kv)
     {
         store_hd->OnStartFollowing(
-            leader_node_id, primary_term, standby_term, resubscribe);
+            ng_id_, leader_node_id, primary_term, standby_term, resubscribe);
     }
     uint32_t seq_grp_cnt = start_follow_resp.start_sequence_id_size();
     std::vector<uint64_t> init_seq_ids;


### PR DESCRIPTION
- Change the count of all buckets from 16384 to 1024 (equals to the count of all hash partitions)
- Replace random number generator `srand()/rand()` with `std::mt19937` to generate the distribution of buckets in `InitRangeBuckets()` for `srand()/rand()` is not thread-safe. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Switched shard-to-partition mapping to use configurable hash partitions for more consistent distribution.
  * Replaced non-deterministic, non-thread-safe randomization with per-node-group deterministic, thread-safe RNG for bucket assignment and migration; added capacity safeguards and warnings.
  * Updated public handler interfaces and call sites to include node-group context for leadership, subscription, and coordination flows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->