### PR TITLE
fix RocksDBHandler

### DIFF
--- a/store_handler/rocksdb_handler.cpp
+++ b/store_handler/rocksdb_handler.cpp
@@ -254,7 +254,7 @@ bool RocksDBHandler::Connect()
             std::filesystem::remove_all(entry.path(), error_code);
             if (error_code.value() != 0)
             {
-                LOG(ERROR) << "unable to remove rocksdb checkpoint entry: "
+                LOG(ERROR) << "unable to remove received snapshot entry: "
                            << entry.path()
                            << ", error code: " << error_code.value()
                            << ", error message: " << error_code.message();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Connection setup now properly detects failures during cleanup of checkpoint and snapshot paths, logs an error with the affected path and message, and prevents completing the connection when cleanup fails—improving robustness and making startup issues visible.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->