### PR TITLE
Maintaining range size on postwritecc

### DIFF
--- a/tx_service/include/cc/cc_handler.h
+++ b/tx_service/include/cc/cc_handler.h
@@ -166,7 +166,9 @@ public:
                                   const TxRecord *record,
                                   OperationType operation_type,
                                   uint32_t key_shard_code,
-                                  CcHandlerResult<PostProcessResult> &hres) = 0;
+                                  CcHandlerResult<PostProcessResult> &hres,
+                                  int32_t partition_id = -1,
+                                  bool on_dirty_range = false) = 0;
 
     /**
      * @briefPost-processes a read/scan key. Post-processing clears the read

--- a/tx_service/include/cc/cc_request.h
+++ b/tx_service/include/cc/cc_request.h
@@ -740,7 +740,9 @@ public:
                const TxRecord *rec,
                OperationType operation_type,
                uint32_t key_shard_code,
-               CcHandlerResult<PostProcessResult> *res)
+               CcHandlerResult<PostProcessResult> *res,
+               int32_t partition_id = -1,
+               bool on_dirty_range = false)
     {
         TemplatedCcRequest<PostWriteCc, PostProcessResult>::Reset(
             nullptr, res, addr->NodeGroupId(), tx_number, tx_term);
@@ -754,6 +756,8 @@ public:
         is_remote_ = false;
         ccm_ = nullptr;
         is_initial_insert_ = false;
+        partition_id_ = partition_id;
+        on_dirty_range_ = on_dirty_range;
     }
 
     void Reset(const TxKey *key,
@@ -767,7 +771,9 @@ public:
                uint32_t key_shard_code,
                CcHandlerResult<PostProcessResult> *res,
                bool initial_insertion = false,
-               int64_t ng_term = INIT_TERM)
+               int64_t ng_term = INIT_TERM,
+               int32_t partition_id = -1,
+               bool on_dirty_range = false)
     {
         TemplatedCcRequest<PostWriteCc, PostProcessResult>::Reset(
             &table_name,
@@ -788,6 +794,8 @@ public:
         is_remote_ = false;
         ccm_ = nullptr;
         is_initial_insert_ = initial_insertion;
+        partition_id_ = partition_id;
+        on_dirty_range_ = on_dirty_range;
     }
 
     void Reset(const CcEntryAddr *addr,
@@ -797,7 +805,9 @@ public:
                const std::string *rec,
                OperationType operation_type,
                uint32_t key_shard_code,
-               CcHandlerResult<PostProcessResult> *res)
+               CcHandlerResult<PostProcessResult> *res,
+               int32_t partition_id = -1,
+               bool on_dirty_range = false)
     {
         TemplatedCcRequest<PostWriteCc, PostProcessResult>::Reset(
             nullptr, res, addr->NodeGroupId(), tx_number, tx_term);
@@ -811,6 +821,8 @@ public:
         is_remote_ = true;
         ccm_ = nullptr;
         is_initial_insert_ = false;
+        partition_id_ = partition_id;
+        on_dirty_range_ = on_dirty_range;
     }
 
     void Reset(const TableName *table_name,
@@ -824,7 +836,9 @@ public:
                uint32_t key_shard_code,
                CcHandlerResult<PostProcessResult> *res,
                bool initial_insertion = false,
-               int64_t ng_term = INIT_TERM)
+               int64_t ng_term = INIT_TERM,
+               int32_t partition_id = -1,
+               bool on_dirty_range = false)
     {
         TemplatedCcRequest<PostWriteCc, PostProcessResult>::Reset(
             table_name,
@@ -845,6 +859,8 @@ public:
         is_remote_ = true;
         ccm_ = nullptr;
         is_initial_insert_ = initial_insertion;
+        partition_id_ = partition_id;
+        on_dirty_range_ = on_dirty_range;
     }
 
     const CcEntryAddr *CceAddr() const
@@ -877,6 +893,11 @@ public:
         return key_shard_code_;
     }
 
+    int32_t PartitionId() const
+    {
+        return partition_id_;
+    }
+
     const void *Key() const
     {
         return is_remote_ ? nullptr : key_;
@@ -890,6 +911,16 @@ public:
     bool IsInitialInsert() const
     {
         return is_initial_insert_;
+    }
+
+    bool OnDirtyRange() const
+    {
+        return on_dirty_range_;
+    }
+
+    bool NeedUpdateRangeSize() const
+    {
+        return partition_id_ >= 0;
     }
 
 private:
@@ -909,6 +940,9 @@ private:
         const void *key_;
         const std::string *key_str_;
     };
+    int32_t partition_id_{-1};
+    // True if the key is located in a splitting range.
+    bool on_dirty_range_{false};
 };
 
 struct PostWriteAllCc

--- a/tx_service/include/cc/local_cc_handler.h
+++ b/tx_service/include/cc/local_cc_handler.h
@@ -103,7 +103,9 @@ public:
                           const TxRecord *record,
                           OperationType operation_type,
                           uint32_t key_shard_code,
-                          CcHandlerResult<PostProcessResult> &hres) override;
+                          CcHandlerResult<PostProcessResult> &hres,
+                          int32_t partition_id = -1,
+                          bool on_dirty_range = false) override;
 
     CcReqStatus PostRead(
         uint64_t tx_number,

--- a/tx_service/include/cc/template_cc_map.h
+++ b/tx_service/include/cc/template_cc_map.h
@@ -38,6 +38,7 @@
 #include <variant>
 #include <vector>
 
+#include "absl/container/flat_hash_map.h"
 #include "cc_entry.h"
 #include "cc_map.h"
 #include "cc_page_clean_guard.h"
@@ -591,6 +592,8 @@ public:
                     cce->ArchiveBeforeUpdate();
                 }
 
+                [[maybe_unused]] const size_t old_payload_size =
+                    cce->PayloadSize();
                 if (is_del)
                 {
                     cce->payload_.SetCurrentPayload(nullptr);
@@ -611,6 +614,42 @@ public:
                     is_del ? RecordStatus::Deleted : RecordStatus::Normal;
                 bool was_dirty = cce->IsDirty();
                 cce->SetCommitTsPayloadStatus(commit_ts, new_status);
+
+                if constexpr (RangePartitioned)
+                {
+                    if (req.NeedUpdateRangeSize())
+                    {
+                        const int64_t key_delta_size =
+                            (new_status == RecordStatus::Deleted)
+                                ? (-static_cast<int64_t>(write_key->Size() +
+                                                         old_payload_size))
+                                : (cce_old_status != RecordStatus::Normal
+                                       ? static_cast<int64_t>(
+                                             write_key->Size() +
+                                             cce->PayloadSize())
+                                       : static_cast<int64_t>(
+                                             cce->PayloadSize() -
+                                             old_payload_size));
+                        const uint32_t range_id = req.PartitionId();
+                        // is_dirty: true when range is splitting.
+                        bool need_split = UpdateRangeSize(
+                            range_id,
+                            static_cast<int32_t>(key_delta_size),
+                            req.OnDirtyRange());
+
+                        if (need_split)
+                        {
+                            assert(!req.OnDirtyRange());
+                            // Create a data sync task for the range.
+                            shard_->CreateSplitRangeDataSyncTask(
+                                table_name_,
+                                cc_ng_id_,
+                                cce_addr->Term(),
+                                range_id,
+                                commit_ts);
+                        }
+                    }
+                }
 
                 if (req.IsInitialInsert())
                 {

--- a/tx_service/include/proto/cc_request.proto
+++ b/tx_service/include/proto/cc_request.proto
@@ -176,6 +176,10 @@ message UploadBatchRequest
     bytes commit_ts = 9;
     bytes rec_status = 10;
     UploadBatchKind kind = 11;
+    // Target range partition;
+    int32 partition_id = 12;
+    // Per-key one byte: [uint8_t, ...]
+    bytes range_size_flags = 13;
 }
 
 message UploadBatchSlicesRequest
@@ -918,6 +922,8 @@ message PostCommitRequest {
     bytes record = 5;
     uint32 operation_type = 6;
     uint32 key_shard_code = 7;
+    int32 partition_id = 8;
+    bool on_dirty_range = 9;
 }
 
 message ForwardPostCommitRequest {

--- a/tx_service/include/read_write_entry.h
+++ b/tx_service/include/read_write_entry.h
@@ -49,17 +49,25 @@ struct WriteSetEntry
           op_(other.op_),
           cce_addr_(other.cce_addr_),
           key_shard_code_(other.key_shard_code_),
-          forward_addr_(std::move(other.forward_addr_))
+          partition_id_(other.partition_id_),
+          forward_addr_(std::move(other.forward_addr_)),
+          on_dirty_range_(other.on_dirty_range_)
     {
     }
 
     WriteSetEntry &operator=(WriteSetEntry &&other) noexcept
     {
+        if (this == &other)
+        {
+            return *this;
+        }
         rec_ = std::move(other.rec_);
         op_ = other.op_;
         cce_addr_ = other.cce_addr_;
         key_shard_code_ = other.key_shard_code_;
+        partition_id_ = other.partition_id_;
         forward_addr_ = std::move(other.forward_addr_);
+        on_dirty_range_ = other.on_dirty_range_;
 
         return *this;
     }
@@ -68,8 +76,11 @@ struct WriteSetEntry
     OperationType op_;
     CcEntryAddr cce_addr_;
     uint32_t key_shard_code_{};
+    int32_t partition_id_{-1};
     // Used in double write scenarios during online DDL.
-    std::unordered_map<uint32_t, CcEntryAddr> forward_addr_;
+    // key shard code -> (partition id, cce addr)
+    std::unordered_map<uint32_t, std::pair<int32_t, CcEntryAddr>> forward_addr_;
+    bool on_dirty_range_{false};
 };
 
 /**

--- a/tx_service/include/remote/remote_cc_handler.h
+++ b/tx_service/include/remote/remote_cc_handler.h
@@ -84,7 +84,9 @@ public:
                    const TxRecord *record,
                    OperationType operation_type,
                    uint32_t key_shard_code,
-                   CcHandlerResult<PostProcessResult> &hres);
+                   CcHandlerResult<PostProcessResult> &hres,
+                   int32_t partition_id = -1,
+                   bool on_dirty_range = false);
 
     void PostWriteAll(uint32_t src_node_id,
                       const TableName &table_name,

--- a/tx_service/src/cc/local_cc_handler.cpp
+++ b/tx_service/src/cc/local_cc_handler.cpp
@@ -274,7 +274,9 @@ txservice::CcReqStatus txservice::LocalCcHandler::PostWrite(
     const TxRecord *record,
     OperationType operation_type,
     uint32_t key_shard_code,
-    CcHandlerResult<PostProcessResult> &hres)
+    CcHandlerResult<PostProcessResult> &hres,
+    int32_t partition_id,
+    bool on_dirty_range)
 {
     uint32_t ng_id = cce_addr.NodeGroupId();
     uint32_t dest_node_id = Sharder::Instance().LeaderNodeId(ng_id);
@@ -293,7 +295,9 @@ txservice::CcReqStatus txservice::LocalCcHandler::PostWrite(
                    record,
                    operation_type,
                    key_shard_code,
-                   &hres);
+                   &hres,
+                   partition_id,
+                   on_dirty_range);
         TX_TRACE_ACTION(this, req);
         TX_TRACE_DUMP(req);
         cc_shards_.EnqueueCcRequest(thd_id_, cce_addr.CoreId(), req);
@@ -312,7 +316,9 @@ txservice::CcReqStatus txservice::LocalCcHandler::PostWrite(
                              record,
                              operation_type,
                              key_shard_code,
-                             hres);
+                             hres,
+                             partition_id,
+                             on_dirty_range);
     }
     return req_status;
 }

--- a/tx_service/src/remote/remote_cc_handler.cpp
+++ b/tx_service/src/remote/remote_cc_handler.cpp
@@ -159,7 +159,9 @@ void txservice::remote::RemoteCcHandler::PostWrite(
     const TxRecord *record,
     OperationType operation_type,
     uint32_t key_shard_code,
-    CcHandlerResult<PostProcessResult> &hres)
+    CcHandlerResult<PostProcessResult> &hres,
+    int32_t partition_id,
+    bool on_dirty_range)
 {
     CcMessage send_msg;
 
@@ -194,6 +196,8 @@ void txservice::remote::RemoteCcHandler::PostWrite(
     post_commit->set_commit_ts(commit_ts);
     post_commit->set_operation_type(static_cast<uint32_t>(operation_type));
     post_commit->set_key_shard_code(key_shard_code);
+    post_commit->set_partition_id(partition_id);
+    post_commit->set_on_dirty_range(on_dirty_range);
 
     stream_sender_.SendMessageToNg(cce_addr.NodeGroupId(), send_msg, &hres);
 }

--- a/tx_service/src/remote/remote_cc_request.cpp
+++ b/tx_service/src/remote/remote_cc_request.cpp
@@ -594,7 +594,9 @@ void txservice::remote::RemotePostWrite::Reset(
             rec_str,
             static_cast<OperationType>(post_commit.operation_type()),
             post_commit.key_shard_code(),
-            &cc_res_);
+            &cc_res_,
+            post_commit.partition_id(),
+            post_commit.on_dirty_range());
     }
     else
     {

--- a/tx_service/src/tx_execution.cpp
+++ b/tx_service/src/tx_execution.cpp
@@ -4611,12 +4611,17 @@ bool TransactionExecution::FillDataLogRequest(WriteToLogOp &write_log)
                 // ngs, write log for both ngs.
                 uint32_t forward_ng_id =
                     Sharder::Instance().ShardToCcNodeGroup(forward_shard_code);
-                auto table_rec_it = ng_table_set.try_emplace(forward_ng_id);
+                auto [table_rec_it, inserted] =
+                    ng_table_set.try_emplace(forward_ng_id);
+                if (!inserted)
+                {
+                    continue;
+                }
                 std::unordered_map<
                     TableName,
                     std::vector<
                         std::pair<const TxKey *, const WriteSetEntry *>>>
-                    &table_rec_set = table_rec_it.first->second.second;
+                    &table_rec_set = table_rec_it->second.second;
 
                 auto rec_vec_it = table_rec_set.emplace(
                     std::piecewise_construct,
@@ -5288,6 +5293,7 @@ void TransactionExecution::Process(PostProcessOp &post_process)
         {
             for (const auto &[key, write_entry] : pair.second)
             {
+                bool on_dirty_range = write_entry.on_dirty_range_;
                 CcReqStatus ret =
                     cc_handler_->PostWrite(tx_number,
                                            tx_term_,
@@ -5297,10 +5303,12 @@ void TransactionExecution::Process(PostProcessOp &post_process)
                                            write_entry.rec_.get(),
                                            write_entry.op_,
                                            write_entry.key_shard_code_,
-                                           post_process.hd_result_);
+                                           post_process.hd_result_,
+                                           write_entry.partition_id_,
+                                           on_dirty_range);
                 update_post_cnt(ret);
 
-                for (auto &[forward_shard_code, cce_addr] :
+                for (auto &[forward_shard_code, forward_pair] :
                      write_entry.forward_addr_)
                 {
                     CcReqStatus ret =
@@ -5308,11 +5316,13 @@ void TransactionExecution::Process(PostProcessOp &post_process)
                                                tx_term_,
                                                command_id,
                                                commit_ts_,
-                                               cce_addr,
+                                               forward_pair.second,
                                                write_entry.rec_.get(),
                                                write_entry.op_,
                                                forward_shard_code,
-                                               post_process.hd_result_);
+                                               post_process.hd_result_,
+                                               forward_pair.first,
+                                               on_dirty_range);
                     update_post_cnt(ret);
                 }
             }
@@ -5394,9 +5404,10 @@ void TransactionExecution::Process(PostProcessOp &post_process)
                     // Keys that were not successfully locked in the cc
                     // map do not need post-processing.
 
-                    for (const auto &[forward_shard_code, cce_addr] :
+                    for (const auto &[forward_shard_code, forward_pair] :
                          write_entry.forward_addr_)
                     {
+                        const CcEntryAddr &cce_addr = forward_pair.second;
                         if (cce_addr.Term() >= 0)
                         {
                             assert(!cce_addr.Empty());

--- a/tx_service/src/tx_operation.cpp
+++ b/tx_service/src/tx_operation.cpp
@@ -464,19 +464,20 @@ void AcquireWriteOperation::AggregateAcquiredKeys(TransactionExecution *txm)
             }
         }
 
-        for (auto &[forward_shard_code, cce_addr] : write_entry->forward_addr_)
+        for (auto &[forward_shard_code, forward_pair] :
+             write_entry->forward_addr_)
         {
             AcquireKeyResult &acquire_key_res = acquire_key_vec[res_idx++];
             CcEntryAddr &addr = acquire_key_res.cce_addr_;
             term = addr.Term();
             if (term < 0)
             {
-                cce_addr.SetCceLock(0, -1, 0);
+                forward_pair.second.SetCceLock(0, -1, 0);
             }
             else if (acquire_key_res.commit_ts_ == 0)
             {
                 // acqurie write failed on forward addr.
-                cce_addr.SetCceLock(0, -1, 0);
+                forward_pair.second.SetCceLock(0, -1, 0);
                 // Set term to -1 so that post write will not be sent to this
                 // addr.
                 addr.SetTerm(-1);
@@ -485,7 +486,7 @@ void AcquireWriteOperation::AggregateAcquiredKeys(TransactionExecution *txm)
             {
                 // Assigns to the write entry the cc entry address obtained
                 // in the acquire phase.
-                cce_addr = addr;
+                forward_pair.second = addr;
             }
 
             // No need to dedup forwarded req since they are not visible to read
@@ -720,17 +721,23 @@ void LockWriteRangeBucketsOp::Advance(TransactionExecution *txm)
         size_t new_range_idx = 0;
 
         auto *range_info = txm->range_rec_.GetRangeInfo();
+        int32_t range_id = range_info->PartitionId();
+        uint32_t residual = static_cast<uint32_t>(range_id & 0x3FF);
+        bool on_dirty_range = range_info->IsDirty();
         while (write_key_it_ != next_range_start)
         {
             const TxKey &write_tx_key = write_key_it_->first;
             WriteSetEntry &write_entry = write_key_it_->second;
-            size_t hash = write_tx_key.Hash();
-            write_entry.key_shard_code_ = (range_ng << 10) | (hash & 0x3FF);
+            write_entry.key_shard_code_ = (range_ng << 10) | residual;
+            write_entry.partition_id_ = range_id;
+            write_entry.on_dirty_range_ = on_dirty_range;
             // If current range is migrating, forward to new range owner.
             if (new_bucket_ng != UINT32_MAX)
             {
-                write_entry.forward_addr_.try_emplace((new_bucket_ng << 10) |
-                                                      (hash & 0x3FF));
+                assert(new_bucket_ng != range_ng);
+                write_entry.forward_addr_.try_emplace(
+                    ((new_bucket_ng << 10) | residual),
+                    std::make_pair(range_id, CcEntryAddr()));
             }
 
             // If range is splitting and the key will fall on a new range after
@@ -748,18 +755,47 @@ void LockWriteRangeBucketsOp::Advance(TransactionExecution *txm)
             }
             if (new_range_ng != UINT32_MAX)
             {
-                if (new_range_ng != range_ng)
-                {
-                    write_entry.forward_addr_.try_emplace((new_range_ng << 10) |
-                                                          (hash & 0x3FF));
-                }
-                // If the new range is migrating, forward to the new owner of
-                // new range.
-                if (new_range_new_bucket_ng != UINT32_MAX &&
-                    new_range_new_bucket_ng != range_ng)
+                int32_t new_range_id =
+                    range_info->NewPartitionId()->at(new_range_idx - 1);
+                uint32_t new_residual =
+                    static_cast<uint32_t>(new_range_id & 0x3FF);
+                uint16_t core_cnt =
+                    Sharder::Instance().GetLocalCcShards()->Count();
+                uint16_t new_range_shard =
+                    static_cast<uint16_t>(new_residual % core_cnt);
+                uint16_t range_shard =
+                    static_cast<uint16_t>(residual % core_cnt);
+                if (new_range_ng != range_ng || new_range_shard != range_shard)
                 {
                     write_entry.forward_addr_.try_emplace(
-                        (new_range_new_bucket_ng << 10) | (hash & 0x3FF));
+                        ((new_range_ng << 10) | new_residual),
+                        std::make_pair(new_range_id, CcEntryAddr()));
+                    // There is no need to update the range size of the old
+                    // range.
+                    write_entry.partition_id_ = -1;
+                }
+                else if (new_range_ng == range_ng &&
+                         new_range_shard == range_shard)
+                {
+                    // Only update the range size on the new range id in case of
+                    // the new range and the old range are located on the same
+                    // shard.
+                    write_entry.partition_id_ = new_range_id;
+                }
+
+                // If the new range is migrating, forward to the new owner of
+                // new range.
+                // TODO(ysw): double check the logic here.
+                if (new_range_new_bucket_ng != UINT32_MAX)
+                {
+                    assert(new_range_new_bucket_ng != new_range_ng);
+                    if (new_range_new_bucket_ng != range_ng ||
+                        new_range_shard != range_shard)
+                    {
+                        write_entry.forward_addr_.try_emplace(
+                            ((new_range_new_bucket_ng << 10) | new_residual),
+                            std::make_pair(new_range_id, CcEntryAddr()));
+                    }
                 }
             }
 


### PR DESCRIPTION
1. During a post-write operation, the range size information for the corresponding partition is maintained.

2. If a range is in the process of splitting, the range size is updated in the delta size information.

3. For a "double-write" operation, only the range size information for the newly split partition is updated.