### PR TITLE
Fix the issue where SplitFlushRange gets stuck

### DIFF
--- a/include/cc/cc_req_misc.h
+++ b/include/cc/cc_req_misc.h
@@ -539,8 +539,6 @@ private:
     uint32_t slice_size_{0};
     uint32_t rec_cnt_{0};
 
-    std::vector<bool> core_finished_{};
-
 public:
     // These variables only be used in DataStoreHandler
     const std::string *kv_table_name_{nullptr};

--- a/include/cc/cc_shard.h
+++ b/include/cc/cc_shard.h
@@ -1059,8 +1059,6 @@ public:
         return init_key_cache_cc_pool_.NextRequest();
     }
 
-    void AddRetryCount(size_t count);
-
     std::shared_ptr<ReaderWriterObject<TableSchema>> FindSchemaCntl(
         const TableName &tbl_name);
 

--- a/include/cc/range_slice.h
+++ b/include/cc/range_slice.h
@@ -22,7 +22,6 @@
 #pragma once
 
 #include <atomic>
-#include <chrono>
 #include <cmath>
 #include <condition_variable>
 #include <cstdint>
@@ -1421,19 +1420,8 @@ public:
                         }
                     }
 
-                    // auto start_time =
-                    // std::chrono::high_resolution_clock::now();
                     std::unique_lock<std::mutex> prefetch_lk(
                         prefetch_slice->slice_mux_, std::try_to_lock);
-
-                    /*
-                    auto stop_time = std::chrono::high_resolution_clock::now();
-                    auto duration =
-                        std::chrono::duration_cast<std::chrono::microseconds>(
-                            stop_time - start_time)
-                            .count();
-                    Sharder::Instance().AddLockLatency(duration);
-                    */
 
                     if (prefetch_lk.owns_lock())
                     {

--- a/include/cc/template_cc_map.h
+++ b/include/cc/template_cc_map.h
@@ -5204,7 +5204,6 @@ public:
                 const KeyT &search_key) -> std::pair<RangeSliceId, bool>
         {
             bool succ = false;
-            bool debug_prefetch_size = 32;  // 32
             RangeSliceOpStatus pin_status;
             RangeSliceId slice_id = shard_->local_shards_.PinRangeSlice(
                 table_name_,
@@ -5221,7 +5220,7 @@ public:
                 shard_,
                 pin_status,
                 true,
-                debug_prefetch_size,
+                32,
                 false,
                 false,
                 !req.export_base_table_item_,

--- a/include/sharder.h
+++ b/include/sharder.h
@@ -188,9 +188,6 @@ public:
     void Shutdown();
     void CloseStreamSender();
 
-    void AddLockLatency(uint64_t latency);
-    void AddUnlockLatency(uint64_t latency);
-
     /**
      * @brief Returns the ID of the leader node of the input cc node group.
      *

--- a/src/cc/cc_req_misc.cpp
+++ b/src/cc/cc_req_misc.cpp
@@ -544,9 +544,6 @@ void FillStoreSliceCc::Reset(const TableName &table_name,
     slice_size_ = 0;
     rec_cnt_ = 0;
     err_code_ = CcErrorCode::NO_ERROR;
-    core_finished_.clear();
-    core_finished_.resize(cc_shards.Count(), false);
-    err_code_ = CcErrorCode::NO_ERROR;
 }
 
 void FillStoreSliceCc::SetKvFinish(bool success)
@@ -656,7 +653,6 @@ bool FillStoreSliceCc::SetFinish(CcShard *cc_shard)
     {
         std::lock_guard<std::mutex> lk(mux_);
         ++finish_cnt_;
-        core_finished_[cc_shard->core_id_] = true;
 
         if (finish_cnt_ == core_cnt_)
         {
@@ -725,9 +721,6 @@ bool FillStoreSliceCc::SetError(CcErrorCode err_code)
         ++finish_cnt_;
         err_code_ = err_code;
 
-        // LOG(INFO) << "== FillStoreSliceCc::SetError: finish_cnt_="
-        //          << finish_cnt_ << ", core_cnt_=" << core_cnt_
-        //          << ", this = " << this;
         if (finish_cnt_ == core_cnt_)
         {
             finish_all = true;

--- a/src/cc/cc_shard.cpp
+++ b/src/cc/cc_shard.cpp
@@ -24,9 +24,6 @@
 #include <brpc/controller.h>
 #include <bthread/bthread.h>
 #include <bthread/remote_task_queue.h>
-#include <bvar/bvar.h>
-#include <bvar/latency_recorder.h>
-#include <bvar/recorder.h>
 
 #include <chrono>  // std::chrono
 #include <cstdint>
@@ -53,17 +50,11 @@
 #include "tx_start_ts_collector.h"
 #include "type.h"
 #include "util.h"
-bvar::LatencyRecorder g_retry_recorder("yf_retry_count");
 
 DECLARE_bool(cmd_read_catalog);
 
 namespace txservice
 {
-void CcShard::AddRetryCount(size_t count)
-{
-    g_retry_recorder << count;
-}
-
 CcShard::CcShard(
     uint16_t core_id,
     uint32_t core_cnt,

--- a/src/cc/local_cc_shards.cpp
+++ b/src/cc/local_cc_shards.cpp
@@ -2650,38 +2650,8 @@ void LocalCcShards::EnqueueDataSyncTaskForTable(
             return;
         }
 
-        /*
-        size_t debug_idx = 0;
         for (auto &range : *ranges)
         {
-            LOG(INFO) << "== range id = "
-                      << range.second->GetRangeInfo()->PartitionId()
-                      << ", version = " << range.second->Version()
-                      << ", debug idx = " << debug_idx;
-            debug_idx++;
-        }
-        */
-
-        for (auto &range : *ranges)
-        {
-            /*
-            if (range.second->Version() == 1762482755490268)
-            {
-                LOG(INFO) << "Debug point for range "
-                          << range.second->GetRangeInfo()->PartitionId()
-                          << ", version = " << range.second->Version()
-                          << ", index = " << debug_idx;
-            }
-            else if (range.second->Version() == 1762482755490270)
-            {
-                LOG(INFO) << "Debug point for range "
-                          << range.second->GetRangeInfo()->PartitionId()
-                          << ", version = " << range.second->Version()
-                          << ", index = " << debug_idx;
-            }
-            debug_idx++;
-            */
-
             if (EnqueueRangeDataSyncTask(table_name,
                                          ng_id,
                                          ng_term,

--- a/src/cc/range_slice.cpp
+++ b/src/cc/range_slice.cpp
@@ -632,16 +632,7 @@ StoreRange::LoadSliceStatus StoreRange::LoadSlice(
             slice.cc_queue_.emplace_back(cc_request, cc_shard);
         }
 
-        // auto start_time = std::chrono::high_resolution_clock::now();
         slice_lk.unlock();
-
-        /*
-        auto stop_time = std::chrono::high_resolution_clock::now();
-        auto duration = std::chrono::duration_cast<std::chrono::microseconds>(
-                            stop_time - start_time)
-                            .count();
-        Sharder::Instance().AddUnlockLatency(duration);
-        */
 
         if (ctrl.AsyncEmit())
         {
@@ -747,8 +738,6 @@ StoreRange::LoadSliceStatus StoreRange::LoadSlice(
                 slice.fetch_slice_cc_->Free();
                 slice.fetch_slice_cc_ = nullptr;
                 pins_.fetch_sub(1, std::memory_order_release);
-                // LOG(INFO) << "== 1: LoadSlice retrying for table: "
-                //          << tbl_name.StringView();
                 return LoadSliceStatus::Retry;
             default:
                 // Abort those ccrequests except the first one which will be
@@ -795,8 +784,6 @@ StoreRange::LoadSliceStatus StoreRange::LoadSlice(
             // it into ccrequest queue. If OOM, the queued request will be
             // aborted. Setting force load to true means that requests will
             // ignore OOM errors, such as DataSyncScanCc.
-            // LOG(INFO) << "== 2: LoadSlice retrying for table: "
-            //          << tbl_name.StringView();
             return LoadSliceStatus::Retry;
         }
 

--- a/src/sharder.cpp
+++ b/src/sharder.cpp
@@ -22,10 +22,6 @@
 #include "sharder.h"
 
 #include <brpc/channel.h>
-#include <bvar/bvar.h>
-#include <bvar/latency_recorder.h>
-#include <bvar/reducer.h>
-#include <bvar/window.h>
 #include <spawn.h>
 #include <unistd.h>
 
@@ -55,20 +51,6 @@ namespace GFLAGS_NAMESPACE = gflags;
 
 namespace txservice
 {
-
-bvar::LatencyRecorder g_lock_recorder("yf_pin_slice_lock_time");
-bvar::LatencyRecorder g_unlock_recorder("yf_pin_slice_unlock_time");
-
-void Sharder::AddLockLatency(uint64_t latency)
-{
-    g_lock_recorder << latency;
-}
-
-void Sharder::AddUnlockLatency(uint64_t latency)
-{
-    g_unlock_recorder << latency;
-}
-
 Sharder::Sharder() = default;
 Sharder::~Sharder()
 {


### PR DESCRIPTION
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Reference the link of issue using `fixes eloqdb/tx_service#issue_id`
- [ ] Reference the link of RFC if exists
- [ ] Pass `./mtr --suite=mono_main,mono_multi,mono_basic`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a new write-preferential synchronization mechanism for improved concurrency control.

* **Bug Fixes**
  * Enhanced archive-backed and base record fetch handling for correctness.
  * Refined timestamp tracking for snapshot isolation consistency.

* **Performance Improvements**
  * Prefetch loading now uses non-blocking lock acquisition for optimized resource contention.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->