### PR TITLE
fix crash in malloc_usable_size and rocksdb_gcs compile

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -290,7 +290,7 @@ SET(DATA_SUBSTRATE_SOURCES
 )
 
 # Add store handler sources based on data store type
-if(WITH_DATA_STORE STREQUAL "ELOQDSS_ROCKSDB" OR WITH_DATA_STORE STREQUAL "ELOQDSS_ROCKSDB_CLOUD_S3")
+if(WITH_DATA_STORE STREQUAL "ELOQDSS_ROCKSDB" OR WITH_DATA_STORE STREQUAL "ELOQDSS_ROCKSDB_CLOUD_S3" OR WITH_DATA_STORE STREQUAL "ELOQDSS_ROCKSDB_CLOUD_GCS")
     SET(DATA_SUBSTRATE_SOURCES ${DATA_SUBSTRATE_SOURCES}
         store_handler/data_store_service_client.cpp
         store_handler/data_store_service_client_closure.cpp
@@ -317,6 +317,12 @@ if(WITH_DATA_STORE STREQUAL "ELOQDSS_ROCKSDB" OR WITH_DATA_STORE STREQUAL "ELOQD
             store_handler/eloq_data_store_service/purger_event_listener.cpp
             store_handler/eloq_data_store_service/purger_sliding_window.cpp
 	    store_handler/eloq_data_store_service/s3_file_downloader.cpp
+        )
+    elseif(WITH_DATA_STORE STREQUAL "ELOQDSS_ROCKSDB_CLOUD_GCS")
+        SET(DATA_SUBSTRATE_SOURCES ${DATA_SUBSTRATE_SOURCES}
+            store_handler/eloq_data_store_service/rocksdb_cloud_data_store.cpp
+            store_handler/eloq_data_store_service/purger_event_listener.cpp
+            store_handler/eloq_data_store_service/purger_sliding_window.cpp
         )
     endif()
 elseif(WITH_DATA_STORE STREQUAL "ELOQDSS_ELOQSTORE")
@@ -354,7 +360,7 @@ if(WITH_LOG_SERVICE)
     SET(DATA_SUBSTRATE_LINK_LIBS ${DATA_SUBSTRATE_LINK_LIBS} logservice)
 endif()
 
-if(WITH_DATA_STORE STREQUAL "ELOQDSS_ROCKSDB" OR WITH_DATA_STORE STREQUAL "ELOQDSS_ROCKSDB_CLOUD_S3")
+if(WITH_DATA_STORE STREQUAL "ELOQDSS_ROCKSDB" OR WITH_DATA_STORE STREQUAL "ELOQDSS_ROCKSDB_CLOUD_S3" OR WITH_DATA_STORE STREQUAL "ELOQDSS_ROCKSDB_CLOUD_GCS")
     SET(DATA_SUBSTRATE_LINK_LIBS ${DATA_SUBSTRATE_LINK_LIBS} ${ROCKSDB_LIBRARIES})
 elseif(WITH_DATA_STORE STREQUAL "DYNAMODB")
     SET(DATA_SUBSTRATE_LINK_LIBS ${DATA_SUBSTRATE_LINK_LIBS} ${AWSSDK_LINK_LIBRARIES})

--- a/core/src/storage_init.cpp
+++ b/core/src/storage_init.cpp
@@ -69,11 +69,8 @@ DEFINE_string(bigtable_instance_id, "", "Instance id of BigTable");
 DEFINE_string(bigtable_keyspace, "eloq", "KeySpace of BigTable");
 #endif
 // aws_secret_key
-#if defined(DATA_STORE_TYPE_ELOQDSS_ROCKSDB_CLOUD_S3)
-DECLARE_string(aws_access_key_id);
-DECLARE_string(aws_secret_key);
-#elif defined(DATA_STORE_TYPE_DYNAMODB) || defined(LOG_STATE_TYPE_RKDB_S3) || \
-    defined(LOG_STATE_TYPE_RKDB_GCS)
+#if defined(DATA_STORE_TYPE_ELOQDSS_ROCKSDB_CLOUD_S3) || \
+    defined(DATA_STORE_TYPE_DYNAMODB) || defined(LOG_STATE_TYPE_RKDB_S3)
 DEFINE_string(aws_access_key_id, "", "AWS SDK access key id");
 DEFINE_string(aws_secret_key, "", "AWS SDK secret key");
 #endif

--- a/store_handler/eloq_data_store_service/rocksdb_config.cpp
+++ b/store_handler/eloq_data_store_service/rocksdb_config.cpp
@@ -277,8 +277,10 @@ DEFINE_bool(rocksdb_cloud_run_purger, true, "Rocksdb cloud run purger");
 DEFINE_uint32(rocksdb_cloud_purger_periodicity_secs,
               10 * 60, /*10 minutes*/
               "Rocksdb cloud purger periodicity seconds");
-DEFINE_string(aws_access_key_id, "", "AWS SDK access key id");
-DEFINE_string(aws_secret_key, "", "AWS SDK secret key");
+#endif
+#if (defined(DATA_STORE_TYPE_ELOQDSS_ROCKSDB_CLOUD_S3))
+DECLARE_string(aws_access_key_id);
+DECLARE_string(aws_secret_key);
 #endif
 
 DEFINE_bool(rocksdb_io_uring_enabled,


### PR DESCRIPTION
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Reference the link of issue using `fixes eloqdb/tx_service#issue_id`
- [ ] Reference the link of RFC if exists
- [ ] Pass `./mtr --suite=mono_main,mono_multi,mono_basic`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Google Cloud Storage as an additional RocksDB-backed storage option.

* **Bug Fixes**
  * Improved stability in data flush paths by adding defensive checks to avoid unsafe memory accesses and potential crashes.

* **Chores**
  * Refined storage backend configuration and moved AWS credential flags so they apply only to the S3 variant.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->