### PR TITLE
Convert deleted to put when enable mvcc

### DIFF
--- a/store_handler/data_store_service_client.cpp
+++ b/store_handler/data_store_service_client.cpp
@@ -5622,7 +5622,8 @@ void DataStoreServiceClient::PrepareRangePartitionBatches(
         batch_size += tx_key.Size();
 
         const txservice::TxRecord *rec = ckpt_rec.Payload();
-        if (is_deleted)
+        // Convert deleted to put with retired ttl for mvcc enabled case
+        if (is_deleted && enabled_mvcc)
         {
             batch_request.records_ttl.push_back(retired_ttl_for_deleted);
         }


### PR DESCRIPTION
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Reference the link of issue using `fixes eloqdb/tx_service#issue_id`
- [ ] Reference the link of RFC if exists
- [ ] Pass `./mtr --suite=mono_main,mono_multi,mono_basic`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted handling of deleted records so they are converted to a retired-entry (PUT with a TTL) only when multi-version concurrency control (MVCC) is enabled; when MVCC is disabled, deletions remain as DELETE. This clarifies and stabilizes record ordering and consistency across MVCC and non-MVCC paths.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->