### PR TITLE
Fix hash scan crash on multi eloqkv nodes

### DIFF
--- a/src/remote/cc_stream_receiver.cpp
+++ b/src/remote/cc_stream_receiver.cpp
@@ -1130,12 +1130,11 @@ void CcStreamReceiver::OnReceiveCcMsg(std::unique_ptr<CcMessage> msg)
         CcScanner *scanner = hd_res->Value().ccm_scanner_;
         ::txservice::remote::ShardCacheMsgMap *shard_caches =
             scan_next_res.mutable_shard_cache_map();
-        for (auto &[core_id, shard_cache] :
+        for (auto &[shard_code, shard_cache] :
              *shard_caches->mutable_shard_caches())
         {
             const ::txservice::remote::ScanCache_msg &memory_cache =
                 shard_cache.memory_scan_cache();
-            uint32_t shard_code = (node_group_id << 10) + core_id;
 
             if (memory_cache.scan_tuple_size() > 0)
             {


### PR DESCRIPTION
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Reference the link of issue using `fixes eloqdb/tx_service#issue_id`
- [ ] Reference the link of RFC if exists
- [ ] Pass `./mtr --suite=mono_main,mono_multi,mono_basic`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal stream receiver implementation for improved code efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->