### PR TITLE
fix compile warning of dynamic annotation between butil and absl

### DIFF
--- a/core/src/data_substrate.cpp
+++ b/core/src/data_substrate.cpp
@@ -28,7 +28,9 @@
 #include <mutex>
 
 #include "INIReader.h"
+// clang-format off
 #include "tx_service.h"
+// clang-format on
 #include "log_server.h"
 #include "sequences/sequences.h"
 #include "store/data_store_handler.h"


### PR DESCRIPTION
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Reference the link of issue using `fixes eloqdb/tx_service#issue_id`
- [ ] Reference the link of RFC if exists
- [ ] Pass `./mtr --suite=mono_main,mono_multi,mono_basic`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Internal code reorganization and formatting adjustments; no user-facing changes or behavioral impact.

* **Notes**
  * No public APIs or exported interfaces were modified.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->