### PR TITLE
Fix cleanpage during range split

### DIFF
--- a/include/cc/local_cc_shards.h
+++ b/include/cc/local_cc_shards.h
@@ -1486,13 +1486,15 @@ public:
                 bool kickout_any = false;
                 uint64_t dirty_range_version =
                     range_entry->GetRangeInfo()->DirtyTs();
+                uint64_t last_sync_ts = range_entry->GetLastSyncTs();
                 idx = clean_guard->MarkCleanInRange(
                     store_range,
                     idx,
                     kickout_any,
                     (range_entry->GetRangeInfo()->IsDirty()
                          ? &dirty_range_version
-                         : nullptr));
+                         : nullptr),
+                    last_sync_ts);
                 if (kickout_any && clean_guard->cc_shard_->IsBucketsMigrating())
                 {
                     // If the key is kicked out, we need to update the bucket


### PR DESCRIPTION
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Reference the link of issue using `fixes eloqdb/tx_service#issue_id`
- [ ] Reference the link of RFC if exists
- [ ] Pass `./mtr --suite=mono_main,mono_multi,mono_basic`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced internal cache page cleanup logic with improved synchronization timestamp tracking for range operations.
  * Updated eviction criteria to refine when cached entries are considered for cleanup during range-based operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->