### PR TITLE
call Reset() for result before retry tx operation, call BatchReadOperation result Reset() only before retry.

### DIFF
--- a/tx_service/src/tx_operation.cpp
+++ b/tx_service/src/tx_operation.cpp
@@ -1399,7 +1399,7 @@ void ScanOpenOperation::Forward(TransactionExecution *txm)
             retry_num_ > 0)
         {
             Sharder::Instance().UpdateLeaders();
-            Reset();
+            hd_result_.Reset();
             ReRunOp(txm);
             return;
         }


### PR DESCRIPTION
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Reference the link of issue using `fixes eloqdb/tx_service#issue_id`
- [ ] Reference the link of RFC if exists
- [ ] Pass `./mtr --suite=mono_main,mono_multi,mono_basic`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved retry handling by resetting operation state before re-attempts to prevent stale state during leader-term retries.
  * Added early exit when a node is no longer the leader, marking per-item results accordingly to surface leadership failures sooner and avoid wasted retries.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->