### PR TITLE
Update RangePartitionDataSyncScanCc execution for performing pinslice by only one core

### DIFF
--- a/tx_service/include/cc/template_cc_map.h
+++ b/tx_service/include/cc/template_cc_map.h
@@ -5465,7 +5465,7 @@ public:
                     // Try to become the pinning core (The last core will be)
                     if (req.slice_barrier_.Status() !=
                             SliceBarrierStatus::Pinning &&
-                        !req.slice_barrier_.TryStart(req.core_cnt_))
+                        !req.slice_barrier_.TryStart())
                     {
                         // Not the last core，blocked by slice operation.
                         req.PausePos(shard_->core_id_).first =
@@ -5546,7 +5546,7 @@ public:
                     // reset
                     if (slice_pinned)
                     {
-                        if (req.slice_barrier_.TryFinish(req.core_cnt_))
+                        if (req.slice_barrier_.TryFinish())
                         {
                             // The last core
                             req.slice_barrier_.PinnedSlice().Unpin();
@@ -5756,7 +5756,7 @@ public:
             {
                 if (slice_pinned)
                 {
-                    if (req.slice_barrier_.TryFinish(req.core_cnt_))
+                    if (req.slice_barrier_.TryFinish())
                     {
                         // The last core
                         req.slice_barrier_.PinnedSlice().Unpin();
@@ -5827,7 +5827,7 @@ public:
             bool succ = req.slice_barrier_.SetFinish();
             if (slice_pinned)
             {
-                if (req.slice_barrier_.TryFinish(req.core_cnt_))
+                if (req.slice_barrier_.TryFinish())
                 {
                     // The last core
                     req.slice_barrier_.PinnedSlice().Unpin();


### PR DESCRIPTION
This PR addresses the mutex contention issue when multiple core threads simultaneously attempt to pin the same slice during `RangePartitionDataSyncScanCc` execution. The solution coordinates slice pinning so that only one core (the last one try to pin/unpin slice) performs the pin operation, while other cores wait and then proceed once the slice is pinned.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Centralized slice coordination for range-partitioned scans with a unified barrier and per-core blocking state.
  * Consolidated lifecycle and readiness logic to simplify initialization, reset, and wakeup behavior across cores.
* **Bug Fixes**
  * Fixed races that could leave slice processing blocked or inconsistently completed, improving stability under concurrent load.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->