### PR TITLE
Fix slice split

### DIFF
--- a/tx_service/include/cc/template_cc_map.h
+++ b/tx_service/include/cc/template_cc_map.h
@@ -5421,7 +5421,11 @@ public:
                 range_ptr->FindSlice(slice_key);
 
             assert(slice->PostCkptSize() != UINT64_MAX);
-            return slice->PostCkptSize() > StoreSlice::slice_upper_bound;
+            // Only need to split the slice when the post ckpt size of the slice
+            // is greater than the current size and greater than the slice upper
+            // bound.
+            return (slice->PostCkptSize() > StoreSlice::slice_upper_bound &&
+                    slice->PostCkptSize() > slice->Size());
         };
 
         const KeyT *const req_start_key = req.start_key_ != nullptr

--- a/tx_service/src/cc/local_cc_shards.cpp
+++ b/tx_service/src/cc/local_cc_shards.cpp
@@ -5462,8 +5462,11 @@ void LocalCcShards::UpdateSlices(const TableName &table_name,
                                                                        : false;
 
         uint64_t slice_post_ckpt_size = curr_slice->PostCkptSize();
+        // If post ckpt size of the slice is less than or equal to the current
+        // size, there is no need to split the slice.
         if (slice_post_ckpt_size == UINT64_MAX ||
-            slice_post_ckpt_size <= StoreSlice::slice_upper_bound)
+            slice_post_ckpt_size <= StoreSlice::slice_upper_bound ||
+            slice_post_ckpt_size <= curr_slice->Size())
         {
             // Case 1: There is no unpersisted data in the current slice, so no
             // need to split the slice. Only to migrate this data from the old


### PR DESCRIPTION
1. Only need to split slice when post ckpt size is greater than the current size of the slice and greater than the slice upper bound.
2. For non snapshot read, there is no need to return the deleted keys from the data store.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Reference the link of issue using `fixes eloqdb/tx_service#issue_id`
- [ ] Reference the link of RFC if exists
- [ ] Pass `./mtr --suite=mono_main,mono_multi,mono_basic`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Refined snapshot read handling for improved data consistency and accuracy.
  * Optimized data partitioning logic to reduce unnecessary splitting operations and improve overall system efficiency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->