### PR TITLE
Fix recent bugs

### DIFF
--- a/tx_service/include/cc/cc_request.h
+++ b/tx_service/include/cc/cc_request.h
@@ -4456,6 +4456,8 @@ private:
         {
             first_slice_id_.Reset();
             pinned_slices_.clear();
+            min_paused_key_ = TxKey();
+            min_paused_slice_index_ = 0;
             prepared_slice_cnt_ = 0;
             ready_for_scan_.store(false, std::memory_order_relaxed);
             batch_end_slice_index_ = 0;


### PR DESCRIPTION
1. Abort blocking cmd does not try to recycle key lock struct after abort.
2. Range partition data sync did not return mem quota after scan fail or flush fail

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transaction coordination state management to ensure consistent reset behavior during operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->