### PR TITLE
skip catalog_entry->UpdateLastDataSyncTS when datasync skips entries

### DIFF
--- a/tx_service/src/cc/local_cc_shards.cpp
+++ b/tx_service/src/cc/local_cc_shards.cpp
@@ -4465,8 +4465,8 @@ void LocalCcShards::PostProcessHashPartitionDataSyncTask(
             {
                 std::shared_lock<std::shared_mutex> meta_data_lk(
                     meta_data_mux_);
-                // Make sure that the term has not changed so that catalog
-                // entry is still valid.
+                // Make sure that the term has not changed so that catalog entry
+                // is still valid.
                 if (!Sharder::Instance().CheckLeaderTerm(
                         task->node_group_id_, task->node_group_term_))
                 {


### PR DESCRIPTION
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Reference the link of issue using `fixes eloqdb/tx_service#issue_id`
- [ ] Reference the link of RFC if exists
- [ ] Pass `./mtr --suite=mono_main,mono_multi,mono_basic`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Bug Fixes**
- Enhanced data synchronization logic to properly handle edge cases where entries are skipped during the synchronization process, improving overall system robustness
- Improved error validation and recovery mechanisms in the data synchronization pipeline for better system reliability and consistency
- Refined catalog update procedures to ensure accurate timestamp management in all synchronization scenarios

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->