### PR TITLE
Fix datasyncscan paused key with debug log

### DIFF
--- a/tx_service/include/cc/cc_request.h
+++ b/tx_service/include/cc/cc_request.h
@@ -4299,6 +4299,8 @@ public:
             while (curr_slice->EndTxKey() < pause_pos_[core_id].first)
             {
                 ++curr_slice_idx;
+                assert(curr_slice_idx <
+                       slice_coordinator_.pinned_slices_.size());
                 curr_slice = slice_coordinator_.pinned_slices_[curr_slice_idx];
             }
             curr_slice_index_[core_id] = curr_slice_idx;

--- a/tx_service/include/cc/template_cc_map.h
+++ b/tx_service/include/cc/template_cc_map.h
@@ -5734,7 +5734,11 @@ public:
         bool no_more_data = (key_it == slice_end_it) && req.IsLastBatch();
         if (!no_more_data)
         {
-            next_pause_key = key_it->first->CloneTxKey();
+            // If key_it == slice_end_it, it means the current slice is
+            // completed. The paused key should be the slice end key.
+            next_pause_key = key_it != slice_end_it
+                                 ? key_it->first->CloneTxKey()
+                                 : slice_end_key->CloneTxKey();
         }
 
         // Set the pause_pos_ to mark resume position.


### PR DESCRIPTION
The paused key should be the end key of slice if it paused on the end of a slice.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Added bounds checking to prevent potential access violations when advancing through data slices during scan operations.
* Refined resumption logic for data scans across partitions to correctly position pause points at slice boundaries.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->