### PR TITLE
add parameter to reuse local files

### DIFF
--- a/store_handler/eloq_data_store_service/eloq_store_config.cpp
+++ b/store_handler/eloq_data_store_service/eloq_store_config.cpp
@@ -115,6 +115,9 @@ DEFINE_bool(eloq_store_prewarm_cloud_cache,
 DEFINE_uint32(eloq_store_prewarm_task_count,
               3,
               "EloqStore prewarm task count per shard.");
+DEFINE_bool(eloq_store_reuse_local_files,
+            false,
+            "EloqStore reuse local files in cloud mode");
 DEFINE_uint32(eloq_store_data_page_size, 1 << 12, "EloqStore data page size.");
 DEFINE_uint32(eloq_store_pages_per_file_shift,
               11,
@@ -443,6 +446,12 @@ EloqStoreConfig::EloqStoreConfig(const INIReader &config_reader,
             : config_reader.GetInteger("store",
                                        "eloq_store_prewarm_task_count",
                                        FLAGS_eloq_store_prewarm_task_count);
+    eloqstore_configs_.allow_reuse_local_caches =
+        !CheckCommandLineFlagIsDefault("eloq_store_reuse_local_files")
+            ? FLAGS_eloq_store_reuse_local_files
+            : config_reader.GetBoolean("store",
+                                       "eloq_store_reuse_local_files",
+                                       FLAGS_eloq_store_reuse_local_files);
     eloqstore_configs_.data_page_size =
         !CheckCommandLineFlagIsDefault("eloq_store_data_page_size")
             ? FLAGS_eloq_store_data_page_size


### PR DESCRIPTION
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Reference the link of issue using `fixes eloqdb/tx_service#issue_id`
- [ ] Reference the link of RFC if exists
- [ ] Pass `./mtr --suite=mono_main,mono_multi,mono_basic`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new configuration option to control whether local file caches are reused. This setting can be configured via command line or configuration file, with command line parameters taking precedence over file-based settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->