### PR TITLE
Range sizes definition

### DIFF
--- a/tx_service/include/cc/cc_map.h
+++ b/tx_service/include/cc/cc_map.h
@@ -21,10 +21,12 @@
  */
 #pragma once
 
+#include <cstdint>
 #include <map>
 #include <memory>
 #include <utility>  // std::pair
 
+#include "absl/container/flat_hash_map.h"
 #include "cc/cc_req_base.h"
 #include "cc_protocol.h"
 #include "error_messages.h"  // CcErrorCode
@@ -260,6 +262,20 @@ public:
     virtual const txservice::KeySchema *KeySchema() const = 0;
     virtual const txservice::RecordSchema *RecordSchema() const = 0;
 
+    /**
+     * Called by FetchTableRangeSizeCc::Execute when async load completes.
+     * Merges loaded size with accumulated delta (second), or resets to
+     * kNotInitialized on failure.
+     * When emplace is true and partition_id is absent, inserts (partition_id,
+     * (0,0)) before merging; used for new ranges after split.
+     */
+    bool InitRangeSize(uint32_t partition_id,
+                       int32_t persisted_size,
+                       bool succeed = true,
+                       bool emplace = false);
+
+    void ResetRangeStatus(uint32_t partition_id);
+
     uint64_t SchemaTs() const
     {
         return schema_ts_;
@@ -294,6 +310,15 @@ public:
     uint64_t last_dirty_commit_ts_{0};
 
 protected:
+    // Range id -> (range_size, delta_range_size). Only used when
+    // RangePartitioned.
+    // - first: current range size; RangeSizeState::Loading (-1) = loading from
+    //   store; RangeSizeState::Uninitialized (-2) = not yet loaded.
+    // - second: delta accumulated during load (first==-1) or split (first>=0).
+    // - third: True if a split task been triggered due to reaching a threshold.
+    absl::flat_hash_map<uint32_t, std::tuple<int32_t, int32_t, bool>>
+        range_sizes_;
+
     /**
      * @brief After the input request is executed at the current shard, moves
      * the request to another shard for execution.

--- a/tx_service/include/cc/template_cc_map.h
+++ b/tx_service/include/cc/template_cc_map.h
@@ -38,6 +38,7 @@
 #include <variant>
 #include <vector>
 
+#include "absl/container/flat_hash_map.h"
 #include "cc_entry.h"
 #include "cc_map.h"
 #include "cc_page_clean_guard.h"
@@ -8771,6 +8772,10 @@ public:
         }
 
         normal_obj_sz_ = 0;
+        if constexpr (RangePartitioned)
+        {
+            range_sizes_.clear();
+        }
         ccmp_.clear();
     }
 
@@ -11912,6 +11917,74 @@ protected:
     CcPage<KeyT, ValueT, VersionedRecord, RangePartitioned> *PagePosInf()
     {
         return &pos_inf_page_;
+    }
+
+    bool UpdateRangeSize(uint32_t partition_id,
+                         int32_t delta_size,
+                         bool is_dirty)
+    {
+        if constexpr (RangePartitioned)
+        {
+            auto it = range_sizes_.find(partition_id);
+            if (it == range_sizes_.end())
+            {
+                it = range_sizes_
+                         .emplace(partition_id,
+                                  std::make_tuple(
+                                      static_cast<int32_t>(
+                                          RangeSizeStatus::kNotInitialized),
+                                      0,
+                                      false))
+                         .first;
+            }
+            if (std::get<0>(it->second) ==
+                    static_cast<int32_t>(RangeSizeStatus::kNotInitialized) &&
+                !is_dirty)
+            {
+                std::get<1>(it->second) += delta_size;
+                // Init the range size of this range.
+                std::get<0>(it->second) =
+                    static_cast<int32_t>(RangeSizeStatus::kLoading);
+
+                int64_t ng_term = Sharder::Instance().LeaderTerm(cc_ng_id_);
+                shard_->FetchTableRangeSize(table_name_,
+                                            static_cast<int32_t>(partition_id),
+                                            cc_ng_id_,
+                                            ng_term);
+                return false;
+            }
+
+            if (std::get<0>(it->second) ==
+                    static_cast<int32_t>(RangeSizeStatus::kLoading) ||
+                is_dirty)
+            {
+                // Loading or split: record delta in delta part (.second).
+                std::get<1>(it->second) += delta_size;
+            }
+            else
+            {
+                int32_t new_range_size = std::get<0>(it->second) + delta_size;
+                std::get<0>(it->second) =
+                    new_range_size > 0 ? new_range_size : 0;
+
+                bool trigger_split =
+                    !is_dirty && !std::get<2>(it->second) &&
+                    std::get<0>(it->second) >=
+                        static_cast<int32_t>(StoreRange::range_max_size);
+
+                DLOG_IF(INFO, trigger_split)
+                    << "Range size is too large, need to split. table: "
+                    << table_name_.StringView()
+                    << " partition: " << partition_id
+                    << " range size: " << std::get<0>(it->second)
+                    << " range max size: " << StoreRange::range_max_size;
+                std::get<2>(it->second) =
+                    trigger_split == true ? true : std::get<2>(it->second);
+                return trigger_split;
+            }
+        }  // RangePartitioned
+
+        return false;
     }
 
     absl::btree_map<

--- a/tx_service/include/type.h
+++ b/tx_service/include/type.h
@@ -167,6 +167,13 @@ enum class TableEngine : uint8_t
     InternalHash = 5,  // eg. Sequence table is a kind of internal hash table.
 };
 
+// Status values for range_sizes_.first (range size not yet known).
+enum RangeSizeStatus : int32_t
+{
+    kNotInitialized = -2,  // Range size not yet initialized; need to fetch.
+    kLoading = -1,         // Range size is being loaded; delta goes to .second.
+};
+
 inline std::string KvTablePrefixOf(TableEngine engine)
 {
     switch (engine)

--- a/tx_service/src/cc/cc_map.cpp
+++ b/tx_service/src/cc/cc_map.cpp
@@ -27,6 +27,7 @@
 #include "cc/local_cc_shards.h"
 #include "cc_entry.h"
 #include "tx_trace.h"
+#include "type.h"
 
 namespace txservice
 {
@@ -459,6 +460,59 @@ void CcMap::DecrReadIntent(NonBlockingLock *lock,
         shard_->DeleteLockHoldingTx(tx_number, cce, ng_id);
         cce->RecycleKeyLock(*shard_);
     }
+}
+
+bool CcMap::InitRangeSize(uint32_t partition_id,
+                          int32_t persisted_size,
+                          bool succeed,
+                          bool emplace)
+{
+    auto it = range_sizes_.find(partition_id);
+    if (it == range_sizes_.end())
+    {
+        if (!emplace)
+        {
+            return false;
+        }
+        it = range_sizes_.emplace(partition_id, std::make_tuple(0, 0, false))
+                 .first;
+    }
+
+    if (succeed)
+    {
+        int32_t final_size = persisted_size + std::get<1>(it->second);
+        std::get<0>(it->second) = final_size < 0 ? 0 : final_size;
+        std::get<1>(it->second) = 0;
+
+        bool trigger_split =
+            !std::get<2>(it->second) &&
+            std::get<0>(it->second) >=
+                static_cast<int32_t>(StoreRange::range_max_size);
+        std::get<2>(it->second) =
+            trigger_split == true ? true : std::get<2>(it->second);
+        return trigger_split;
+    }
+    else
+    {
+        // Load range size failed; reset to not-initialized for retry.
+        std::get<0>(it->second) =
+            static_cast<int32_t>(RangeSizeStatus::kNotInitialized);
+    }
+    return false;
+}
+
+void CcMap::ResetRangeStatus(uint32_t partition_id)
+{
+    auto it = range_sizes_.find(partition_id);
+    if (it == range_sizes_.end())
+    {
+        return;
+    }
+    std::get<2>(it->second) = false;
+
+    DLOG(INFO) << "ResetRangeStatus: table: " << table_name_.StringView()
+               << " partition: " << partition_id
+               << " status: " << std::boolalpha << std::get<2>(it->second);
 }
 
 }  // namespace txservice


### PR DESCRIPTION
In order to trigger range splits in a timely manner, the range size is tracked in memory.

Init range sizes interface
Update range size interface
Reset range splitting status interface


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic per-range size tracking with on-demand lazy loading for partitioned data
  * Range split decisions triggered when partitions exceed configured size thresholds
  * Ability to initialize or reset range status to control retry/loading behavior

* **Documentation**
  * Added usage notes for range initialization and reset behaviors
<!-- end of auto-generated comment: release notes by coderabbit.ai -->