### PR TITLE
feat: add eloq_store_root_meta_cache_size to eloq_store_config

### DIFF
--- a/store_handler/eloq_data_store_service/eloq_store_config.cpp
+++ b/store_handler/eloq_data_store_service/eloq_store_config.cpp
@@ -362,6 +362,38 @@ EloqStoreConfig::EloqStoreConfig(const INIReader &config_reader,
             : config_reader.GetBoolean("store",
                                        "eloq_store_skip_verify_checksum",
                                        FLAGS_eloq_store_skip_verify_checksum);
+    std::string root_meta_cache_size_str;
+    if (CheckCommandLineFlagIsDefault("eloq_store_root_meta_cache_size"))
+    {
+        if (config_reader.HasValue("store", "eloq_store_root_meta_cache_size"))
+        {
+            root_meta_cache_size_str =
+                config_reader.GetString("store",
+                                        "eloq_store_root_meta_cache_size",
+                                        FLAGS_eloq_store_root_meta_cache_size);
+        }
+        else
+        {
+            root_meta_cache_size_str =
+                std::to_string(node_memory_mb / 20) + "MB";
+            LOG(INFO) << "config is automatically set: "
+                      << "eloq_store_root_meta_cache_size="
+                      << root_meta_cache_size_str
+                      << ", available memory=" << node_memory_mb << "MB";
+        }
+    }
+    else
+    {
+        root_meta_cache_size_str = FLAGS_eloq_store_root_meta_cache_size;
+    }
+    uint64_t root_meta_cache_size = parse_size(root_meta_cache_size_str);
+    if (root_meta_cache_size / (1024 * 1024) > node_memory_mb)
+    {
+        LOG(FATAL) << "root meta cache size (" << root_meta_cache_size
+                   << ") exceeds node memory mb";
+    }
+    node_memory_mb -= root_meta_cache_size / (1024 * 1024);
+    eloqstore_configs_.root_meta_cache_size = root_meta_cache_size;
     std::string buffer_pool_size_str;
     if (CheckCommandLineFlagIsDefault("eloq_store_buffer_pool_size"))
     {
@@ -397,38 +429,6 @@ EloqStoreConfig::EloqStoreConfig(const INIReader &config_reader,
     eloqstore_configs_.buffer_pool_size =
         buffer_pool_size / eloqstore_configs_.num_threads;
 
-    std::string root_meta_cache_size_str;
-    if (CheckCommandLineFlagIsDefault("eloq_store_root_meta_cache_size"))
-    {
-        if (config_reader.HasValue("store", "eloq_store_root_meta_cache_size"))
-        {
-            root_meta_cache_size_str =
-                config_reader.GetString("store",
-                                        "eloq_store_root_meta_cache_size",
-                                        FLAGS_eloq_store_root_meta_cache_size);
-        }
-        else
-        {
-            root_meta_cache_size_str =
-                std::to_string(node_memory_mb / 20) + "MB";
-            LOG(INFO) << "config is automatically set: "
-                      << "eloq_store_root_meta_cache_size="
-                      << root_meta_cache_size_str
-                      << ", available memory=" << node_memory_mb << "MB";
-        }
-    }
-    else
-    {
-        root_meta_cache_size_str = FLAGS_eloq_store_root_meta_cache_size;
-    }
-    uint64_t root_meta_cache_size = parse_size(root_meta_cache_size_str);
-    if (root_meta_cache_size / (1024 * 1024) > node_memory_mb)
-    {
-        LOG(FATAL) << "root meta cache size (" << root_meta_cache_size
-                   << ") exceeds node memory mb";
-    }
-    node_memory_mb -= root_meta_cache_size / (1024 * 1024);
-    eloqstore_configs_.root_meta_cache_size = root_meta_cache_size;
     eloqstore_configs_.manifest_limit =
         !CheckCommandLineFlagIsDefault("eloq_store_manifest_limit")
             ? FLAGS_eloq_store_manifest_limit


### PR DESCRIPTION
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Reference the link of issue using `fixes eloqdb/tx_service#issue_id`
- [ ] Reference the link of RFC if exists
- [ ] Pass `./mtr --suite=mono_main,mono_multi,mono_basic`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a global, configurable root metadata cache size with optional manual override.
  * Cache size now auto-computes from available memory when unset, validates against system memory, and is enforced to ensure consistent and reliable memory management.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->