### PR TITLE
fix DataStoreServiceClusterManager::PrepareShardingError

### DIFF
--- a/store_handler/eloq_data_store_service/data_store_service_config.cpp
+++ b/store_handler/eloq_data_store_service/data_store_service_config.cpp
@@ -923,7 +923,7 @@ void DataStoreServiceClusterManager::PrepareShardingError(
     DLOG(INFO) << "=====PrepareShardingError";
     result->set_error_msg("Requested data not on local node.");
     auto *key_sharding_changed_message = result->mutable_new_key_sharding();
-    if (!IsMemberOfShard(this_node_, shard_id))
+    if (!topology_.IsMemberOfShard(this_node_, shard_id))
     {
         // Node group changed - send full cluster config
         key_sharding_changed_message->set_type(


### PR DESCRIPTION
Fixes https://github.com/eloqdata/project_tracker/issues/182.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed shard membership logic so cluster configuration updates are emitted correctly depending on whether the local node belongs to a shard, preventing incorrect cluster/state broadcasts and ensuring accurate primary node reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->