### PR TITLE
fix ReadLocalOp assert

### DIFF
--- a/tx_service/src/tx_operation.cpp
+++ b/tx_service/src/tx_operation.cpp
@@ -303,7 +303,9 @@ void ReadLocalOperation::Forward(txservice::TransactionExecution *txm)
         {
             assert(hd_result_->ErrorCode() ==
                        CcErrorCode::ACQUIRE_KEY_LOCK_FAILED_FOR_RW_CONFLICT ||
-                   hd_result_->ErrorCode() == CcErrorCode::DATA_STORE_ERR);
+                   hd_result_->ErrorCode() == CcErrorCode::DATA_STORE_ERR ||
+                   hd_result_->ErrorCode() ==
+                       CcErrorCode::LEADER_NODE_UNREACHABLE);
             // If acquire range read lock blocked by DDL, check if tx has
             // already acquired other range read lock. If so we need to abort
             // tx since it might cause dead lock with range split. If this tx


### PR DESCRIPTION
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Reference the link of issue using `fixes eloqdb/tx_service#issue_id`
- [ ] Reference the link of RFC if exists
- [ ] Pass `./mtr --suite=mono_main,mono_multi,mono_basic`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling for transaction operations when leader nodes are unavailable, enabling more consistent error recovery and retry behavior across different error conditions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->