### PR TITLE
Fix create table PostWriteAllCc PostCommit CatalogEntry contains a null dirty schema

### DIFF
--- a/include/cc/catalog_cc_map.h
+++ b/include/cc/catalog_cc_map.h
@@ -1212,8 +1212,7 @@ public:
                 assert(catalog_entry->schema_ == nullptr);
                 if (catalog_entry->dirty_schema_ == nullptr)
                 {
-                    cce->SetCommitTsPayloadStatus(
-                        catalog_entry->schema_version_, RecordStatus::Deleted);
+                    cce->SetCommitTsPayloadStatus(1, RecordStatus::Deleted);
                 }
                 else
                 {

--- a/src/cc/cc_entry.cpp
+++ b/src/cc/cc_entry.cpp
@@ -45,7 +45,7 @@ void VersionedLruEntry<Versioned, RangePartitioned>::SetCommitTsPayloadStatus(
     uint8_t stat = static_cast<uint8_t>(status);
     uint64_t curr_ts = entry_info_.commit_ts_and_status_ >> 8;
 
-    if (curr_ts < ts || curr_ts == 0)
+    if (curr_ts < ts)
     {
         entry_info_.commit_ts_and_status_ = (ts << 8) | stat;
     }


### PR DESCRIPTION
The CatalogCcMap::ReadCc triggered a FetchCatalogCc during the creation table.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced catalog operations reliability by improving edge case handling for schema validation scenarios and implementing more robust retry mechanisms for catalog requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->