### PR TITLE
Revert "Range read block on rw conflict (#283)"

### DIFF
--- a/tx_service/include/cc/range_cc_map.h
+++ b/tx_service/include/cc/range_cc_map.h
@@ -29,7 +29,6 @@
 #include "cc_handler_result.h"
 #include "cc_protocol.h"
 #include "cc_request.h"
-#include "dead_lock_check.h"
 #include "error_messages.h"  //CcErrorCode
 #include "range_bucket_cc_map.h"
 #include "range_bucket_key_record.h"
@@ -230,9 +229,9 @@ public:
         // is never a read-outside request that brings an individual range into
         // memory for caching.
         assert(req.Type() != ReadType::OutsideNormal);
-        // Range reads now block when lock acquisition fails (similar to regular
-        // data reads), allowing deadlock detection to see wait conditions.
-        // Resumed range read cc requests are now possible.
+        // We directly abort cc request if blocked by write lock. So we should
+        // not have any resumed range read cc.
+        assert(req.CcePtr() == nullptr);
 
         LockType acquired_lock;
         CcErrorCode err_code;
@@ -325,12 +324,19 @@ public:
         else
         {
             assert(err_code == CcErrorCode::ACQUIRE_LOCK_BLOCKED);
-            DeadLockCheck::RequestCheck();
-
-            req.SetBlockType(ReadCc::BlockByLock);
-            // Request is now in blocking queue, stop execution
-            return false;
+            // Release the acquired bucket read lock before aborting.
+            ReleaseCceLock(bucket_cce->GetKeyLock(),
+                           bucket_cce,
+                           req.Txn(),
+                           this->cc_ng_id_,
+                           LockType::ReadLock);
+            floor_cce->GetKeyLock()->AbortQueueRequest(
+                req.Txn(),
+                CcErrorCode::ACQUIRE_KEY_LOCK_FAILED_FOR_RW_CONFLICT);
+            return true;
         }
+
+        return true;
     }
 
     bool Execute(PostReadCc &req) override

--- a/tx_service/include/dead_lock_check.h
+++ b/tx_service/include/dead_lock_check.h
@@ -193,7 +193,8 @@ public:
     {
         if (inst_)
         {
-            inst_->requested_check_.store(true, std::memory_order_release);
+            std::unique_lock<std::mutex> lk(inst_->mutex_);
+            inst_->requested_check_ = true;
             inst_->con_var_.notify_one();
         }
     }
@@ -241,6 +242,6 @@ protected:
     // The node to rise dead lock check.
     uint32_t check_node_id_;
     // If the dead lock check is requested by this node.
-    std::atomic<bool> requested_check_{false};
+    bool requested_check_{false};
 };
 }  // namespace txservice

--- a/tx_service/src/dead_lock_check.cpp
+++ b/tx_service/src/dead_lock_check.cpp
@@ -523,27 +523,27 @@ void DeadLockCheck::Run()
         });
 
         std::unique_lock<std::mutex> lk(mutex_);
-        con_var_.wait_for(
-            lk,
-            1s,
-            [this]()
-            {
-                if (stop_)
-                {
-                    return true;
-                }
+        con_var_.wait_for(lk,
+                          1s,
+                          [this]()
+                          {
+                              if (stop_)
+                              {
+                                  return true;
+                              }
 
-                if (requested_check_.load(std::memory_order_acquire))
-                {
-                    uint64_t ival = LocalCcShards::ClockTs() - last_check_time_;
-                    if (ival >= time_interval_)
-                    {
-                        return true;
-                    }
-                }
+                              if (requested_check_)
+                              {
+                                  uint64_t ival = LocalCcShards::ClockTs() -
+                                                  last_check_time_;
+                                  if (ival >= time_interval_)
+                                  {
+                                      return true;
+                                  }
+                              }
 
-                return false;
-            });
+                              return false;
+                          });
 
         if (stop_)
         {
@@ -556,7 +556,7 @@ void DeadLockCheck::Run()
             continue;
         }
 
-        if (!requested_check_.load(std::memory_order_acquire))
+        if (!requested_check_)
         {
             continue;
         }
@@ -566,7 +566,7 @@ void DeadLockCheck::Run()
         }
 
         // Reset the check flag brefore gather lock dependancy
-        requested_check_.store(false, std::memory_order_release);
+        requested_check_ = false;
         lk.unlock();
         GatherLockDependancy();
     }

--- a/tx_service/src/tx_operation.cpp
+++ b/tx_service/src/tx_operation.cpp
@@ -304,9 +304,21 @@ void ReadLocalOperation::Forward(txservice::TransactionExecution *txm)
             assert(hd_result_->ErrorCode() ==
                        CcErrorCode::ACQUIRE_KEY_LOCK_FAILED_FOR_RW_CONFLICT ||
                    hd_result_->ErrorCode() == CcErrorCode::DATA_STORE_ERR);
-            // With blocking range reads and deadlock detection, we no longer
-            // need to preemptively abort. The request will block and deadlock
-            // detection will handle actual deadlocks. Retry the operation.
+            // If acquire range read lock blocked by DDL, check if tx has
+            // already acquired other range read lock. If so we need to abort
+            // tx since it might cause dead lock with range split. If this tx
+            // has not acquired any range read lock, we can safely retry here.
+            const auto &rset = txm->rw_set_.MetaDataReadSet();
+            for (const auto &[cce_addr, read_entry_pair] : rset)
+            {
+                if (read_entry_pair.second != catalog_ccm_name_sv &&
+                    read_entry_pair.second != cluster_config_ccm_name_sv)
+                {
+                    // Abort tx.
+                    txm->PostProcess(*this);
+                    return;
+                }
+            }
             hd_result_->Value().Reset();
             hd_result_->Reset();
             execute_immediately_ = false;
@@ -598,9 +610,23 @@ void LockWriteRangeBucketsOp::Forward(TransactionExecution *txm)
         {
             assert(lock_result_->ErrorCode() ==
                    CcErrorCode::ACQUIRE_KEY_LOCK_FAILED_FOR_RW_CONFLICT);
-            // With blocking range reads and deadlock detection, we no longer
-            // need to preemptively abort. The request will block and deadlock
-            // detection will handle actual deadlocks. Retry the operation.
+            // If acquire range/bucket read lock blocked by DDL, check if tx has
+            // already acquired other range/bucket read lock. If so we need to
+            // abort tx since it might cause dead lock with bucket migration. If
+            // this tx has not acquired any range/buckets read lock, we can
+            // safely retry here.
+            const auto &rset = txm->rw_set_.MetaDataReadSet();
+            for (const auto &[cce_addr, read_entry_pair] : rset)
+            {
+                if (read_entry_pair.second != catalog_ccm_name_sv &&
+                    read_entry_pair.second != range_bucket_ccm_name_sv &&
+                    read_entry_pair.second != cluster_config_ccm_name_sv)
+                {
+                    // Abort tx.
+                    txm->PostProcess(*this);
+                    return;
+                }
+            }
             lock_result_->Value().Reset();
             lock_result_->Reset();
             is_running_ = false;
@@ -1830,8 +1856,6 @@ void AcquireAllOp::Forward(TransactionExecution *txm)
         // arbitrarily long, after all acquire requests are acknowledged, we
         // still need to periodically check liveness of the remote node.
 
-        DLOG(INFO) << "All acquire all requests finished for tx "
-                   << txm->TxNumber() << ", fail count: " << fail_cnt_.load();
         if (fail_cnt_.load(std::memory_order_relaxed) == 0)
         {
             for (size_t idx = 0; idx < upload_cnt_; ++idx)
@@ -4200,48 +4224,7 @@ void SplitFlushRangeOp::Forward(TransactionExecution *txm)
                       << range_info_->PartitionId()
                       << ", txn: " << txm->TxNumber();
             // Upgrade to write lock again for commit phase.
-
-#ifdef WITH_FAULT_INJECT
-            // Check if fault injector is enabled
-            FaultEntry *fault_entry =
-                FaultInject::Entry("split_flush_commit_acquire_all_deadlock");
-            if (fault_entry != nullptr)
-            {
-                // Only assign to op_ and push to txm, do not call Process
-                op_ = &commit_acquire_all_write_op_;
-                txm->PushOperation(&commit_acquire_all_write_op_);
-                auto all_node_groups = Sharder::Instance().AllNodeGroups();
-                commit_acquire_all_write_op_.Reset(all_node_groups->size());
-                commit_acquire_all_write_op_.is_running_ = true;
-
-                // Ensure at least one result slot exists.
-                assert(commit_acquire_all_write_op_.hd_results_.size() >= 1);
-                auto &hd_result0 = commit_acquire_all_write_op_.hd_results_[0];
-                hd_result0.Reset();
-                hd_result0.SetToBlock();
-                // Set error on the first hd_result with DEAD_LOCK_ABORT
-                hd_result0.SetError(CcErrorCode::DEAD_LOCK_ABORT);
-                DLOG(INFO)
-                    << "FaultInject split_flush_commit_acquire_all_deadlock, "
-                    << " commit_acquire_all_write_op_.IsDeadlock(): "
-                    << commit_acquire_all_write_op_.IsDeadlock()
-                    << " upload_cnt_: "
-                    << commit_acquire_all_write_op_.upload_cnt_
-                    << " fail_cnt_: "
-                    << commit_acquire_all_write_op_.fail_cnt_.load(
-                           std::memory_order_relaxed);
-                // Auto-remove the fault to prevent it from being triggered
-                // again
-                FaultInject::Instance().InjectFault(
-                    "split_flush_commit_acquire_all_deadlock", "remove");
-            }
-            else
-            {
-                ForwardToSubOperation(txm, &commit_acquire_all_write_op_);
-            }
-#else
             ForwardToSubOperation(txm, &commit_acquire_all_write_op_);
-#endif
         }
     }
     else if (op_ == &prepare_acquire_all_write_op_)
@@ -4518,9 +4501,6 @@ void SplitFlushRangeOp::Forward(TransactionExecution *txm)
     }
     else if (op_ == &commit_acquire_all_write_op_)
     {
-        DLOG(INFO) << "Split Flush commit acquire all write lock op fail cnt: "
-                   << commit_acquire_all_write_op_.fail_cnt_.load(
-                          std::memory_order_relaxed);
         if (commit_acquire_all_write_op_.fail_cnt_.load(
                 std::memory_order_relaxed) > 0)
         {
@@ -4531,7 +4511,7 @@ void SplitFlushRangeOp::Forward(TransactionExecution *txm)
                            << txm->TxNumber();
                 if (commit_acquire_all_write_op_.IsDeadlock())
                 {
-                    DLOG(ERROR)
+                    LOG(ERROR)
                         << "Split Flush transaction deadlocks with other "
                            "transactions, downgrade write lock, tx_number:"
                         << txm->TxNumber();
@@ -4551,14 +4531,6 @@ void SplitFlushRangeOp::Forward(TransactionExecution *txm)
             }
             return;
         }
-
-        CODE_FAULT_INJECTOR(
-            "term_SplitFlushOp_CommitAcquireAllWriteOp_Continue", {
-                LOG(INFO)
-                    << "FaultInject "
-                       "term_SplitFlushOp_CommitAcquireAllWriteOp_Continue";
-                return;
-            });
 
         ACTION_FAULT_INJECTOR("range_split_commit_acquire_all");
 


### PR DESCRIPTION
This reverts commit 7c0a42621ceaae1283ae0a8a531796b49c547a3a.
Causes checkpoint unable to proceed

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Reference the link of issue using `fixes eloqdb/tx_service#issue_id`
- [ ] Reference the link of RFC if exists
- [ ] Pass `./mtr --suite=mono_main,mono_multi,mono_basic`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved transaction conflict resolution for concurrent read/write operations by optimizing retry behavior and reducing suspension periods.
  * Streamlined internal synchronization mechanisms to decrease conflict detection overhead.
  * Enhanced transaction recovery logic when operations encounter lock conflicts.
  * Simplified transaction processing paths by removing legacy diagnostic code.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->