### PR TITLE
Update store range size after datasync

### DIFF
--- a/store_handler/bigtable_handler.cpp
+++ b/store_handler/bigtable_handler.cpp
@@ -710,6 +710,13 @@ void EloqDS::BigTableHandler::FetchRangeSlices(
                      fetch_cc));
 }
 
+void EloqDS::BigTableHandler::FetchTableRangeSize(
+    txservice::FetchTableRangeSizeCc *fetch_cc)
+{
+    LOG(ERROR) << "BigTableHandler::FetchTableRangeSize not implemented";
+    assert(false);
+}
+
 void EloqDS::BigTableHandler::OnFetchRangeSlices(
     google::cloud::future<google::cloud::StatusOr<
         std::pair<bool, google::cloud::bigtable::Row>>> f,

--- a/store_handler/bigtable_handler.h
+++ b/store_handler/bigtable_handler.h
@@ -82,6 +82,9 @@ public:
 
     void FetchRangeSlices(txservice::FetchRangeSlicesReq *fetch_cc) override;
 
+    void FetchTableRangeSize(
+        txservice::FetchTableRangeSizeCc *fetch_cc) override;
+
     /**
      * @brief Read a row from base table or skindex table in datastore with
      * specified key. Caller should pass in complete primary key or skindex key.

--- a/store_handler/data_store_service_client.cpp
+++ b/store_handler/data_store_service_client.cpp
@@ -1038,6 +1038,30 @@ void DataStoreServiceClient::FetchRangeSlices(
          &FetchRangeSlicesCallback);
 }
 
+void DataStoreServiceClient::FetchTableRangeSize(
+    txservice::FetchTableRangeSizeCc *fetch_cc)
+{
+    txservice::TableName range_table_name(fetch_cc->table_name_->StringView(),
+                                          txservice::TableType::RangePartition,
+                                          fetch_cc->table_name_->Engine());
+
+    int32_t kv_partition_id =
+        KvPartitionIdOfRangeSlices(range_table_name, fetch_cc->partition_id_);
+    uint32_t shard_id = GetShardIdByPartitionId(kv_partition_id, false);
+
+    auto catalog_factory = GetCatalogFactory(range_table_name.Engine());
+    assert(catalog_factory != nullptr);
+    fetch_cc->kv_start_key_ =
+        EncodeRangeKey(catalog_factory, range_table_name, fetch_cc->start_key_);
+
+    Read(kv_range_table_name,
+         kv_partition_id,
+         shard_id,
+         fetch_cc->kv_start_key_,
+         fetch_cc,
+         &FetchRangeSizeCallback);
+}
+
 /**
  * @brief Deletes data that is out of the specified range.
  *
@@ -1254,16 +1278,19 @@ std::string DataStoreServiceClient::EncodeRangeKey(
  * @param range_version The version of the range.
  * @param version The general version number.
  * @param segment_cnt The number of segments in the range.
+ * @param range_size The size of the range.
  * @return Binary string containing the encoded range value.
  */
 std::string DataStoreServiceClient::EncodeRangeValue(int32_t range_id,
                                                      uint64_t range_version,
                                                      uint64_t version,
-                                                     uint32_t segment_cnt)
+                                                     uint32_t segment_cnt,
+                                                     int32_t range_size)
 {
     std::string kv_range_record;
     kv_range_record.reserve(sizeof(int32_t) + sizeof(uint64_t) +
-                            sizeof(uint64_t) + sizeof(uint32_t));
+                            sizeof(uint64_t) + sizeof(uint32_t) +
+                            sizeof(int32_t));
     kv_range_record.append(reinterpret_cast<const char *>(&range_id),
                            sizeof(int32_t));
     kv_range_record.append(reinterpret_cast<const char *>(&range_version),
@@ -1273,6 +1300,8 @@ std::string DataStoreServiceClient::EncodeRangeValue(int32_t range_id,
     // segment_cnt of slices
     kv_range_record.append(reinterpret_cast<const char *>(&segment_cnt),
                            sizeof(uint32_t));
+    kv_range_record.append(reinterpret_cast<const char *>(&range_size),
+                           sizeof(int32_t));
     return kv_range_record;
 }
 
@@ -1340,6 +1369,7 @@ RangeSliceBatchPlan DataStoreServiceClient::PrepareRangeSliceBatches(
     RangeSliceBatchPlan plan;
     plan.segment_cnt = 0;
     plan.version = version;
+    plan.range_size = 0;
 
     // Estimate capacity based on slices size
     plan.segment_keys.reserve(slices.size() / 10 + 1);  // Rough estimate
@@ -1388,6 +1418,7 @@ RangeSliceBatchPlan DataStoreServiceClient::PrepareRangeSliceBatches(
                               sizeof(uint32_t));
         segment_record.append(slice_start_key.Data(), key_size);
         uint32_t slice_size = static_cast<uint32_t>(slices[i]->Size());
+        plan.range_size += static_cast<int32_t>(slice_size);
         segment_record.append(reinterpret_cast<const char *>(&slice_size),
                               sizeof(uint32_t));
     }
@@ -1553,6 +1584,7 @@ void DataStoreServiceClient::EnqueueRangeMetadataRecord(
     uint64_t range_version,
     uint64_t version,
     uint32_t segment_cnt,
+    int32_t range_size,
     RangeMetadataAccumulator &accumulator)
 {
     // Compute kv_table_name and kv_partition_id
@@ -1563,8 +1595,8 @@ void DataStoreServiceClient::EnqueueRangeMetadataRecord(
     // Encode key and value
     std::string key_str =
         EncodeRangeKey(catalog_factory, table_name, range_start_key);
-    std::string rec_str =
-        EncodeRangeValue(partition_id, range_version, version, segment_cnt);
+    std::string rec_str = EncodeRangeValue(
+        partition_id, range_version, version, segment_cnt, range_size);
 
     // Get or create entry in accumulator
     auto key = std::make_pair(kv_table_name, kv_partition_id);
@@ -1732,6 +1764,7 @@ bool DataStoreServiceClient::UpdateRangeSlices(
                                                    req.range_slices_,
                                                    req.partition_id_);
         uint32_t segment_cnt = slice_plan.segment_cnt;
+        int32_t range_size = slice_plan.range_size;
         int32_t kv_partition_id =
             KvPartitionIdOfRangeSlices(*req.table_name_, req.partition_id_);
         auto iter = slice_plans.find(kv_partition_id);
@@ -1756,6 +1789,7 @@ bool DataStoreServiceClient::UpdateRangeSlices(
                                    req.range_version_,
                                    req.ckpt_ts_,
                                    segment_cnt,
+                                   range_size,
                                    meta_acc);
     }
 
@@ -1957,6 +1991,7 @@ bool DataStoreServiceClient::UpdateRangeSlices(
                                range_version,
                                version,
                                segment_cnt,
+                               slice_plans[0].range_size,
                                meta_acc);
 
     SyncConcurrentRequest *meta_sync_concurrent =
@@ -2048,6 +2083,7 @@ bool DataStoreServiceClient::UpsertRanges(
         auto slice_plan = PrepareRangeSliceBatches(
             table_name, version, range.slices_, range.partition_id_);
         uint32_t segment_cnt = slice_plan.segment_cnt;
+        int32_t range_size = slice_plan.range_size;
 
         int32_t kv_partition_id =
             KvPartitionIdOfRangeSlices(table_name, range.partition_id_);
@@ -2071,6 +2107,7 @@ bool DataStoreServiceClient::UpsertRanges(
             version,  // range_version (using version for now)
             version,
             segment_cnt,
+            range_size,
             meta_acc);
     }
 
@@ -4651,7 +4688,8 @@ bool DataStoreServiceClient::InitTableRanges(
 
     std::string key_str =
         EncodeRangeKey(catalog_factory, table_name, *neg_inf_key);
-    std::string rec_str = EncodeRangeValue(init_range_id, version, version, 0);
+    std::string rec_str =
+        EncodeRangeValue(init_range_id, version, version, 0, 0);
 
     keys.emplace_back(std::string_view(key_str.data(), key_str.size()));
     records.emplace_back(std::string_view(rec_str.data(), rec_str.size()));

--- a/store_handler/data_store_service_client.h
+++ b/store_handler/data_store_service_client.h
@@ -66,6 +66,7 @@ struct RangeSliceBatchPlan
     std::vector<std::string> segment_keys;     // Owned string buffers
     std::vector<std::string> segment_records;  // Owned string buffers
     size_t version;
+    int32_t range_size{0};
 
     // Clear method for reuse
     void Clear()
@@ -74,6 +75,7 @@ struct RangeSliceBatchPlan
         segment_keys.clear();
         segment_records.clear();
         version = 0;
+        range_size = 0;
     }
 };
 
@@ -271,6 +273,9 @@ public:
 
     void FetchRangeSlices(txservice::FetchRangeSlicesReq *fetch_cc) override;
 
+    void FetchTableRangeSize(
+        txservice::FetchTableRangeSizeCc *fetch_cc) override;
+
     bool DeleteOutOfRangeData(
         const txservice::TableName &table_name,
         int32_t partition_id,
@@ -339,7 +344,8 @@ public:
     std::string EncodeRangeValue(int32_t range_id,
                                  uint64_t range_version,
                                  uint64_t version,
-                                 uint32_t segment_cnt);
+                                 uint32_t segment_cnt,
+                                 int32_t range_size);
     std::string EncodeRangeSliceKey(const txservice::TableName &table_name,
                                     int32_t range_id,
                                     uint32_t segment_id);
@@ -642,6 +648,7 @@ private:
         uint64_t range_version,
         uint64_t version,
         uint32_t segment_cnt,
+        int32_t range_size,
         RangeMetadataAccumulator &accumulator);
 
     void DispatchRangeMetadataBatches(
@@ -922,6 +929,11 @@ private:
         ::google::protobuf::Closure *closure,
         DataStoreServiceClient &client,
         const remote::CommonResult &result);
+
+    friend void FetchRangeSizeCallback(void *data,
+                                       ::google::protobuf::Closure *closure,
+                                       DataStoreServiceClient &client,
+                                       const remote::CommonResult &result);
 };
 
 struct UpsertTableData

--- a/store_handler/data_store_service_client_closure.cpp
+++ b/store_handler/data_store_service_client_closure.cpp
@@ -793,8 +793,9 @@ void FetchTableRangesCallback(void *data,
         for (uint32_t i = 0; i < items_size; i++)
         {
             scan_next_closure->GetItem(i, key, value, ts, ttl);
-            assert(value.size() == (sizeof(int32_t) + sizeof(uint64_t) +
-                                    sizeof(uint64_t) + sizeof(uint32_t)));
+            assert(value.size() ==
+                   (sizeof(int32_t) + sizeof(uint64_t) + sizeof(uint64_t) +
+                    sizeof(uint32_t) + sizeof(int32_t)));
             const char *buf = value.data();
             int32_t partition_id = *(reinterpret_cast<const int32_t *>(buf));
             buf += sizeof(partition_id);
@@ -926,6 +927,45 @@ void FetchTableRangesCallback(void *data,
     }
 }
 
+void FetchRangeSizeCallback(void *data,
+                            ::google::protobuf::Closure *closure,
+                            DataStoreServiceClient &client,
+                            const remote::CommonResult &result)
+{
+    txservice::FetchTableRangeSizeCc *fetch_range_size_cc =
+        static_cast<txservice::FetchTableRangeSizeCc *>(data);
+
+    if (result.error_code() == remote::DataStoreError::KEY_NOT_FOUND)
+    {
+        fetch_range_size_cc->store_range_size_ = 0;
+        fetch_range_size_cc->SetFinish(
+            static_cast<uint32_t>(txservice::CcErrorCode::NO_ERROR));
+    }
+    else if (result.error_code() != remote::DataStoreError::NO_ERROR)
+    {
+        LOG(ERROR) << "Fetch range size failed with error code: "
+                   << result.error_code();
+        fetch_range_size_cc->SetFinish(
+            static_cast<uint32_t>(txservice::CcErrorCode::DATA_STORE_ERR));
+    }
+    else
+    {
+        ReadClosure *read_closure = static_cast<ReadClosure *>(closure);
+        std::string_view read_val = read_closure->Value();
+        assert(read_closure->TableName() == kv_range_table_name);
+        assert(read_val.size() ==
+               (sizeof(int32_t) + sizeof(uint64_t) + sizeof(uint64_t) +
+                sizeof(uint32_t) + sizeof(int32_t)));
+        const char *buf = read_val.data();
+        buf += read_val.size() - sizeof(int32_t);
+        fetch_range_size_cc->store_range_size_ =
+            *reinterpret_cast<const int32_t *>(buf);
+
+        fetch_range_size_cc->SetFinish(
+            static_cast<uint32_t>(txservice::CcErrorCode::NO_ERROR));
+    }
+}
+
 void FetchRangeSlicesCallback(void *data,
                               ::google::protobuf::Closure *closure,
                               DataStoreServiceClient &client,
@@ -966,8 +1006,9 @@ void FetchRangeSlicesCallback(void *data,
         else
         {
             assert(read_closure->TableName() == kv_range_table_name);
-            assert(read_val.size() == (sizeof(int32_t) + sizeof(uint64_t) +
-                                       sizeof(uint64_t) + sizeof(uint32_t)));
+            assert(read_val.size() ==
+                   (sizeof(int32_t) + sizeof(uint64_t) + sizeof(uint64_t) +
+                    sizeof(uint32_t) + sizeof(int32_t)));
             const char *buf = read_val.data();
             int32_t range_partition_id =
                 *(reinterpret_cast<const int32_t *>(buf));

--- a/store_handler/data_store_service_client_closure.h
+++ b/store_handler/data_store_service_client_closure.h
@@ -3103,6 +3103,14 @@ void FetchTableRangesCallback(void *data,
                               const remote::CommonResult &result);
 
 /**
+ * Callback for fetching range size from table_ranges.
+ */
+void FetchRangeSizeCallback(void *data,
+                            ::google::protobuf::Closure *closure,
+                            DataStoreServiceClient &client,
+                            const remote::CommonResult &result);
+
+/**
  * Callback for fetching range slices.
  *
  * Handles the completion of range slice fetch operations and processes the

--- a/store_handler/dynamo_handler.cpp
+++ b/store_handler/dynamo_handler.cpp
@@ -2534,6 +2534,12 @@ void EloqDS::DynamoHandler::FetchRangeSlices(FetchRangeSlicesReq *fetch_cc)
     assert(false);
 }
 
+void EloqDS::DynamoHandler::FetchTableRangeSize(FetchTableRangeSizeCc *fetch_cc)
+{
+    LOG(ERROR) << "DynamoHandler::FetchTableRangeSize not implemented";
+    assert(false);
+}
+
 void EloqDS::DynamoHandler::OnFetchRangeSlices(
     const Aws::DynamoDB::DynamoDBClient *client,
     const Aws::DynamoDB::Model::GetItemRequest &request,

--- a/store_handler/dynamo_handler.h
+++ b/store_handler/dynamo_handler.h
@@ -158,6 +158,7 @@ public:
     //-- range partition
     void FetchTableRanges(FetchTableRangesCc *fetch_cc) override;
     void FetchRangeSlices(FetchRangeSlicesReq *fetch_cc) override;
+    void FetchTableRangeSize(FetchTableRangeSizeCc *fetch_cc) override;
 
     bool DeleteOutOfRangeData(
         const txservice::TableName &table_name,

--- a/store_handler/rocksdb_handler.cpp
+++ b/store_handler/rocksdb_handler.cpp
@@ -1128,6 +1128,13 @@ void RocksDBHandler::FetchRangeSlices(txservice::FetchRangeSlicesReq *fetch_cc)
     assert(false);
 }
 
+void RocksDBHandler::FetchTableRangeSize(
+    txservice::FetchTableRangeSizeCc *fetch_cc)
+{
+    LOG(ERROR) << "RocksDBHandler::FetchTableRangeSize not implemented";
+    assert(false);
+}
+
 bool DeleteOutOfRangeDataInternal(std::string delete_from_partition_sql,
                                   int32_t partition_id,
                                   const txservice::TxKey *start_k)

--- a/store_handler/rocksdb_handler.h
+++ b/store_handler/rocksdb_handler.h
@@ -346,6 +346,9 @@ public:
 
     void FetchRangeSlices(txservice::FetchRangeSlicesReq *fetch_cc) override;
 
+    void FetchTableRangeSize(
+        txservice::FetchTableRangeSizeCc *fetch_cc) override;
+
     bool DeleteOutOfRangeDataInternal(std::string delete_from_partition_sql,
                                       int32_t partition_id,
                                       const txservice::TxKey *start_k);

--- a/tx_service/include/cc/cc_req_misc.h
+++ b/tx_service/include/cc/cc_req_misc.h
@@ -1148,4 +1148,35 @@ public:
 private:
     size_t free_count_{0};
 };
+
+struct FetchTableRangeSizeCc : public CcRequestBase
+{
+public:
+    FetchTableRangeSizeCc() = default;
+    ~FetchTableRangeSizeCc() = default;
+
+    void Reset(const TableName &table_name,
+               int32_t partition_id,
+               const TxKey &start_key,
+               CcShard *ccs,
+               NodeGroupId ng_id,
+               int64_t ng_term);
+
+    bool ValidTermCheck();
+    bool Execute(CcShard &ccs) override;
+    void SetFinish(uint32_t error);
+
+    const TableName *table_name_;
+    int32_t partition_id_{0};
+    TxKey start_key_{};
+    NodeGroupId node_group_id_{0};
+    int64_t node_group_term_{-1};
+    CcShard *ccs_{nullptr};
+
+    uint32_t error_code_{0};
+    int32_t store_range_size_{0};
+
+    // Only used in DataStoreHandler
+    std::string kv_start_key_;
+};
 }  // namespace txservice

--- a/tx_service/include/cc/cc_shard.h
+++ b/tx_service/include/cc/cc_shard.h
@@ -315,6 +315,11 @@ public:
      */
     CcMap *GetCcm(const TableName &table_name, uint32_t node_group);
 
+    void FetchTableRangeSize(const TableName &table_name,
+                             int32_t partition_id,
+                             NodeGroupId cc_ng_id,
+                             int64_t cc_ng_term);
+
     void AdjustDataKeyStats(const TableName &table_name,
                             int64_t size_delta,
                             int64_t dirty_delta);
@@ -1222,6 +1227,7 @@ private:
 
     CcRequestPool<FillStoreSliceCc> fill_store_slice_cc_pool_;
     CcRequestPool<InitKeyCacheCc> init_key_cache_cc_pool_;
+    CcRequestPool<FetchTableRangeSizeCc> fetch_range_size_cc_pool_;
 
     // CcRequest queue on this shard/core.
     moodycamel::ConcurrentQueue<CcRequestBase *> cc_queue_;

--- a/tx_service/include/store/data_store_handler.h
+++ b/tx_service/include/store/data_store_handler.h
@@ -134,6 +134,8 @@ public:
 
     virtual void FetchRangeSlices(FetchRangeSlicesReq *fetch_cc) = 0;
 
+    virtual void FetchTableRangeSize(FetchTableRangeSizeCc *fetch_cc) = 0;
+
     /**
      * @brief Read a row from base table or skindex table in datastore with
      * specified key. Caller should pass in complete primary key or skindex key.

--- a/tx_service/src/cc/cc_req_misc.cpp
+++ b/tx_service/src/cc/cc_req_misc.cpp
@@ -1536,4 +1536,59 @@ bool ShardCleanCc::Execute(CcShard &ccs)
     }
 }
 
+void FetchTableRangeSizeCc::Reset(const TableName &table_name,
+                                  int32_t partition_id,
+                                  const TxKey &start_key,
+                                  CcShard *ccs,
+                                  NodeGroupId ng_id,
+                                  int64_t ng_term)
+{
+    table_name_ = &table_name;
+    partition_id_ = partition_id;
+    start_key_ = start_key.GetShallowCopy();
+    node_group_id_ = ng_id;
+    node_group_term_ = ng_term;
+    ccs_ = ccs;
+    error_code_ = 0;
+    store_range_size_ = 0;
+}
+
+bool FetchTableRangeSizeCc::ValidTermCheck()
+{
+    int64_t ng_leader_term = Sharder::Instance().LeaderTerm(node_group_id_);
+    return ng_leader_term == node_group_term_;
+}
+
+bool FetchTableRangeSizeCc::Execute(CcShard &ccs)
+{
+    if (!ValidTermCheck())
+    {
+        error_code_ = static_cast<uint32_t>(CcErrorCode::NG_TERM_CHANGED);
+    }
+
+    bool succ = (error_code_ == 0);
+    CcMap *ccm = ccs.GetCcm(*table_name_, node_group_id_);
+    assert(ccm != nullptr);
+    bool need_split = ccm->InitRangeSize(
+        static_cast<uint32_t>(partition_id_), store_range_size_, succ);
+
+    if (need_split)
+    {
+        uint64_t data_sync_ts = ccs.local_shards_.ClockTs();
+        ccs.CreateSplitRangeDataSyncTask(*table_name_,
+                                         node_group_id_,
+                                         node_group_term_,
+                                         partition_id_,
+                                         data_sync_ts);
+    }
+
+    return true;
+}
+
+void FetchTableRangeSizeCc::SetFinish(uint32_t error)
+{
+    error_code_ = error;
+    ccs_->Enqueue(this);
+}
+
 }  // namespace txservice

--- a/tx_service/src/cc/cc_shard.cpp
+++ b/tx_service/src/cc/cc_shard.cpp
@@ -398,6 +398,26 @@ CcMap *CcShard::GetCcm(const TableName &table_name, uint32_t node_group)
     }
 }
 
+void CcShard::FetchTableRangeSize(const TableName &table_name,
+                                  int32_t partition_id,
+                                  NodeGroupId cc_ng_id,
+                                  int64_t cc_ng_term)
+{
+    FetchTableRangeSizeCc *fetch_cc = fetch_range_size_cc_pool_.NextRequest();
+
+    const TableName range_table_name(table_name.StringView(),
+                                     TableType::RangePartition,
+                                     table_name.Engine());
+    const TableRangeEntry *range_entry =
+        GetTableRangeEntry(range_table_name, cc_ng_id, partition_id);
+    assert(range_entry != nullptr);
+    TxKey start_key = range_entry->GetRangeInfo()->StartTxKey();
+
+    fetch_cc->Reset(
+        table_name, partition_id, start_key, this, cc_ng_id, cc_ng_term);
+    local_shards_.store_hd_->FetchTableRangeSize(fetch_cc);
+}
+
 void CcShard::AdjustDataKeyStats(const TableName &table_name,
                                  int64_t size_delta,
                                  int64_t dirty_delta)


### PR DESCRIPTION
1. Update load range size
After a successful flush, the store range size is persisted.

2. Load range size from storage
When accessing the memory range size, if it has not yet been initialized, a fetch operation from storage is performed to retrieve the range size.
