### PR TITLE
Crash-safe RocksDB snapshot swapping with backup-aware startup

### DIFF
--- a/store_handler/rocksdb_handler.cpp
+++ b/store_handler/rocksdb_handler.cpp
@@ -85,6 +85,25 @@ DECLARE_bool(bootstrap);
 namespace EloqKV
 {
 
+namespace
+{
+std::string NormalizeDbPath(const std::string &path)
+{
+    std::string normalized = path;
+    while (!normalized.empty() &&
+           (normalized.back() == '/' || normalized.back() == '\\'))
+    {
+        normalized.pop_back();
+    }
+    if (normalized.empty())
+    {
+        return path;
+    }
+
+    return normalized;
+}
+}  // namespace
+
 RocksDBHandler::RocksDBHandler(const EloqShare::RocksDBConfig &config,
                                bool create_if_missing,
                                bool tx_enable_cache_replacement)
@@ -2978,18 +2997,7 @@ bool RocksDBHandlerImpl::StartDB(bool is_ng_leader, uint32_t *next_leader_node)
         return true;
     }
 
-    std::string db_dir_str = db_path_;
-    while (!db_dir_str.empty() &&
-           (db_dir_str.back() == '/' || db_dir_str.back() == '\\'))
-    {
-        db_dir_str.pop_back();
-    }
-    if (db_dir_str.empty())
-    {
-        db_dir_str = db_path_;
-    }
-
-    std::filesystem::path db_dir(db_dir_str);
+    std::filesystem::path db_dir(NormalizeDbPath(db_path_));
     std::error_code error_code;
     bool db_dir_exists = std::filesystem::exists(db_dir, error_code);
     if (error_code.value() != 0)
@@ -3557,18 +3565,7 @@ bool RocksDBHandlerImpl::OverrideDB(const std::string &new_snapshot_path)
 
     assert(GetDBPtr() == nullptr);
 
-    std::string db_dir_str = db_path_;
-    while (!db_dir_str.empty() &&
-           (db_dir_str.back() == '/' || db_dir_str.back() == '\\'))
-    {
-        db_dir_str.pop_back();
-    }
-    if (db_dir_str.empty())
-    {
-        db_dir_str = db_path_;
-    }
-
-    std::filesystem::path db_dir(db_dir_str);
+    std::filesystem::path db_dir(NormalizeDbPath(db_path_));
     std::filesystem::path old_db_dir = db_dir;
     old_db_dir += ".old";
 


### PR DESCRIPTION
- Rework OverrideDB to swap snapshot directories via rename instead of remove_all, add debug logs, and guarantee we can roll back by keeping a db.old backup until RocksDB starts successfully.
- StartDB prefer an existing db/, restore db.old only when db/ is missing, refuse to start if neither exists, and always clean up leftover db.old after a successful open.

This ensures snapshot application survives crashes/kills mid-switch and prevents stale .old directories from blocking future swaps.

Fixes https://github.com/eloqdata/project_tracker/issues/145.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Automatic restoration from backups if the primary database directory is missing.
  * Rollback restores original data when a switch fails, preserving state.
  * Warnings logged when cleanup or restore operations fail.

* **Improvements**
  * Normalize database paths and remove trailing separators before use.
  * Consistent backup/restore and cleanup across variants.
  * Atomic snapshot switching with removal of temporary backup directories after success.
  * Expanded diagnostic logging for switch and cleanup phases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->