### PR TITLE
fix parsing of enable_wal

### DIFF
--- a/core/src/data_substrate.cpp
+++ b/core/src/data_substrate.cpp
@@ -442,7 +442,7 @@ bool DataSubstrate::LoadCoreAndNetworkConfig(const INIReader &config_reader)
 
     core_config_.enable_wal =
         !core_config_.bootstrap &&
-        (CheckCommandLineFlagIsDefault("enable_wal")
+        (!CheckCommandLineFlagIsDefault("enable_wal")
              ? FLAGS_enable_wal
              : config_reader.GetBoolean(
                    "local", "enable_wal", FLAGS_enable_wal));


### PR DESCRIPTION
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Reference the link of issue using `fixes eloqdb/tx_service#issue_id`
- [ ] Reference the link of RFC if exists
- [ ] Pass `./mtr --suite=mono_main,mono_multi,mono_basic`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Write-Ahead Logging (WAL) configuration precedence handling to properly prioritize command-line settings over configuration files during system initialization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->