### PR TITLE
fix snapshot coverage check for snapshot sync requests

### DIFF
--- a/tx_service/src/store/snapshot_manager.cpp
+++ b/tx_service/src/store/snapshot_manager.cpp
@@ -191,7 +191,7 @@ void SnapshotManager::SyncWithStandby()
 
             if (pending_task_subscribe_id >= current_subscribe_id)
             {
-                DLOG(WARNING)
+                LOG(WARNING)
                     << "The snapshot generated at subscribe counter: "
                     << current_subscribe_id
                     << ", does not cover the task subscribe id: "


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed snapshot synchronization edge case: the system now correctly identifies when a snapshot does not cover a pending task, skips that task for the current round, and waits for the next update. This prevents incorrect coverage assumptions and improves reliability of synchronization with standby replicas.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->