### PR TITLE
Fix underflow dirty size

### DIFF
--- a/tx_service/include/cc/object_cc_map.h
+++ b/tx_service/include/cc/object_cc_map.h
@@ -1970,7 +1970,7 @@ public:
                     cce->payload_.cur_payload_ == nullptr
                         ? RecordStatus::Deleted
                         : RecordStatus::Normal;
-                bool was_dirty = (cce->CommitTs() > 1 && !cce->IsPersistent());
+                bool was_dirty = cce->IsDirty();
                 cce->SetCommitTsPayloadStatus(commit_ts, payload_status);
                 this->OnCommittedUpdate(cce, was_dirty);
                 if (s_obj_exist && payload_status != RecordStatus::Normal)
@@ -2006,7 +2006,7 @@ public:
 
                 // Emplace txn_cmd and try to commit all pending commands.
                 int64_t buffered_cmd_cnt_old = buffered_cmd_list.Size();
-                bool was_dirty = (cce->CommitTs() > 1 && !cce->IsPersistent());
+                bool was_dirty = cce->IsDirty();
                 cce->EmplaceAndCommitBufferedTxnCommand(
                     txn_cmd, shard_->NowInMilliseconds());
                 this->OnCommittedUpdate(cce, was_dirty);

--- a/tx_service/src/cc/cc_req_misc.cpp
+++ b/tx_service/src/cc/cc_req_misc.cpp
@@ -1212,22 +1212,24 @@ bool UpdateCceCkptTsCc::Execute(CcShard &ccs)
                     static_cast<VersionedLruEntry<true, true> *>(ref.cce_);
 
                 assert(v_entry->CommitTs() > 1 && !v_entry->IsPersistent());
+                bool was_dirty = v_entry->IsDirty();
                 v_entry->entry_info_.SetDataStoreSize(ref.post_flush_size_);
 
                 v_entry->SetCkptTs(ref.commit_ts_);
                 v_entry->ClearBeingCkpt();
-                ccm->OnEntryFlushed(true, v_entry->IsPersistent());
+                ccm->OnEntryFlushed(was_dirty, v_entry->IsPersistent());
             }
             else
             {
                 VersionedLruEntry<false, true> *v_entry =
                     static_cast<VersionedLruEntry<false, true> *>(ref.cce_);
                 assert(v_entry->CommitTs() > 1 && !v_entry->IsPersistent());
+                bool was_dirty = v_entry->IsDirty();
                 v_entry->entry_info_.SetDataStoreSize(ref.post_flush_size_);
 
                 v_entry->SetCkptTs(ref.commit_ts_);
                 v_entry->ClearBeingCkpt();
-                ccm->OnEntryFlushed(true, v_entry->IsPersistent());
+                ccm->OnEntryFlushed(was_dirty, v_entry->IsPersistent());
             }
         }
         else
@@ -1238,9 +1240,10 @@ bool UpdateCceCkptTsCc::Execute(CcShard &ccs)
                     static_cast<VersionedLruEntry<true, false> *>(ref.cce_);
 
                 assert(v_entry->CommitTs() > 1 && !v_entry->IsPersistent());
+                bool was_dirty = v_entry->IsDirty();
                 v_entry->SetCkptTs(ref.commit_ts_);
                 v_entry->ClearBeingCkpt();
-                ccm->OnEntryFlushed(true, v_entry->IsPersistent());
+                ccm->OnEntryFlushed(was_dirty, v_entry->IsPersistent());
             }
             else
             {
@@ -1248,9 +1251,10 @@ bool UpdateCceCkptTsCc::Execute(CcShard &ccs)
                     static_cast<VersionedLruEntry<false, false> *>(ref.cce_);
 
                 assert(v_entry->CommitTs() > 1 && !v_entry->IsPersistent());
+                bool was_dirty = v_entry->IsDirty();
                 v_entry->SetCkptTs(ref.commit_ts_);
                 v_entry->ClearBeingCkpt();
-                ccm->OnEntryFlushed(true, v_entry->IsPersistent());
+                ccm->OnEntryFlushed(was_dirty, v_entry->IsPersistent());
             }
         }
     }


### PR DESCRIPTION
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Reference the link of issue using `fixes eloqdb/tx_service#issue_id`
- [ ] Reference the link of RFC if exists
- [ ] Pass `./mtr --suite=mono_main,mono_multi,mono_basic`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dirty-state detection so flush/commit notifications reflect an entry’s actual modified state.
  * Ensured template overwrite paths propagate prior dirty state when updating and committing entries.
  * Tightened synchronization during cache updates to maintain consistent shard statistics.
  * Added safeguards to prevent underflow in shard-level counters and keep counts non-negative.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->