### PR TITLE
Add engine prefix to kv table name

### DIFF
--- a/store_handler/data_store_service_client.h
+++ b/store_handler/data_store_service_client.h
@@ -176,6 +176,12 @@ public:
         const std::unordered_map<uint32_t, uint32_t> &ng_leaders,
         DataStoreServiceClusterManager &cluster_manager);
 
+    static void InitBucketsInfo(
+        const std::set<uint32_t> &node_groups,
+        uint64_t version,
+        std::unordered_map<uint16_t, std::unique_ptr<txservice::BucketInfo>>
+            &ng_bucket_infos);
+
     void ConnectToLocalDataStoreService(
         std::unique_ptr<DataStoreService> ds_serv);
 
@@ -350,27 +356,32 @@ public:
         const std::function<void()> *resume_fptr = nullptr) override;
 
     bool DiscoverAllTableNames(
+        txservice::TableEngine table_engine,
         std::vector<std::string> &norm_name_vec,
         const std::function<void()> *yield_fptr = nullptr,
         const std::function<void()> *resume_fptr = nullptr) override;
 
     //-- database
     bool UpsertDatabase(
+        txservice::TableEngine table_engine,
         std::string_view db,
         std::string_view definition,
         const std::function<void()> *yield_fptr = nullptr,
         const std::function<void()> *resume_fptr = nullptr) override;
     bool DropDatabase(
+        txservice::TableEngine table_engine,
         std::string_view db,
         const std::function<void()> *yield_fptr = nullptr,
         const std::function<void()> *resume_fptr = nullptr) override;
     bool FetchDatabase(
+        txservice::TableEngine table_engine,
         std::string_view db,
         std::string &definition,
         bool &found,
         const std::function<void()> *yield_fptr = nullptr,
         const std::function<void()> *resume_fptr = nullptr) override;
     bool FetchAllDatabase(
+        txservice::TableEngine table_engine,
         std::vector<std::string> &dbnames,
         const std::function<void()> *yield_fptr = nullptr,
         const std::function<void()> *resume_fptr = nullptr) override;
@@ -759,11 +770,6 @@ private:
     bool UpdateOwnerNodeIndexOfShard(uint32_t shard_id,
                                      uint32_t old_node_index,
                                      uint32_t &new_node_index);
-    void InitBucketsInfo(
-        const std::set<uint32_t> &node_groups,
-        uint64_t version,
-        std::unordered_map<uint16_t, std::unique_ptr<txservice::BucketInfo>>
-            &ng_bucket_infos);
 
     void UpdateShardOwner(uint32_t shard_id, uint32_t node_id);
 

--- a/store_handler/data_store_service_client_closure.h
+++ b/store_handler/data_store_service_client_closure.h
@@ -2632,6 +2632,7 @@ struct FetchTableCallbackData : public SyncCallbackData
                const std::function<void()> *resume_fptr = nullptr)
     {
         SyncCallbackData::Reset();
+        key_str_.clear();
         schema_image_ = &schema_image;
         found_ = &found;
         version_ts_ = &version_ts;
@@ -2642,6 +2643,7 @@ struct FetchTableCallbackData : public SyncCallbackData
     void Clear() override
     {
         SyncCallbackData::Clear();
+        key_str_.clear();
         schema_image_ = nullptr;
         found_ = nullptr;
         version_ts_ = nullptr;
@@ -2672,6 +2674,9 @@ struct FetchTableCallbackData : public SyncCallbackData
             SyncCallbackData::Notify();
         }
     }
+
+    // Table name with engine prefix.
+    std::string key_str_;
 
     std::string *schema_image_;
     bool *found_;
@@ -2737,6 +2742,7 @@ struct FetchDatabaseCallbackData : public SyncCallbackData
         found_ = nullptr;
         yield_fptr_ = nullptr;
         resume_fptr_ = nullptr;
+        key_str_.clear();
         SyncCallbackData::Clear();
     }
 
@@ -2768,6 +2774,9 @@ struct FetchDatabaseCallbackData : public SyncCallbackData
     bool *found_;
     const std::function<void()> *yield_fptr_;
     const std::function<void()> *resume_fptr_;
+
+    // db name with engine prefix.
+    std::string key_str_;
 };
 
 /**
@@ -2791,12 +2800,14 @@ struct FetchAllDatabaseCallbackData : public SyncCallbackData
     FetchAllDatabaseCallbackData() = default;
     ~FetchAllDatabaseCallbackData() = default;
 
-    void Reset(std::vector<std::string> &dbnames,
+    void Reset(uint32_t engine_prefix_len,
+               std::vector<std::string> &dbnames,
                const std::function<void()> *yield_fptr,
                const std::function<void()> *resume_fptr)
     {
         SyncCallbackData::Reset();
         dbnames_ = &dbnames;
+        engine_prefix_len_ = engine_prefix_len;
         yield_fptr_ = yield_fptr;
         resume_fptr_ = resume_fptr;
         session_id_.clear();
@@ -2808,6 +2819,7 @@ struct FetchAllDatabaseCallbackData : public SyncCallbackData
     {
         SyncCallbackData::Clear();
         dbnames_ = nullptr;
+        engine_prefix_len_ = 0;
         yield_fptr_ = nullptr;
         resume_fptr_ = nullptr;
         session_id_.clear();
@@ -2846,6 +2858,8 @@ struct FetchAllDatabaseCallbackData : public SyncCallbackData
     std::string session_id_;
     std::string start_key_;
     std::string end_key_;
+
+    uint32_t engine_prefix_len_;
 };
 
 /**
@@ -2883,6 +2897,7 @@ struct UpsertDatabaseCallbackData : public SyncCallbackData
         SyncCallbackData::Clear();
         yield_fptr_ = nullptr;
         resume_fptr_ = nullptr;
+        key_str_.clear();
     }
 
     void Wait() override
@@ -2911,6 +2926,9 @@ struct UpsertDatabaseCallbackData : public SyncCallbackData
 
     const std::function<void()> *yield_fptr_;
     const std::function<void()> *resume_fptr_;
+
+    // db name with engine prefix.
+    std::string key_str_;
 };
 
 /**
@@ -2937,6 +2955,7 @@ struct DropDatabaseCallbackData : public SyncCallbackData
         SyncCallbackData::Clear();
         yield_fptr_ = nullptr;
         resume_fptr_ = nullptr;
+        key_str_.clear();
     }
 
     void Wait() override
@@ -2965,6 +2984,9 @@ struct DropDatabaseCallbackData : public SyncCallbackData
 
     const std::function<void()> *yield_fptr_;
     const std::function<void()> *resume_fptr_;
+
+    // db name with engine prefix.
+    std::string key_str_;
 };
 
 /**
@@ -2999,12 +3021,14 @@ struct DiscoverAllTableNamesCallbackData : public SyncCallbackData
     DiscoverAllTableNamesCallbackData() = default;
     ~DiscoverAllTableNamesCallbackData() = default;
 
-    void Reset(std::vector<std::string> &table_names,
+    void Reset(uint32_t engine_prefix_len,
+               std::vector<std::string> &table_names,
                const std::function<void()> *yield_fptr,
                const std::function<void()> *resume_fptr)
     {
         SyncCallbackData::Reset();
         table_names_ = &table_names;
+        engine_prefix_len_ = engine_prefix_len;
         yield_fptr_ = yield_fptr;
         resume_fptr_ = resume_fptr;
         session_id_.clear();
@@ -3014,6 +3038,7 @@ struct DiscoverAllTableNamesCallbackData : public SyncCallbackData
     {
         SyncCallbackData::Clear();
         table_names_ = nullptr;
+        engine_prefix_len_ = 0;
         yield_fptr_ = nullptr;
         resume_fptr_ = nullptr;
         session_id_.clear();
@@ -3048,6 +3073,9 @@ struct DiscoverAllTableNamesCallbackData : public SyncCallbackData
     const std::function<void()> *resume_fptr_;
 
     std::string session_id_;
+    std::string start_key_;
+    std::string end_key_;
+    uint32_t engine_prefix_len_;
 };
 
 /**

--- a/store_handler/eloq_data_store_service/data_store_factory.h
+++ b/store_handler/eloq_data_store_service/data_store_factory.h
@@ -23,6 +23,7 @@
 
 #include <memory>
 #include <string>
+#include <unordered_set>
 
 #include "data_store.h"
 
@@ -107,6 +108,15 @@ public:
     virtual bool IsOssUrlConfigured() const
     {
         return false;
+    }
+
+    /**
+     * @brief Set the prewarm filter function for eloqstore
+     * @param prewarm_filter The prewarm filter function
+     */
+    virtual void InitializePrewarmFilter(
+        uint32_t ng_id, std::unordered_set<uint16_t> &&bucket_ids)
+    {
     }
 };
 

--- a/store_handler/eloq_data_store_service/data_store_service.cpp
+++ b/store_handler/eloq_data_store_service/data_store_service.cpp
@@ -2198,8 +2198,15 @@ void DataStoreService::CloseDataStore(uint32_t shard_id)
     }
 }
 
-void DataStoreService::OpenDataStore(uint32_t shard_id)
+void DataStoreService::OpenDataStore(uint32_t shard_id,
+                                     std::unordered_set<uint16_t> &&bucket_ids)
 {
+    if (data_store_factory_ != nullptr)
+    {
+        data_store_factory_->InitializePrewarmFilter(shard_id,
+                                                     std::move(bucket_ids));
+    }
+
     auto start_time = std::chrono::steady_clock::now();
     auto &ds_ref = data_shards_.at(shard_id);
     if (ds_ref.shard_status_.load() != DSShardStatus::Closed)

--- a/store_handler/eloq_data_store_service/data_store_service.h
+++ b/store_handler/eloq_data_store_service/data_store_service.h
@@ -649,7 +649,8 @@ public:
     }
 
     void CloseDataStore(uint32_t shard_id);
-    void OpenDataStore(uint32_t shard_id);
+    void OpenDataStore(uint32_t shard_id,
+                       std::unordered_set<uint16_t> &&bucket_ids);
 
     DataStoreServiceClusterManager &GetClusterManager()
     {

--- a/store_handler/rocksdb_handler.cpp
+++ b/store_handler/rocksdb_handler.cpp
@@ -1493,6 +1493,7 @@ bool RocksDBHandler::FetchTable(const txservice::TableName &table_name,
 }
 
 bool RocksDBHandler::DiscoverAllTableNames(
+    txservice::TableEngine table_engine,
     std::vector<std::string> &norm_name_vec,
     const std::function<void()> *yield_fptr,
     const std::function<void()> *resume_fptr)
@@ -1504,7 +1505,8 @@ bool RocksDBHandler::DiscoverAllTableNames(
 }
 
 //-- database
-bool RocksDBHandler::UpsertDatabase(std::string_view db,
+bool RocksDBHandler::UpsertDatabase(txservice::TableEngine table_engine,
+                                    std::string_view db,
                                     std::string_view definition,
                                     const std::function<void()> *yield_fptr,
                                     const std::function<void()> *resume_fptr)
@@ -1516,7 +1518,8 @@ bool RocksDBHandler::UpsertDatabase(std::string_view db,
     return true;
 }
 
-bool RocksDBHandler::DropDatabase(std::string_view db,
+bool RocksDBHandler::DropDatabase(txservice::TableEngine table_engine,
+                                  std::string_view db,
                                   const std::function<void()> *yield_fptr,
                                   const std::function<void()> *resume_fptr)
 {
@@ -1526,7 +1529,8 @@ bool RocksDBHandler::DropDatabase(std::string_view db,
     return true;
 }
 
-bool RocksDBHandler::FetchDatabase(std::string_view db,
+bool RocksDBHandler::FetchDatabase(txservice::TableEngine table_engine,
+                                   std::string_view db,
                                    std::string &definition,
                                    bool &found,
                                    const std::function<void()> *yield_fptr,
@@ -1538,7 +1542,8 @@ bool RocksDBHandler::FetchDatabase(std::string_view db,
     return true;
 }
 
-bool RocksDBHandler::FetchAllDatabase(std::vector<std::string> &dbnames,
+bool RocksDBHandler::FetchAllDatabase(txservice::TableEngine table_engine,
+                                      std::vector<std::string> &dbnames,
                                       const std::function<void()> *yield_fptr,
                                       const std::function<void()> *resume_fptr)
 {

--- a/store_handler/rocksdb_handler.h
+++ b/store_handler/rocksdb_handler.h
@@ -423,27 +423,32 @@ public:
         const std::function<void()> *resume_fptr = nullptr) override;
 
     bool DiscoverAllTableNames(
+        txservice::TableEngine table_engine,
         std::vector<std::string> &norm_name_vec,
         const std::function<void()> *yield_fptr = nullptr,
         const std::function<void()> *resume_fptr = nullptr) override;
 
     //-- database
     bool UpsertDatabase(
+        txservice::TableEngine table_engine,
         std::string_view db,
         std::string_view definition,
         const std::function<void()> *yield_fptr = nullptr,
         const std::function<void()> *resume_fptr = nullptr) override;
     bool DropDatabase(
+        txservice::TableEngine table_engine,
         std::string_view db,
         const std::function<void()> *yield_fptr = nullptr,
         const std::function<void()> *resume_fptr = nullptr) override;
     bool FetchDatabase(
+        txservice::TableEngine table_engine,
         std::string_view db,
         std::string &definition,
         bool &found,
         const std::function<void()> *yield_fptr = nullptr,
         const std::function<void()> *resume_fptr = nullptr) override;
     bool FetchAllDatabase(
+        txservice::TableEngine table_engine,
         std::vector<std::string> &dbnames,
         const std::function<void()> *yield_fptr = nullptr,
         const std::function<void()> *resume_fptr = nullptr) override;

--- a/tx_service/include/cc/cc_req_misc.h
+++ b/tx_service/include/cc/cc_req_misc.h
@@ -127,6 +127,10 @@ public:
 
     void SetFinish(RecordStatus status, int err);
 
+public:
+    // Table name with engine prefix, only used in DataStoreHandler.
+    std::string kv_key_;
+
 private:
     const TableName table_name_;
     std::string catalog_image_;

--- a/tx_service/include/sequences/sequences.h
+++ b/tx_service/include/sequences/sequences.h
@@ -76,7 +76,7 @@ public:
         txservice::sequence_table_name_sv};
     inline static const TableName table_name_{txservice::sequence_table_name};
     inline static const std::string_view kv_table_name_sv_{
-        txservice::sequence_table_name_sv};
+        txservice::sequence_kv_table_name_sv};
     inline static const uint64_t seq_schema_version_{100U};
 
     static void InitSequence(TxService *tx_service,

--- a/tx_service/include/store/data_store_handler.h
+++ b/tx_service/include/store/data_store_handler.h
@@ -240,27 +240,32 @@ public:
     }
 
     virtual bool DiscoverAllTableNames(
+        txservice::TableEngine table_engine,
         std::vector<std::string> &norm_name_vec,
         const std::function<void()> *yield_fptr = nullptr,
         const std::function<void()> *resume_fptr = nullptr) = 0;
 
     //-- database
     virtual bool UpsertDatabase(
+        txservice::TableEngine table_engine,
         std::string_view db,
         std::string_view definition,
         const std::function<void()> *yield_fptr = nullptr,
         const std::function<void()> *resume_fptr = nullptr) = 0;
     virtual bool DropDatabase(
+        txservice::TableEngine table_engine,
         std::string_view db,
         const std::function<void()> *yield_fptr = nullptr,
         const std::function<void()> *resume_fptr = nullptr) = 0;
     virtual bool FetchDatabase(
+        txservice::TableEngine table_engine,
         std::string_view db,
         std::string &definition,
         bool &found,
         const std::function<void()> *yield_fptr = nullptr,
         const std::function<void()> *resume_fptr = nullptr) = 0;
     virtual bool FetchAllDatabase(
+        txservice::TableEngine table_engine,
         std::vector<std::string> &dbnames,
         const std::function<void()> *yield_fptr = nullptr,
         const std::function<void()> *resume_fptr = nullptr) = 0;

--- a/tx_service/include/type.h
+++ b/tx_service/include/type.h
@@ -167,6 +167,29 @@ enum class TableEngine : uint8_t
     InternalHash = 5,  // eg. Sequence table is a kind of internal hash table.
 };
 
+inline std::string KvTablePrefixOf(TableEngine engine)
+{
+    switch (engine)
+    {
+    case txservice::TableEngine::None:
+        return "";
+    case txservice::TableEngine::EloqSql:
+        return "eloqsql_";
+    case txservice::TableEngine::EloqKv:
+        return "eloqkv_";
+    case txservice::TableEngine::EloqDoc:
+        return "eloqdoc_";
+    case txservice::TableEngine::InternalRange:
+        return "irange_";
+    case txservice::TableEngine::InternalHash:
+        return "ihash_";
+    }
+
+    LOG(FATAL) << "Unimplemnt the KvTablePrefixOf for engine type: "
+               << static_cast<int>(engine);
+    return "";
+}
+
 struct TableName
 {
     TableName() = delete;
@@ -567,11 +590,12 @@ enum class PostReadType
 
 constexpr static std::string_view empty_sv{"__empty"};
 constexpr static std::string_view catalog_ccm_name_sv{"__catalog"};
-constexpr static std::string_view redis_table_name_sv{"redis_table"};
 constexpr static std::string_view range_bucket_ccm_name_sv{"__range_bucket"};
 constexpr static std::string_view cluster_config_ccm_name_sv{
     "__cluster_config"};
 constexpr static std::string_view sequence_table_name_sv{"__sequence_table"};
+constexpr static std::string_view sequence_kv_table_name_sv{
+    "ihash_sequence_table"};
 constexpr static std::string_view internal_range_table_name_sv{
     "__internal_range_table"};
 constexpr static std::string_view internal_hash_table_name_sv{


### PR DESCRIPTION
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Reference the link of issue using `fixes eloqdb/tx_service#issue_id`
- [ ] Reference the link of RFC if exists
- [ ] Pass `./mtr --suite=mono_main,mono_multi,mono_basic`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-engine scoping: catalog, table and database entries are isolated per engine.
  * Bucket-aware startup: node groups bind and prewarm only their owned buckets.

* **Refactor**
  * Unified engine-prefixed keying across discovery, read/write and catalog flows.
  * Discovery callbacks now strip engine prefixes and use stable ranged scans.

* **Chore**
  * Public interfaces updated to carry engine context and bucket info; prewarm filter hook added.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->