### PR TITLE
Wrong return for all fault injection

### DIFF
--- a/tx_service/src/fault/fault_inject.cpp
+++ b/tx_service/src/fault/fault_inject.cpp
@@ -262,9 +262,8 @@ void FaultInject::InjectFault(std::string fault_name, std::string paras)
     if (fault_name == "override_log_retention_seconds")
     {
         txlog::FaultInject::Instance().InjectFault(fault_name, paras);
+        return;
     }
-
-    return;
 #endif
 
     // To remove the pointed fault inject.


### PR DESCRIPTION
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Reference the link of issue using `fixes eloqdb/tx_service#issue_id`
- [ ] Reference the link of RFC if exists
- [ ] Pass `./mtr --suite=mono_main,mono_multi,mono_basic`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed fault injection logic to properly handle multiple fault scenarios instead of prematurely terminating processing for certain conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->