### PR TITLE
adapt parameter

### DIFF
--- a/store_handler/eloq_data_store_service/eloq_store_config.cpp
+++ b/store_handler/eloq_data_store_service/eloq_store_config.cpp
@@ -94,6 +94,9 @@ DEFINE_uint32(eloq_store_reserve_space_ratio,
 DEFINE_bool(eloq_store_prewarm_cloud_cache,
             false,
             "EloqStore prewarm cloud cache during startup.");
+DEFINE_uint32(eloq_store_prewarm_task_count,
+              3,
+              "EloqStore prewarm task count per shard.");
 DEFINE_uint32(eloq_store_data_page_size, 1 << 12, "EloqStore data page size.");
 DEFINE_uint32(eloq_store_pages_per_file_shift,
               11,
@@ -423,6 +426,12 @@ EloqStoreConfig::EloqStoreConfig(const INIReader &config_reader,
             : config_reader.GetBoolean("store",
                                        "eloq_store_prewarm_cloud_cache",
                                        FLAGS_eloq_store_prewarm_cloud_cache);
+    eloqstore_configs_.prewarm_task_count =
+        !CheckCommandLineFlagIsDefault("eloq_store_prewarm_task_count")
+            ? FLAGS_eloq_store_prewarm_task_count
+            : config_reader.GetInteger("store",
+                                       "eloq_store_prewarm_task_count",
+                                       FLAGS_eloq_store_prewarm_task_count);
     eloqstore_configs_.data_page_size =
         !CheckCommandLineFlagIsDefault("eloq_store_data_page_size")
             ? FLAGS_eloq_store_data_page_size


### PR DESCRIPTION
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Reference the link of issue using `fixes eloqdb/tx_service#issue_id`
- [ ] Reference the link of RFC if exists
- [ ] Pass `./mtr --suite=mono_main,mono_multi,mono_basic`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added configurable prewarm task count settings, allowing operators to tune data prewarming performance on a per-shard basis. The new option defaults to 3 tasks per shard and can be configured through command-line parameters or configuration files for optimal performance across various deployment scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->