### PR TITLE
fix ReadLocalOp assert

### DIFF
--- a/tx_service/src/tx_operation.cpp
+++ b/tx_service/src/tx_operation.cpp
@@ -305,7 +305,8 @@ void ReadLocalOperation::Forward(txservice::TransactionExecution *txm)
                        CcErrorCode::ACQUIRE_KEY_LOCK_FAILED_FOR_RW_CONFLICT ||
                    hd_result_->ErrorCode() == CcErrorCode::DATA_STORE_ERR ||
                    hd_result_->ErrorCode() ==
-                       CcErrorCode::LEADER_NODE_UNREACHABLE);
+                       CcErrorCode::LEADER_NODE_UNREACHABLE ||
+                   hd_result_->ErrorCode() == CcErrorCode::NG_TERM_CHANGED);
             // If acquire range read lock blocked by DDL, check if tx has
             // already acquired other range read lock. If so we need to abort
             // tx since it might cause dead lock with range split. If this tx


### PR DESCRIPTION
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Reference the link of issue using `fixes eloqdb/tx_service#issue_id`
- [ ] Reference the link of RFC if exists
- [ ] Pass `./mtr --suite=mono_main,mono_multi,mono_basic`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced transaction operation reliability by improving error handling for term change scenarios. The system now treats certain failure conditions with consistent logic, enabling more graceful recovery and appropriate retry decisions when transactions encounter specific error states.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->