### PR TITLE
Reset range size after range split

### DIFF
--- a/tx_service/include/cc/range_cc_map.h
+++ b/tx_service/include/cc/range_cc_map.h
@@ -743,7 +743,56 @@ public:
                 // update previous cce's end key
                 cce->SetCommitTsPayloadStatus(new_range_info->version_ts_,
                                               RecordStatus::Normal);
+
+                // Reset new range size on the data table ccmap (emplace if
+                // absent).
+                int32_t new_range_id = new_range_info->PartitionId();
+                NodeGroupId new_range_owner =
+                    shard_->GetRangeOwner(new_range_id, this->cc_ng_id_)
+                        ->BucketOwner();
+                if (new_range_owner == this->cc_ng_id_ &&
+                    static_cast<uint16_t>((new_range_id & 0x3FF) %
+                                          shard_->core_cnt_) ==
+                        shard_->core_id_)
+                {
+                    TableType data_table_type =
+                        TableName::Type(this->table_name_.StringView());
+                    TableName data_table_name(this->table_name_.StringView(),
+                                              data_table_type,
+                                              this->table_name_.Engine());
+                    CcMap *ccm =
+                        shard_->GetCcm(data_table_name, this->cc_ng_id_);
+                    assert(ccm != nullptr);
+                    size_t range_size = new_range_entries.at(idx)
+                                            ->TypedStoreRange()
+                                            ->PostCkptSize();
+                    ccm->InitRangeSize(static_cast<uint32_t>(new_range_id),
+                                       static_cast<int32_t>(range_size),
+                                       true,
+                                       true);
+                }
             }
+            // Reset old range size on the data table ccmap (no emplace).
+            int32_t old_partition_id =
+                upload_range_rec->GetRangeInfo()->PartitionId();
+            if (range_owner == this->cc_ng_id_ &&
+                static_cast<uint16_t>((old_partition_id & 0x3FF) %
+                                      shard_->core_cnt_) == shard_->core_id_)
+            {
+                TableType data_table_type =
+                    TableName::Type(this->table_name_.StringView());
+                TableName data_table_name(this->table_name_.StringView(),
+                                          data_table_type,
+                                          this->table_name_.Engine());
+                CcMap *ccm = shard_->GetCcm(data_table_name, this->cc_ng_id_);
+                assert(ccm != nullptr);
+                size_t old_range_size =
+                    old_entry->TypedStoreRange()->PostCkptSize();
+                ccm->InitRangeSize(static_cast<uint32_t>(old_partition_id),
+                                   static_cast<int32_t>(old_range_size));
+                ccm->ResetRangeStatus(static_cast<uint32_t>(old_partition_id));
+            }
+
             // range_owner_rec_ needs to be reset on each core since they point
             // to bucket records on different cores.
             upload_range_rec->range_owner_rec_ =

--- a/tx_service/include/cc/template_cc_map.h
+++ b/tx_service/include/cc/template_cc_map.h
@@ -7399,9 +7399,12 @@ public:
         }
         LruPage *lru_page;
         uint16_t pause_idx = shard_->core_id_;
-        if (req.GetCleanType() == CleanType::CleanBucketData)
+        CleanType clean_type = req.GetCleanType();
+        if (clean_type == CleanType::CleanBucketData ||
+            clean_type == CleanType::CleanRangeData)
         {
-            // For clean bucket data, cc req is only sent to 1 core.
+            // For clean bucket data and range data, cc req is only sent to 1
+            // core.
             pause_idx = 0;
         }
         if (req.ResumeKey(pause_idx)->KeyPtr() != nullptr)

--- a/tx_service/src/cc/local_cc_handler.cpp
+++ b/tx_service/src/cc/local_cc_handler.cpp
@@ -1907,7 +1907,8 @@ void txservice::LocalCcHandler::KickoutData(const TableName &table_name,
         KickoutCcEntryCc *req = kickout_ccentry_pool_.NextRequest();
         // For hash partition, all data in a single bucket should be hashed to
         // the same core.
-        uint16_t core_cnt = clean_type == CleanType::CleanBucketData
+        uint16_t core_cnt = (clean_type == CleanType::CleanBucketData ||
+                             clean_type == CleanType::CleanRangeData)
                                 ? 1
                                 : Sharder::Instance().GetLocalCcShardsCount();
         req->Reset(table_name,
@@ -1933,6 +1934,14 @@ void txservice::LocalCcHandler::KickoutData(const TableName &table_name,
             cc_shards_.EnqueueToCcShard(
                 Sharder::Instance().ShardBucketIdToCoreIdx((*bucket_id)[0]),
                 req);
+        }
+        else if (clean_type == CleanType::CleanRangeData)
+        {
+            assert(range_id != INT32_MAX);
+            uint16_t dest_core = static_cast<uint16_t>(
+                (range_id & 0x3FF) %
+                Sharder::Instance().GetLocalCcShardsCount());
+            cc_shards_.EnqueueToCcShard(dest_core, req);
         }
         else
         {

--- a/tx_service/src/cc/range_slice.cpp
+++ b/tx_service/src/cc/range_slice.cpp
@@ -449,12 +449,11 @@ bool StoreRange::SampleSubRangeKeys(StoreSlice *slice,
                                         &end_key,
                                         key_cnt);
 
-    // Send the request to one shard randomly.
-    uint64_t core_rand = butil::fast_rand();
-    local_cc_shards_.EnqueueLowPriorityCcRequestToShard(
-        core_rand % local_cc_shards_.Count(), &sample_keys_cc);
-    DLOG(INFO) << "Send the sample range keys request to shard#"
-               << core_rand % local_cc_shards_.Count();
+    uint16_t dest_core = static_cast<uint16_t>((partition_id_ & 0x3FF) %
+                                               local_cc_shards_.Count());
+    local_cc_shards_.EnqueueLowPriorityCcRequestToShard(dest_core,
+                                                        &sample_keys_cc);
+    DLOG(INFO) << "Send the sample range keys request to shard#" << dest_core;
 
     sample_keys_cc.Wait();
     CcErrorCode res = sample_keys_cc.ErrorCode();

--- a/tx_service/src/tx_operation.cpp
+++ b/tx_service/src/tx_operation.cpp
@@ -5132,8 +5132,13 @@ bool SplitFlushRangeOp::ForwardKickoutIterator(TransactionExecution *txm)
             NodeGroupId new_owner = new_range_bucket_info->BucketOwner();
             NodeGroupId dirty_new_owner =
                 new_range_bucket_info->DirtyBucketOwner();
-            if (new_owner != txm->TxCcNodeId() &&
-                dirty_new_owner != txm->TxCcNodeId())
+            uint16_t range_shard_id = static_cast<uint16_t>(
+                (range_info_->PartitionId() & 0x3FF) % local_shards->Count());
+            uint16_t new_range_shard_id = static_cast<uint16_t>(
+                (kickout_data_it_->second & 0x3FF) % local_shards->Count());
+            if ((new_owner != txm->TxCcNodeId() &&
+                 dirty_new_owner != txm->TxCcNodeId()) ||
+                (range_shard_id != new_range_shard_id))
             {
                 // Note that even if the new node group falls on the same node,
                 // we still need to clean the cc entry from native ccmap since
@@ -5152,11 +5157,14 @@ bool SplitFlushRangeOp::ForwardKickoutIterator(TransactionExecution *txm)
                 }
                 kickout_old_range_data_op_.clean_type_ =
                     CleanType::CleanRangeData;
+                kickout_old_range_data_op_.range_id_ =
+                    range_info_->PartitionId();
                 kickout_old_range_data_op_.node_group_ = txm->TxCcNodeId();
                 LOG(INFO)
                     << "Split Flush transaction kickout old data in range "
                     << kickout_data_it_->second << ", original range id "
                     << range_info_->PartitionId()
+                    << ", new range id: " << kickout_data_it_->second
                     << ", txn: " << txm->TxNumber();
                 kickout_data_it_++;
                 return false;


### PR DESCRIPTION
1. In the post-commit phase of a range split transaction, the range size of all related partitions is updated: base range size + delta size.

2. Reset the range splitting flag.

3. Update the kickoutcc process to accommodate the new key sharding logic.

4. Update the processing procedure for SampleSubRangeKeys to accommodate the new key sharding logic.