### PR TITLE
Make putall across tables parallel

### DIFF
--- a/core/src/metrics_init.cpp
+++ b/core/src/metrics_init.cpp
@@ -95,7 +95,7 @@ bool DataSubstrate::InitializeMetrics(const INIReader &config_reader)
                       << (metrics::enable_kv_metrics ? "ON" : "OFF");
 
             metrics::enable_eloqstore_metrics = config_reader.GetBoolean(
-                "metrics", "enable_eloqstore_metrics", false);
+                "metrics", "enable_eloqstore_metrics", true);
             LOG(INFO) << "enable_eloqstore_metrics: "
                       << (metrics::enable_eloqstore_metrics ? "ON" : "OFF");
         }

--- a/store_handler/data_store_service_client_closure.h
+++ b/store_handler/data_store_service_client_closure.h
@@ -130,6 +130,7 @@ private:
  */
 struct PartitionFlushState : public Poolable
 {
+    bool is_range_partitioned{false};
     int32_t partition_id;
     std::queue<PartitionBatchRequest> pending_batches;
     bool failed = false;
@@ -141,9 +142,10 @@ struct PartitionFlushState : public Poolable
         result.Clear();
     }
 
-    void Reset(int32_t pid)
+    void Reset(int32_t pid, bool is_range_partitioned)
     {
         partition_id = pid;
+        this->is_range_partitioned = is_range_partitioned;
         while (!pending_batches.empty())
         {
             pending_batches.pop();
@@ -1756,7 +1758,7 @@ public:
                 ::EloqDS::remote::DataStoreError::REQUESTED_NODE_NOT_OWNER)
             {
                 ds_service_client_->HandleShardingError(result_);
-                // TODO(lzx): retry.
+                need_retry = true;
             }
         }
 


### PR DESCRIPTION
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Reference the link of issue using `fixes eloqdb/tx_service#issue_id`
- [ ] Reference the link of RFC if exists
- [ ] Pass `./mtr --suite=mono_main,mono_multi,mono_basic`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Parallel flush across tables**
> 
> - Reworks `PutAll` to build a single global `SyncPutAllData` across all tables, aggregate partition states, and start first batches concurrently; waits once and performs unified error handling and cleanup
> - Uses `PartitionFlushState::Reset(partition_id, is_range)` and new `partition_state.is_range_partitioned` for correct `GetShardIdByPartitionId` routing; moves `records_count` outside per-table loop and keeps metrics collection once
> 
> **Partition state/API tweaks**
> 
> - Adds `bool is_range_partitioned` to `PartitionFlushState` and updates `Reset` signature; callers updated for hash vs range partitions
> 
> **Reliability**
> 
> - On `REQUESTED_NODE_NOT_OWNER`, sets `need_retry = true` to trigger retry logic instead of TODO
> 
> **Config/metrics**
> 
> - Defaults `metrics.enable_eloqstore_metrics` to `true` (was `false`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0c330f15f35067706a9e333fefc8011cea745ff5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled metrics collection by default.

* **Bug Fixes**
  * Improved retry handling for remote data store operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->