### PR TITLE
fix: put deleted keys with ttl when mvcc is enabled

### DIFF
--- a/store_handler/data_store_service_client.cpp
+++ b/store_handler/data_store_service_client.cpp
@@ -5622,7 +5622,7 @@ void DataStoreServiceClient::PrepareRangePartitionBatches(
         batch_size += tx_key.Size();
 
         const txservice::TxRecord *rec = ckpt_rec.Payload();
-        if (is_deleted)
+        if (is_deleted && enabled_mvcc)
         {
             batch_request.records_ttl.push_back(retired_ttl_for_deleted);
         }


### PR DESCRIPTION
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Reference the link of issue using `fixes eloqdb/tx_service#issue_id`
- [ ] Reference the link of RFC if exists
- [ ] Pass `./mtr --suite=mono_main,mono_multi,mono_basic`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of Time-To-Live (TTL) settings for deleted records. TTL for deleted records now applies more precisely when Multi-Version Concurrency Control (MVCC) is enabled, ensuring more consistent data retention behavior across different system configurations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->