### PR TITLE
Create a high-priority DataSync task to trigger range split

### DIFF
--- a/tx_service/include/cc/cc_shard.h
+++ b/tx_service/include/cc/cc_shard.h
@@ -1152,6 +1152,11 @@ public:
 
     void DeleteSchemaCntl(const TableName &tbl_name);
 
+    void CreateSplitRangeDataSyncTask(const TableName &table_name,
+                                      uint32_t ng_id,
+                                      int64_t ng_term,
+                                      int32_t range_id);
+
     void ClearNativeSchemaCntl();
     void CollectCacheHit();
     void CollectCacheMiss();

--- a/tx_service/include/cc/local_cc_shards.h
+++ b/tx_service/include/cc/local_cc_shards.h
@@ -1913,7 +1913,8 @@ private:
                                   bool can_be_skipped,
                                   uint64_t &last_sync_ts,
                                   std::shared_ptr<DataSyncStatus> status,
-                                  CcHandlerResult<Void> *hres);
+                                  CcHandlerResult<Void> *hres,
+                                  bool high_priority = false);
     bool EnqueueDataSyncTaskToCore(
         const TableName &table_name,
         uint32_t ng_id,
@@ -2303,7 +2304,7 @@ private:
     {
         // `0` means no pending task
         uint64_t latest_pending_task_ts_{0};
-        std::queue<std::shared_ptr<DataSyncTask>> pending_tasks_;
+        std::deque<std::shared_ptr<DataSyncTask>> pending_tasks_;
 
         uint64_t UnsetLatestPendingTs()
         {

--- a/tx_service/include/cc/template_cc_map.h
+++ b/tx_service/include/cc/template_cc_map.h
@@ -632,9 +632,21 @@ public:
                                              old_payload_size));
                         const uint32_t range_id = req.PartitionId();
                         // is_dirty: true when range is splitting.
-                        UpdateRangeSize(range_id,
-                                        static_cast<int32_t>(key_delta_size),
-                                        req.OnDirtyRange());
+                        bool need_split = UpdateRangeSize(
+                            range_id,
+                            static_cast<int32_t>(key_delta_size),
+                            req.OnDirtyRange());
+
+                        if (need_split)
+                        {
+                            assert(!req.OnDirtyRange());
+                            // Create a data sync task for the range.
+                            shard_->CreateSplitRangeDataSyncTask(
+                                table_name_,
+                                cc_ng_id_,
+                                cce_addr->Term(),
+                                range_id);
+                        }
                     }
                 }
 
@@ -11422,7 +11434,7 @@ protected:
         return &pos_inf_page_;
     }
 
-    void UpdateRangeSize(uint32_t partition_id,
+    bool UpdateRangeSize(uint32_t partition_id,
                          int32_t delta_size,
                          bool is_dirty)
     {
@@ -11451,7 +11463,7 @@ protected:
                                             static_cast<int32_t>(partition_id),
                                             cc_ng_id_,
                                             ng_term);
-                return;
+                return false;
             }
 
             if (it->second.first ==
@@ -11466,8 +11478,14 @@ protected:
                 assert(delta_size >= 0 ||
                        it->second.first >= static_cast<int32_t>(-delta_size));
                 it->second.first += delta_size;
+
+                return !is_dirty &&
+                       it->second.first >=
+                           static_cast<int32_t>(StoreRange::range_max_size);
             }
         }  // RangePartitioned
+
+        return false;
     }
 
     absl::btree_map<

--- a/tx_service/include/data_sync_task.h
+++ b/tx_service/include/data_sync_task.h
@@ -124,7 +124,8 @@ public:
         CcHandlerResult<Void> *hres,
         std::function<bool(size_t)> filter_lambda = nullptr,
         bool forward_cache = false,
-        bool is_standby_node_ckpt = false)
+        bool is_standby_node_ckpt = false,
+        bool high_priority = false)
         : table_name_(table_name),
           id_(id),
           range_version_(range_version),
@@ -138,7 +139,8 @@ public:
           is_dirty_(is_dirty),
           sync_ts_adjustable_(need_adjust_ts),
           task_res_(hres),
-          need_update_ckpt_ts_(true)
+          need_update_ckpt_ts_(true),
+          high_priority_(high_priority)
     {
     }
 
@@ -238,6 +240,7 @@ public:
         cce_entries_;
 
     bool need_update_ckpt_ts_{true};
+    bool high_priority_{false};
 };
 
 struct FlushTaskEntry

--- a/tx_service/src/cc/cc_shard.cpp
+++ b/tx_service/src/cc/cc_shard.cpp
@@ -3467,6 +3467,31 @@ void CcShard::RecycleTxLockInfo(TxLockInfo::uptr lock_info)
     tx_lock_info_head_.next_ = std::move(lock_info);
 }
 
+void CcShard::CreateSplitRangeDataSyncTask(const TableName &table_name,
+                                           uint32_t ng_id,
+                                           int64_t ng_term,
+                                           int32_t range_id)
+{
+    std::shared_ptr<DataSyncStatus> status =
+        std::make_shared<DataSyncStatus>(ng_id, ng_term, false);
+    TableRangeEntry *range_entry = const_cast<TableRangeEntry *>(
+        local_shards_.GetTableRangeEntry(table_name, ng_id, range_id));
+    assert(range_entry != nullptr);
+    uint64_t data_sync_ts = local_shards_.ClockTs();
+    uint64_t last_sync_ts = 0;
+    local_shards_.EnqueueRangeDataSyncTask(table_name,
+                                           ng_id,
+                                           ng_term,
+                                           range_entry,
+                                           data_sync_ts,
+                                           false,
+                                           false,
+                                           last_sync_ts,
+                                           status,
+                                           nullptr,
+                                           true);
+}
+
 void CcShard::CollectCacheHit()
 {
     assert(metrics::enable_cache_hit_rate);

--- a/tx_service/src/cc/local_cc_shards.cpp
+++ b/tx_service/src/cc/local_cc_shards.cpp
@@ -2327,7 +2327,8 @@ bool LocalCcShards::EnqueueRangeDataSyncTask(
     bool can_be_skipped,
     uint64_t &last_sync_ts,
     std::shared_ptr<DataSyncStatus> status,
-    CcHandlerResult<Void> *hres)
+    CcHandlerResult<Void> *hres,
+    bool high_priority)
 {
     const RangeInfo *range_info = range_entry->GetRangeInfo();
     NodeGroupId range_ng =
@@ -2361,19 +2362,33 @@ bool LocalCcShards::EnqueueRangeDataSyncTask(
             // Push task to worker task queue.
             std::lock_guard<std::mutex> task_worker_lk(
                 data_sync_worker_ctx_.mux_);
-            data_sync_task_queue_[range_info->PartitionId() %
-                                  data_sync_task_queue_.size()]
-                .emplace_back(
-                    std::make_shared<DataSyncTask>(table_name,
-                                                   range_info->PartitionId(),
-                                                   range_info->VersionTs(),
-                                                   ng_id,
-                                                   ng_term,
-                                                   data_sync_ts,
-                                                   status,
-                                                   is_dirty,
-                                                   can_be_skipped,
-                                                   hres));
+            std::deque<std::shared_ptr<DataSyncTask>> &task_queue =
+                data_sync_task_queue_[range_info->PartitionId() %
+                                      data_sync_task_queue_.size()];
+
+            auto task =
+                std::make_shared<DataSyncTask>(table_name,
+                                               range_info->PartitionId(),
+                                               range_info->VersionTs(),
+                                               ng_id,
+                                               ng_term,
+                                               data_sync_ts,
+                                               status,
+                                               is_dirty,
+                                               can_be_skipped,
+                                               hres,
+                                               nullptr,
+                                               false,
+                                               false,
+                                               high_priority);
+            if (high_priority)
+            {
+                task_queue.push_front(std::move(task));
+            }
+            else
+            {
+                task_queue.push_back(std::move(task));
+            }
             return true;
         }
         else
@@ -2381,11 +2396,12 @@ bool LocalCcShards::EnqueueRangeDataSyncTask(
             if (can_be_skipped)
             {
                 assert(hres == nullptr);
+                assert(!high_priority);
                 // '0' means have no pending task on queue.
                 if (iter->second->latest_pending_task_ts_ == 0)
                 {
                     iter->second->latest_pending_task_ts_ = data_sync_ts;
-                    iter->second->pending_tasks_.push(
+                    iter->second->pending_tasks_.push_back(
                         std::make_shared<DataSyncTask>(
                             table_name,
                             range_info->PartitionId(),
@@ -2414,7 +2430,7 @@ bool LocalCcShards::EnqueueRangeDataSyncTask(
                 // This task can't be skipped(DataMigration, CraeteIndex,
                 // LastCheckpoint). So we push this task to the pending task
                 // queue of `Limiter`
-                iter->second->pending_tasks_.push(
+                auto task =
                     std::make_shared<DataSyncTask>(table_name,
                                                    range_info->PartitionId(),
                                                    range_info->VersionTs(),
@@ -2424,7 +2440,19 @@ bool LocalCcShards::EnqueueRangeDataSyncTask(
                                                    status,
                                                    is_dirty,
                                                    can_be_skipped,
-                                                   hres));
+                                                   hres,
+                                                   nullptr,
+                                                   false,
+                                                   false,
+                                                   high_priority);
+                if (high_priority)
+                {
+                    iter->second->pending_tasks_.push_front(std::move(task));
+                }
+                else
+                {
+                    iter->second->pending_tasks_.push_back(std::move(task));
+                }
                 return true;
             }
         }
@@ -2631,7 +2659,7 @@ bool LocalCcShards::EnqueueDataSyncTaskToCore(
             if (iter->second->latest_pending_task_ts_ == 0)
             {
                 iter->second->latest_pending_task_ts_ = data_sync_ts;
-                iter->second->pending_tasks_.push(
+                iter->second->pending_tasks_.push_back(
                     std::make_shared<DataSyncTask>(table_name,
                                                    core_idx,
                                                    0,
@@ -2662,7 +2690,7 @@ bool LocalCcShards::EnqueueDataSyncTaskToCore(
             // LastCheckpoint). Because these operations need to explicitly
             // flush data into storage, rather than relying on other
             // checkpoint tasks.
-            iter->second->pending_tasks_.push(
+            iter->second->pending_tasks_.push_back(
                 std::make_shared<DataSyncTask>(table_name,
                                                core_idx,
                                                0,
@@ -5112,12 +5140,20 @@ void LocalCcShards::PopPendingTask(NodeGroupId ng_id,
     {
         std::shared_ptr<DataSyncTask> task =
             iter->second->pending_tasks_.front();
-        iter->second->pending_tasks_.pop();
+        iter->second->pending_tasks_.pop_front();
         task_limiter_lk.unlock();
 
         std::lock_guard<std::mutex> task_worker_lk(data_sync_worker_ctx_.mux_);
-        data_sync_task_queue_[id % data_sync_task_queue_.size()].push_back(
-            std::move(task));
+        auto &task_queue =
+            data_sync_task_queue_[id % data_sync_task_queue_.size()];
+        if (task->high_priority_)
+        {
+            task_queue.push_front(std::move(task));
+        }
+        else
+        {
+            task_queue.push_back(std::move(task));
+        }
         data_sync_worker_ctx_.cv_.notify_all();
     }
     else
@@ -5149,7 +5185,7 @@ void LocalCcShards::ClearAllPendingTasks(NodeGroupId ng_id,
         auto &task = iter->second->pending_tasks_.front();
         task->SetError(CcErrorCode::REQUESTED_TABLE_NOT_EXISTS);
         task->SetScanTaskFinished();
-        iter->second->pending_tasks_.pop();
+        iter->second->pending_tasks_.pop_front();
     }
 
     task_limiters_.erase(iter);

--- a/tx_service/src/data_sync_task.cpp
+++ b/tx_service/src/data_sync_task.cpp
@@ -79,7 +79,8 @@ DataSyncTask::DataSyncTask(const TableName &table_name,
       range_entry_(range_entry),
       during_split_range_(true),
       export_base_table_items_(export_base_table_items),
-      tx_number_(txn)
+      tx_number_(txn),
+      high_priority_(false)
 {
     assert(!table_name_.IsHashPartitioned());
     if (start_key_.KeyPtr() ==


### PR DESCRIPTION
When a range size exceeds a threshold, construct a high-priority `DataSync` task for range splitting. Note: This task is mutually exclusive with the `Datasync` task constructed by the checkpoint worker.