### PR TITLE
Add  judgement of `bind_data_shard_with_ng_` in functions of `DataStoreServiceClient`

### DIFF
--- a/store_handler/data_store_service_client.cpp
+++ b/store_handler/data_store_service_client.cpp
@@ -3836,6 +3836,11 @@ bool DataStoreServiceClient::OnSnapshotReceived(
     const txservice::remote::OnSnapshotSyncedRequest *req)
 {
 #ifdef DATA_STORE_TYPE_ELOQDSS_ELOQSTORE
+    if (!bind_data_shard_with_ng_)
+    {
+        return true;
+    }
+
     if (data_store_service_ != nullptr)
     {
         uint32_t ng_id = req->ng_id();
@@ -3862,6 +3867,11 @@ bool DataStoreServiceClient::OnUpdateStandbyCkptTs(uint32_t ng_id,
                                                    int64_t ng_term)
 {
 #ifdef DATA_STORE_TYPE_ELOQDSS_ELOQSTORE
+    if (!bind_data_shard_with_ng_)
+    {
+        return true;
+    }
+
     if (data_store_service_ != nullptr)
     {
         data_store_service_->OnUpdateStandbyCkptTs(ng_id, ng_term);

--- a/store_handler/data_store_service_client.h
+++ b/store_handler/data_store_service_client.h
@@ -194,7 +194,7 @@ public:
 
     bool IsSharedStorage() const override
     {
-        if (data_store_service_ != nullptr)
+        if (bind_data_shard_with_ng_ && data_store_service_ != nullptr)
         {
             return data_store_service_->IsCloudMode();
         }

--- a/store_handler/eloq_data_store_service/eloq_store_data_store.cpp
+++ b/store_handler/eloq_data_store_service/eloq_store_data_store.cpp
@@ -879,7 +879,6 @@ void EloqStoreDataStore::OnFloor(::eloqstore::KvRequest *req)
 
 void EloqStoreDataStore::ReloadDataFromCloud(int64_t term)
 {
-    // TODO(lzx): implement this for eloqstore data store.
     LOG(INFO) << "EloqStoreDataStore::ReloadDataFromCloud, term: " << term;
     if (eloq_store_service_->Term() != static_cast<uint64_t>(term))
     {


### PR DESCRIPTION
…ceClient

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Reference the link of issue using `fixes eloqdb/tx_service#issue_id`
- [ ] Reference the link of RFC if exists
- [ ] Pass `./mtr --suite=mono_main,mono_multi,mono_basic`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed data store operations to properly validate binding state before proceeding.
  * Improved cloud mode detection logic to ensure appropriate data store integration.

* **Chores**
  * Removed obsolete development notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->