### PR TITLE
fix log dir

### DIFF
--- a/core/src/data_substrate.cpp
+++ b/core/src/data_substrate.cpp
@@ -822,7 +822,8 @@ bool DataSubstrate::LoadCoreAndNetworkConfig(const INIReader &config_reader)
     aws_options_.loggingOptions.logLevel = Aws::Utils::Logging::LogLevel::Info;
     if (!FLAGS_log_dir.empty())
     {
-        aws_options_.loggingOptions.defaultLogPrefix = FLAGS_log_dir.c_str();
+        static std::string logprefix = (FLAGS_log_dir / "aws_sdk_").string();
+        aws_options.loggingOptions.defaultLogPrefix = logprefix.c_str();
     }
     Aws::InitAPI(aws_options_);
 #endif


### PR DESCRIPTION
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Reference the link of issue using `fixes eloqdb/tx_service#issue_id`
- [ ] Reference the link of RFC if exists
- [ ] Pass `./mtr --suite=mono_main,mono_multi,mono_basic`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Initialize AWS logging prefix when a log directory is specified, ensuring AWS SDK logs are written under the configured logs path. This improves log file organization, makes SDK logs easier to locate and rotate, and supports centralized log management without changing runtime behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->