### PR TITLE
Fix flush worker and datasync worker deadlock

### DIFF
--- a/tx_service/src/data_sync_task.cpp
+++ b/tx_service/src/data_sync_task.cpp
@@ -221,6 +221,7 @@ void DataSyncTask::SetScanTaskFinished()
         // sync task due to pending flush, flush the current flush buffer.
         DLOG(INFO) << "Flushing current flush buffer after all scan tasks are "
                       "finished";
+        task_sender_lk.unlock();
         Sharder::Instance().GetLocalCcShards()->FlushCurrentFlushBuffer();
     }
 }


### PR DESCRIPTION
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Reference the link of issue using `fixes eloqdb/tx_service#issue_id`
- [ ] Reference the link of RFC if exists
- [ ] Pass `./mtr --suite=mono_main,mono_multi,mono_basic`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Unlock the status mutex before calling `FlushCurrentFlushBuffer()` in `DataSyncTask::SetScanTaskFinished` to avoid lock contention/deadlock when scan tasks finish with pending flushes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5723d381cf412140fd1b12360fad495ff98b9ef4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved internal task synchronization handling to prevent potential concurrency issues during data processing operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->