### PR TITLE
fix data sync scan misuse table schema version for key schema version

### DIFF
--- a/core/include/data_substrate.h
+++ b/core/include/data_substrate.h
@@ -119,8 +119,9 @@ public:
     {
         txservice::CatalogFactory *catalog_factory{nullptr};
         txservice::TableEngine engine{txservice::TableEngine::None};
-        bool enable_engine{false};      // Set by main thread before engine init
-        bool engine_registered{false};  // Set true when engine calls RegisterEngine()
+        bool enable_engine{false};  // Set by main thread before engine init
+        bool engine_registered{
+            false};  // Set true when engine calls RegisterEngine()
     };
 
     // Core data substrate configuration

--- a/core/src/metrics_init.cpp
+++ b/core/src/metrics_init.cpp
@@ -83,8 +83,10 @@ bool DataSubstrate::InitializeMetrics(const INIReader &config_reader)
         }
 
         // remote request metrics
-        metrics::enable_remote_request_metrics = config_reader.GetBoolean(
-            "metrics", "enable_remote_request_metrics", metrics::enable_tx_metrics);
+        metrics::enable_remote_request_metrics =
+            config_reader.GetBoolean("metrics",
+                                     "enable_remote_request_metrics",
+                                     metrics::enable_tx_metrics);
         LOG(INFO) << "enable_remote_request_metrics: "
                   << (metrics::enable_remote_request_metrics ? "ON" : "OFF");
         if (core_config_.enable_data_store)

--- a/tx_service/include/cc/template_cc_map.h
+++ b/tx_service/include/cc/template_cc_map.h
@@ -5186,8 +5186,7 @@ public:
         // data sync scan cc for range partitioned table
         assert(RangePartitioned);
 
-        if (req.schema_version_ != 0 &&
-            schema_ts_ != req.schema_version_)
+        if (req.schema_version_ != 0 && schema_ts_ != req.schema_version_)
         {
             assert(req.schema_version_ > schema_ts_);
             LOG(WARNING) << "Table schema version mismatched for data sync "
@@ -5735,8 +5734,7 @@ public:
             });
         TX_TRACE_DUMP(&req);
 
-        if (req.schema_version_ != 0 &&
-            schema_ts_ != req.schema_version_)
+        if (req.schema_version_ != 0 && schema_ts_ != req.schema_version_)
         {
             assert(req.schema_version_ > schema_ts_);
             LOG(WARNING) << "Table schema version mismatched for data sync "
@@ -7863,8 +7861,7 @@ public:
                     .append("0");
             });
         TX_TRACE_DUMP(&req);
-        if (req.schema_version_ != 0 &&
-            schema_ts_ != req.schema_version_)
+        if (req.schema_version_ != 0 && schema_ts_ != req.schema_version_)
         {
             assert(req.schema_version_ > schema_ts_);
             LOG(WARNING) << "Table schema version mismatched for data sync "
@@ -8220,8 +8217,7 @@ public:
                     .append("0");
             });
         TX_TRACE_DUMP(&req);
-        if (req.schema_version_ != 0 &&
-            schema_ts_ != req.schema_version_)
+        if (req.schema_version_ != 0 && schema_ts_ != req.schema_version_)
         {
             assert(req.schema_version_ > schema_ts_);
             LOG(WARNING) << "Table schema version mismatched for data sync "

--- a/tx_service/src/cc/local_cc_shards.cpp
+++ b/tx_service/src/cc/local_cc_shards.cpp
@@ -3478,7 +3478,7 @@ void LocalCcShards::DataSyncForRangePartition(
 
         last_sync_ts = is_dirty ? 0 : range_entry->GetLastSyncTs();
     }
-    
+
     if (table_name.IsBase())
     {
         schema_version = table_schema->KeySchema()->SchemaTs();


### PR DESCRIPTION
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Reference the link of issue using `fixes eloqdb/tx_service#issue_id`
- [ ] Reference the link of RFC if exists
- [ ] Pass `./mtr --suite=mono_main,mono_multi,mono_basic`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Schema validation now consistently compares timestamp-based schema identifiers, reducing false mismatch reports and aligning error messages with the used schema timestamp.

* **Chores**
  * Internal handling of schema references for synchronization, scans and read paths refined to correctly distinguish base vs. index schemas and derive timestamps at the appropriate step.

* **Style**
  * Minor formatting and line-flow cleanups for readability; no behavioral or public API changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->