### PR TITLE
Skip ccpage that has no dirty keys since last datasync during datasyn…

### DIFF
--- a/tx_service/src/cc/local_cc_shards.cpp
+++ b/tx_service/src/cc/local_cc_shards.cpp
@@ -4064,7 +4064,7 @@ void LocalCcShards::DataSyncForRangePartition(
                                          tx_number,
                                          &start_tx_key,
                                          &end_tx_key,
-                                         false,
+                                         last_sync_ts,
                                          export_base_table_items,
                                          false,
                                          store_range,

--- a/tx_service/src/sk_generator.cpp
+++ b/tx_service/src/sk_generator.cpp
@@ -329,7 +329,7 @@ void SkGenerator::ScanAndEncodeIndex(const TxKey *start_key,
                                           tx_number,
                                           start_key,
                                           end_key,
-                                          false,
+                                          0,
                                           true,
                                           true);
 


### PR DESCRIPTION
During the `DataSyncScan` for a range partition, skip `ccpages` that have no dirty keys since the last `DataSync`.

remove useless variable

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Reference the link of issue using `fixes eloqdb/tx_service#issue_id`
- [ ] Reference the link of RFC if exists
- [ ] Pass `./mtr --suite=mono_main,mono_multi,mono_basic`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Data synchronization now uses timestamp-based tracking for finer sync/delta detection.
  * Scans skip partitions/pages with no new updates, improving efficiency and batch progress.
  * Enhanced boundary handling across pages and slices to better determine pause/resume points and reduce unnecessary work.

* **Bug Fixes**
  * Added tighter safety checks to prevent out-of-bounds slice access.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->