### PR TITLE
Fix eloqkv report oom

### DIFF
--- a/include/cc/cc_handler.h
+++ b/include/cc/cc_handler.h
@@ -83,6 +83,7 @@ public:
      * @param is_insert Whether or not the write operation is an insert
      * @param hres Result handler of the request
      * @param proto Concurrency control protocol
+     * @param abort_if_oom Whether or not to abort the request if out of memory
      */
     virtual void AcquireWrite(
         const TableName &table_name,
@@ -97,7 +98,8 @@ public:
         CcHandlerResult<std::vector<AcquireKeyResult>> &hres,
         uint32_t hd_res_idx,
         CcProtocol proto,
-        IsolationLevel iso_level) = 0;
+        IsolationLevel iso_level,
+        bool abort_if_oom) = 0;
 
     /**
      * @brief Acquires write locks for the input key in all shards. This method
@@ -114,6 +116,7 @@ public:
      * @param is_insert Whether or not the write operation is an insert
      * @param hres Result handler of the request
      * @param proto Concurrency control protocol, 2PL or OCC/MVCC
+     * @param abort_if_oom Whether or not to abort the request if out of memory
      */
     virtual void AcquireWriteAll(const TableName &table_name,
                                  const TxKey &key,
@@ -124,7 +127,8 @@ public:
                                  bool is_insert,
                                  CcHandlerResult<AcquireAllResult> &hres,
                                  CcProtocol proto,
-                                 CcOperation cc_op) = 0;
+                                 CcOperation cc_op,
+                                 bool abort_if_oom) = 0;
 
     virtual void PostWriteAll(const TableName &table_name,
                               const TxKey &key,
@@ -136,7 +140,8 @@ public:
                               uint64_t ts,
                               CcHandlerResult<PostProcessResult> &hres,
                               OperationType op_type,
-                              PostWriteType post_write_type) = 0;
+                              PostWriteType post_write_type,
+                              bool abort_if_oom) = 0;
 
     /**
      * @brief Post-processes a write key. Post-processing clears the write lock,
@@ -217,6 +222,7 @@ public:
      * @param hres Result handler of the read request
      * @param iso_level Isolation level
      * @param proto Concurrency control (cc) protocol
+     * @param abort_if_oom Whether or not to abort the request if out of memory
      */
     virtual void Read(const TableName &table_name,
                       const uint64_t schema_version,
@@ -234,7 +240,8 @@ public:
                       bool is_for_write = false,
                       bool is_covering_keys = false,
                       bool point_read_on_miss = false,
-                      int32_t partition_id = -1) = 0;
+                      int32_t partition_id = -1,
+                      bool abort_if_oom = false) = 0;
 
     /**
      * @brief Brings the previously-read key's record into the cc map for
@@ -493,6 +500,7 @@ public:
      * @param proto
      * @param commit if true, not just execute the command to get the result,
      * but also commit it on the object
+     * @param abort_if_oom Whether or not to abort the request if out of memory
      */
     virtual void ObjectCommand(const TableName &table_name,
                                const uint64_t schema_version,
@@ -507,7 +515,8 @@ public:
                                IsolationLevel iso_level,
                                CcProtocol proto,
                                bool commit,
-                               bool always_redirect) = 0;
+                               bool always_redirect,
+                               bool abort_if_oom) = 0;
 
     virtual void PublishMessage(uint64_t ng_id,
                                 int64_t tx_term,

--- a/include/cc/cc_req_base.h
+++ b/include/cc/cc_req_base.h
@@ -92,6 +92,11 @@ public:
         return 0;
     }
 
+    virtual bool AbortIfOom() const
+    {
+        return false;
+    }
+
 protected:
     CcRequestBase() = default;
 

--- a/include/cc/cc_req_misc.h
+++ b/include/cc/cc_req_misc.h
@@ -512,6 +512,11 @@ public:
         return end_key_;
     }
 
+    bool AbortIfOom() const override
+    {
+        return true;
+    }
+
     metrics::TimePoint start_;
 
 private:

--- a/include/cc/local_cc_handler.h
+++ b/include/cc/local_cc_handler.h
@@ -54,7 +54,8 @@ public:
                       CcHandlerResult<std::vector<AcquireKeyResult>> &hres,
                       uint32_t hd_res_idx,
                       CcProtocol proto,
-                      IsolationLevel iso_level) override;
+                      IsolationLevel iso_level,
+                      bool abort_if_oom) override;
 
     void AcquireWriteAll(const TableName &table_name,
                          const TxKey &key,
@@ -65,7 +66,8 @@ public:
                          bool is_insert,
                          CcHandlerResult<AcquireAllResult> &hres,
                          CcProtocol proto,
-                         CcOperation cc_op) override;
+                         CcOperation cc_op,
+                         bool abort_if_oom) override;
 
     void PostWriteAll(const TableName &table_name,
                       const TxKey &key,
@@ -77,7 +79,8 @@ public:
                       uint64_t commit_ts,
                       CcHandlerResult<PostProcessResult> &hres,
                       OperationType op_type,
-                      PostWriteType post_write_type) override;
+                      PostWriteType post_write_type,
+                      bool abort_if_oom) override;
 
     /// <summary>
     /// Installs the committed write and releases the write intention/lock after
@@ -127,6 +130,7 @@ public:
     /// <param name="ts"></param>
     /// <param name="hres"></param>
     /// <param name="proto"></param>
+    /// <param name="abort_if_oom"></param>
     void Read(const TableName &table_name,
               const uint64_t schema_version,
               const TxKey &key,
@@ -143,7 +147,8 @@ public:
               bool is_for_write = false,
               bool is_covering_keys = false,
               bool point_read_on_miss = false,
-              int32_t partition_id = -1) override;
+              int32_t partition_id = -1,
+              bool abort_if_oom = false) override;
 
     void ReadOutside(int64_t tx_term,
                      uint16_t command_id,
@@ -366,7 +371,8 @@ public:
                        IsolationLevel iso_level,
                        CcProtocol proto,
                        bool commit,
-                       bool always_redirect) override;
+                       bool always_redirect,
+                       bool abort_if_oom) override;
 
     void PublishMessage(uint64_t ng_id,
                         int64_t tx_term,

--- a/include/cc/template_cc_map.h
+++ b/include/cc/template_cc_map.h
@@ -7701,6 +7701,11 @@ public:
 
         if (!success)
         {
+            // The is used for send range cache to the future owner during range
+            // split. If the memory is not enough, we should abort the request
+            // to avoid blocking the range split.
+            // This is a performance optimization, and it does't matter if the
+            // request is aborted.
             shard_->EnqueueWaitListIfMemoryFull(&req);
             return false;
         }

--- a/include/proto/cc_request.proto
+++ b/include/proto/cc_request.proto
@@ -796,6 +796,7 @@ message AcquireRequest {
     CcProtocolType protocol = 10;
     IsolationType iso_level = 11;
     uint64 schema_version = 12;
+    bool abort_if_oom = 13;
 }
 
 message AcquireResponse {
@@ -823,6 +824,7 @@ message AcquireAllRequest {
     bool insert = 9;
     CcProtocolType protocol = 10;
     CcOperationType cc_op = 11;
+    bool abort_if_oom = 12;
 }
 
 message AcquireAllResponse {
@@ -884,6 +886,7 @@ message ReadRequest {
     bool point_read_on_miss = 14;
     uint64 schema_version = 15;
     int32 partition_id = 16;
+    bool abort_if_oom = 17;
 }
 
 message ReadResponse {
@@ -946,6 +949,7 @@ message PostWriteAllRequest {
     bytes record = 10;
     uint32 operation_type = 11;
     CommitType commit_type = 12;
+    bool abort_if_oom = 13;
 }
 
 message ScanTuple_msg {
@@ -1320,6 +1324,7 @@ message ApplyRequest {
     CcProtocolType protocol = 10;
     bool apply_and_commit = 11;
     uint64 schema_version = 12;
+    bool abort_if_oom = 13;
 }
 
 message ApplyResponse {

--- a/include/read_write_set.h
+++ b/include/read_write_set.h
@@ -551,6 +551,20 @@ public:
         forward_write_cnt_ = 0;
     }
 
+    bool HasRangeReadLock() const
+    {
+        for (const auto &[cce_addr, read_entry_pair] : meta_data_rset_)
+        {
+            if (read_entry_pair.second != catalog_ccm_name_sv &&
+                read_entry_pair.second != range_bucket_ccm_name_sv &&
+                read_entry_pair.second != cluster_config_ccm_name_sv)
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
 private:
     /**
      * @brief Apply an operation to an existing wset_entry.

--- a/include/remote/remote_cc_handler.h
+++ b/include/remote/remote_cc_handler.h
@@ -59,7 +59,8 @@ public:
                       CcHandlerResult<std::vector<AcquireKeyResult>> &hres,
                       uint32_t hd_res_idx,
                       CcProtocol proto = CcProtocol::OCC,
-                      IsolationLevel iso_level = IsolationLevel::ReadCommitted);
+                      IsolationLevel iso_level = IsolationLevel::ReadCommitted,
+                      bool abort_if_oom = false);
 
     void AcquireWriteAll(uint32_t src_node_id,
                          const TableName &table_name,
@@ -71,7 +72,8 @@ public:
                          bool is_insert,
                          CcHandlerResult<AcquireAllResult> &hres,
                          CcProtocol proto,
-                         CcOperation cc_op);
+                         CcOperation cc_op,
+                         bool abort_if_oom);
 
     void PostWrite(uint32_t src_node_id,
                    uint64_t tx_number,
@@ -95,7 +97,8 @@ public:
                       uint64_t commit_ts,
                       CcHandlerResult<PostProcessResult> &hres,
                       OperationType op_type,
-                      PostWriteType post_write_type);
+                      PostWriteType post_write_type,
+                      bool abort_if_oom);
 
     void PostRead(uint32_t src_node_id,
                   uint64_t tx_number,
@@ -128,7 +131,8 @@ public:
               bool is_for_write = false,
               bool is_covering_keys = false,
               bool point_read_on_miss = false,
-              int32_t partition_id = -1);
+              int32_t partition_id = -1,
+              bool abort_if_oom = false);
 
     void ReadOutside(int64_t tx_term,
                      uint16_t command_id,
@@ -316,7 +320,8 @@ public:
                        CcHandlerResult<ObjectCommandResult> &hres,
                        IsolationLevel iso_level,
                        CcProtocol proto,
-                       bool commit);
+                       bool commit,
+                       bool abort_if_oom);
 
     void PublishMessage(uint64_t ng_id,
                         int64_t tx_term,

--- a/include/tx_execution.h
+++ b/include/tx_execution.h
@@ -556,6 +556,8 @@ private:
 
     void ReleaseCatalogsRead();
 
+    bool HoldingRangeReadLock() const;
+
     enum struct TxType
     {
         Data = 0,

--- a/src/cc/local_cc_handler.cpp
+++ b/src/cc/local_cc_handler.cpp
@@ -61,7 +61,8 @@ void txservice::LocalCcHandler::AcquireWrite(
     CcHandlerResult<std::vector<AcquireKeyResult>> &hres,
     uint32_t hd_res_idx,
     CcProtocol proto,
-    IsolationLevel iso_level)
+    IsolationLevel iso_level,
+    bool abort_if_oom)
 {
     uint32_t ng_id = Sharder::Instance().ShardToCcNodeGroup(key_shard_code);
     AcquireKeyResult &acquire_result = hres.Value()[hd_res_idx];
@@ -90,7 +91,8 @@ void txservice::LocalCcHandler::AcquireWrite(
                    &hres,
                    hd_res_idx,
                    proto,
-                   iso_level);
+                   iso_level,
+                   abort_if_oom);
         TX_TRACE_ACTION(this, req);
         TX_TRACE_DUMP(req);
 
@@ -115,7 +117,8 @@ void txservice::LocalCcHandler::AcquireWrite(
                                 hres,
                                 hd_res_idx,
                                 proto,
-                                iso_level);
+                                iso_level,
+                                abort_if_oom);
     }
 }
 
@@ -129,7 +132,8 @@ void txservice::LocalCcHandler::AcquireWriteAll(
     bool is_insert,
     CcHandlerResult<AcquireAllResult> &hres,
     CcProtocol proto,
-    CcOperation cc_op)
+    CcOperation cc_op,
+    bool abort_if_oom)
 {
 #ifdef EXT_TX_PROC_ENABLED
     hres.SetToBlock();
@@ -149,7 +153,9 @@ void txservice::LocalCcHandler::AcquireWriteAll(
                    &hres,
                    cc_shards_.Count(),
                    proto,
-                   cc_op);
+                   cc_op,
+                   IsolationLevel::ReadCommitted,
+                   abort_if_oom);
         TX_TRACE_ACTION(this, req);
         TX_TRACE_DUMP(req);
         // The request is dispatched to the first core and then passed to
@@ -169,7 +175,8 @@ void txservice::LocalCcHandler::AcquireWriteAll(
                                    is_insert,
                                    hres,
                                    proto,
-                                   cc_op);
+                                   cc_op,
+                                   abort_if_oom);
     }
 }
 
@@ -184,7 +191,8 @@ void txservice::LocalCcHandler::PostWriteAll(
     uint64_t commit_ts,
     CcHandlerResult<PostProcessResult> &hres,
     OperationType op_type,
-    PostWriteType post_write_type)
+    PostWriteType post_write_type,
+    bool abort_if_oom)
 {
 #ifdef EXT_TX_PROC_ENABLED
     hres.SetToBlock();
@@ -213,7 +221,8 @@ void txservice::LocalCcHandler::PostWriteAll(
                        op_type,
                        &hres,
                        post_write_type,
-                       tx_term);
+                       tx_term,
+                       abort_if_oom);
         }
         else
         {
@@ -227,7 +236,8 @@ void txservice::LocalCcHandler::PostWriteAll(
                        op_type,
                        &hres,
                        post_write_type,
-                       tx_term);
+                       tx_term,
+                       abort_if_oom);
         }
 
         TX_TRACE_ACTION(this, req);
@@ -250,7 +260,8 @@ void txservice::LocalCcHandler::PostWriteAll(
                                 commit_ts,
                                 hres,
                                 op_type,
-                                post_write_type);
+                                post_write_type,
+                                abort_if_oom);
     }
 }
 
@@ -424,7 +435,8 @@ void txservice::LocalCcHandler::Read(const TableName &table_name,
                                      bool is_for_write,
                                      bool is_covering_keys,
                                      bool point_read_on_miss,
-                                     int32_t partition_id)
+                                     int32_t partition_id,
+                                     bool abort_if_oom)
 {
     hres.Value().rec_ = &record;
     uint32_t cc_ng_id = Sharder::Instance().ShardToCcNodeGroup(key_shard_code);
@@ -459,7 +471,8 @@ void txservice::LocalCcHandler::Read(const TableName &table_name,
                    nullptr,
                    false,
                    point_read_on_miss,
-                   partition_id);
+                   partition_id,
+                   abort_if_oom);
         TX_TRACE_ACTION(this, req);
         TX_TRACE_DUMP(req);
         cc_shards_.EnqueueCcRequest(thd_id_, key_shard_code, req);
@@ -486,7 +499,8 @@ void txservice::LocalCcHandler::Read(const TableName &table_name,
                         is_for_write,
                         is_covering_keys,
                         point_read_on_miss,
-                        partition_id);
+                        partition_id,
+                        abort_if_oom);
     }
 }
 
@@ -1650,7 +1664,8 @@ void txservice::LocalCcHandler::ObjectCommand(
     IsolationLevel iso_level,
     txservice::CcProtocol proto,
     bool commit,
-    bool always_redirect)
+    bool always_redirect,
+    bool abort_if_oom)
 {
 #ifdef EXT_TX_PROC_ENABLED
     hres.SetToBlock();
@@ -1691,7 +1706,8 @@ void txservice::LocalCcHandler::ObjectCommand(
                    &hres,
                    proto,
                    iso_level,
-                   commit);
+                   commit,
+                   abort_if_oom);
         cc_shards_.EnqueueCcRequest(thd_id_, key_shard_code, req);
         return;
     }
@@ -1712,7 +1728,8 @@ void txservice::LocalCcHandler::ObjectCommand(
                    &hres,
                    proto,
                    iso_level,
-                   commit);
+                   commit,
+                   abort_if_oom);
         cc_shards_.EnqueueCcRequest(thd_id_, key_shard_code, req);
     }
     else
@@ -1741,7 +1758,8 @@ void txservice::LocalCcHandler::ObjectCommand(
                                  hres,
                                  iso_level,
                                  proto,
-                                 commit);
+                                 commit,
+                                 abort_if_oom);
     }
 }
 

--- a/src/remote/remote_cc_handler.cpp
+++ b/src/remote/remote_cc_handler.cpp
@@ -49,7 +49,8 @@ void txservice::remote::RemoteCcHandler::AcquireWrite(
     CcHandlerResult<std::vector<AcquireKeyResult>> &hres,
     uint32_t hd_res_idx,
     CcProtocol proto,
-    IsolationLevel iso_level)
+    IsolationLevel iso_level,
+    bool abort_if_oom)
 {
     /*message AcquireRequest
     {
@@ -88,6 +89,7 @@ void txservice::remote::RemoteCcHandler::AcquireWrite(
     acq->set_key_shard_code(key_shard_code);
     acq->set_protocol(ToRemoteType::ConvertProtocol(proto));
     acq->set_iso_level(ToRemoteType::ConvertIsolation(iso_level));
+    acq->set_abort_if_oom(abort_if_oom);
 
     stream_sender_.SendMessageToNg(dest_ng_id, send_msg, &hres);
 }
@@ -103,7 +105,8 @@ void txservice::remote::RemoteCcHandler::AcquireWriteAll(
     bool is_insert,
     CcHandlerResult<AcquireAllResult> &hres,
     CcProtocol proto,
-    CcOperation cc_op)
+    CcOperation cc_op,
+    bool abort_if_oom)
 {
     CcMessage send_msg;
 
@@ -141,6 +144,7 @@ void txservice::remote::RemoteCcHandler::AcquireWriteAll(
     acq_all->set_insert(is_insert);
     acq_all->set_protocol(ToRemoteType::ConvertProtocol(proto));
     acq_all->set_cc_op(ToRemoteType::ConvertCcOperation(cc_op));
+    acq_all->set_abort_if_oom(abort_if_oom);
 
     stream_sender_.SendMessageToNg(node_group_id, send_msg, &hres);
 }
@@ -206,7 +210,8 @@ void txservice::remote::RemoteCcHandler::PostWriteAll(
     uint64_t commit_ts,
     CcHandlerResult<PostProcessResult> &hres,
     OperationType op_type,
-    PostWriteType post_write_type)
+    PostWriteType post_write_type,
+    bool abort_if_oom)
 {
     CcMessage send_msg;
 
@@ -259,6 +264,7 @@ void txservice::remote::RemoteCcHandler::PostWriteAll(
     CommitType commit_type =
         ToRemoteType::ConvertPostWriteType(post_write_type);
     post_write_all->set_commit_type(commit_type);
+    post_write_all->set_abort_if_oom(abort_if_oom);
 
     stream_sender_.SendMessageToNg(ng_id, send_msg, &hres);
 }
@@ -321,7 +327,8 @@ void txservice::remote::RemoteCcHandler::Read(
     bool is_for_write,
     bool is_covering_keys,
     bool point_read_on_miss,
-    int32_t partition_id)
+    int32_t partition_id,
+    bool abort_if_oom)
 {
     CcMessage send_msg;
 
@@ -373,6 +380,7 @@ void txservice::remote::RemoteCcHandler::Read(
 
     read->set_ts(ts);
     read->set_schema_version(schema_version);
+    read->set_abort_if_oom(abort_if_oom);
 
     stream_sender_.SendMessageToNg(dest_ng_id, send_msg, &hres);
 }
@@ -1049,7 +1057,8 @@ void txservice::remote::RemoteCcHandler::ObjectCommand(
     CcHandlerResult<ObjectCommandResult> &hres,
     IsolationLevel iso_level,
     CcProtocol proto,
-    bool commit)
+    bool commit,
+    bool abort_if_oom)
 {
     CcMessage send_msg;
 
@@ -1076,6 +1085,7 @@ void txservice::remote::RemoteCcHandler::ObjectCommand(
     apply_req->set_tx_ts(tx_ts);
     apply_req->set_apply_and_commit(commit);
     apply_req->set_schema_version(schema_version);
+    apply_req->set_abort_if_oom(abort_if_oom);
 
     apply_req->clear_cmd();
     std::string *cmd_str = apply_req->mutable_cmd();

--- a/src/remote/remote_cc_request.cpp
+++ b/src/remote/remote_cc_request.cpp
@@ -123,7 +123,8 @@ void txservice::remote::RemoteAcquire::Reset(
                      &cc_res_,
                      req.vec_idx(),
                      ToLocalType::ConvertProtocol(req.protocol()),
-                     ToLocalType::ConvertIsolation(req.iso_level()));
+                     ToLocalType::ConvertIsolation(req.iso_level()),
+                     req.abort_if_oom());
 
     input_msg_ = std::move(input_msg);
 
@@ -238,7 +239,9 @@ void txservice::remote::RemoteAcquireAll::Reset(
                         &cc_res_,
                         Sharder::Instance().GetLocalCcShardsCount(),
                         ToLocalType::ConvertProtocol(req.protocol()),
-                        ToLocalType::ConvertCcOperation(req.cc_op()));
+                        ToLocalType::ConvertCcOperation(req.cc_op()),
+                        txservice::IsolationLevel::ReadCommitted,
+                        req.abort_if_oom());
 
     input_msg_ = std::move(input_msg);
 
@@ -459,7 +462,8 @@ void txservice::remote::RemoteRead::Reset(std::unique_ptr<CcMessage> input_msg)
                       req.is_covering_keys(),
                       nullptr,
                       req.point_read_on_miss(),
-                      req.partition_id());
+                      req.partition_id(),
+                      req.abort_if_oom());
     }
     else
     {
@@ -482,7 +486,11 @@ void txservice::remote::RemoteRead::Reset(std::unique_ptr<CcMessage> input_msg)
                       ToLocalType::ConvertIsolation(req.iso_level()),
                       ToLocalType::ConvertProtocol(req.protocol()),
                       req.is_for_write(),
-                      req.is_covering_keys());
+                      req.is_covering_keys(),
+                      nullptr,
+                      false,
+                      -1,
+                      req.abort_if_oom());
     }
 
     input_msg_ = std::move(input_msg);
@@ -702,7 +710,8 @@ void txservice::remote::RemotePostWriteAll::Reset(
                           op_type,
                           &cc_res_,
                           write_type,
-                          tx_term);
+                          tx_term,
+                          post_write_all.abort_if_oom());
 
     input_msg_ = std::move(input_msg);
 
@@ -2232,7 +2241,8 @@ void txservice::remote::RemoteApplyCc::Reset(
                    &cc_res_,
                    ToLocalType::ConvertProtocol(req.protocol()),
                    ToLocalType::ConvertIsolation(req.iso_level()),
-                   req.apply_and_commit());
+                   req.apply_and_commit(),
+                   req.abort_if_oom());
 
     input_msg_ = std::move(input_msg);
 

--- a/src/tx_operation.cpp
+++ b/src/tx_operation.cpp
@@ -5725,7 +5725,8 @@ void MultiObjectCommandOp::Forward(TransactionExecution *txm)
                 txm->iso_level_,
                 txm->protocol_,
                 commit,
-                tx_req_->always_redirect_);
+                tx_req_->always_redirect_,
+                txm->HoldingRangeReadLock());
 
             if (hd_res.Value().is_local_)
             {


### PR DESCRIPTION
1. Normally, when a `ccrequest` can not find enough memory when `FindEmplace`, it triggers a shard clean operation and waits until free memory becomes available. However, if the transaction already holds a range read lock, the `ccrequest` should be aborted with error code `OUT_OF_MEMORY` if no free memory is available; otherwise, it may block range splitting.
2. Remove the macro `ON_KEY_OBJECT`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-request "abort-on-OOM" flag added so individual operations can opt into early abort behavior.
  * Transaction execution exposes range-read-lock state to influence abort-on-OOM decisions.

* **Bug Fixes**
  * OOM handling made deterministic: requests now either re-enqueue or abort immediately based on the new flag.

* **Refactor**
  * Memory wait-list and dequeue flow simplified; new path to abort waiting requests when memory frees.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->