### PR TITLE
update replay log execution

### DIFF
--- a/tx_service/include/cc/cc_request.h
+++ b/tx_service/include/cc/cc_request.h
@@ -4837,7 +4837,10 @@ public:
         std::shared_ptr<std::atomic_uint32_t> range_split_started = nullptr,
         std::unordered_set<TableName> *range_splitting = nullptr,
         uint16_t first_core = 0,
-        ParseDataLogCc *parse_cc = nullptr)
+        ParseDataLogCc *parse_cc = nullptr,
+        const std::unordered_map<TableName,
+                                 std::unordered_map<int32_t, uint64_t>>
+            *split_range_info = nullptr)
     {
         table_name_holder_ =
             TableName(table_name_view, table_type, table_engine);
@@ -4865,6 +4868,15 @@ public:
         is_lock_recovery_ = is_lock_recovery;
         upsert_kv_err_code_ = {true, CcErrorCode::NO_ERROR};
         parse_cc_ = parse_cc;
+        split_ranges_ = nullptr;
+        if (split_range_info != nullptr)
+        {
+            auto table_it = split_range_info->find(table_name_holder_);
+            if (table_it != split_range_info->end())
+            {
+                split_ranges_ = &table_it->second;
+            }
+        }
     }
 
     ReplayLogCc(const ReplayLogCc &rhs) = delete;
@@ -5063,6 +5075,16 @@ public:
         return first_core_;
     }
 
+    uint64_t RangeSplitCommitTs(int32_t range_id) const
+    {
+        if (split_ranges_ == nullptr)
+        {
+            return 0;
+        }
+        auto it = split_ranges_->find(range_id);
+        return it == split_ranges_->end() ? 0 : it->second;
+    }
+
     void SetOffset(size_t offset)
     {
         offset_ = offset;
@@ -5130,6 +5152,9 @@ private:
                                                      CcErrorCode::NO_ERROR};
     ParseDataLogCc *parse_cc_{nullptr};
 
+    // Range split commit ts per range for the current table, if available.
+    const std::unordered_map<int32_t, uint64_t> *split_ranges_{nullptr};
+
     friend std::ostream &operator<<(std::ostream &outs,
                                     txservice::ReplayLogCc *r);
 };
@@ -5146,7 +5171,10 @@ public:
                std::atomic<fault::RecoveryService::WaitingStatus> &status,
                std::atomic<uint64_t> &on_fly_cnt,
                bool &recovery_error,
-               const bool is_lock_recovery = false)
+               const bool is_lock_recovery = false,
+               const std::unordered_map<TableName,
+                                        std::unordered_map<int32_t, uint64_t>>
+                   *split_range_info = nullptr)
     {
         log_records_sv_ =
             std::string_view(log_records.data(), log_records.size());
@@ -5158,6 +5186,7 @@ public:
         on_fly_cnt_ = &on_fly_cnt;
         recovery_error_ = &recovery_error;
         is_lock_recovery_ = is_lock_recovery;
+        split_range_info_ = split_range_info;
     }
 
     void Reset(::txlog::ReplayMessage &&replay_message,
@@ -5167,7 +5196,10 @@ public:
                std::atomic<fault::RecoveryService::WaitingStatus> &status,
                std::atomic<uint64_t> &on_fly_cnt,
                bool &recovery_error,
-               const bool is_lock_recovery = false)
+               const bool is_lock_recovery = false,
+               const std::unordered_map<TableName,
+                                        std::unordered_map<int32_t, uint64_t>>
+                   *split_range_info = nullptr)
     {
         replay_message_ =
             std::make_unique<::txlog::ReplayMessage>(std::move(replay_message));
@@ -5182,13 +5214,15 @@ public:
         on_fly_cnt_ = &on_fly_cnt;
         recovery_error_ = &recovery_error;
         is_lock_recovery_ = is_lock_recovery;
+        split_range_info_ = split_range_info;
     }
 
     bool Execute(CcShard &ccs) override
     {
         size_t offset = 0;
         // core of first key in log
-        int dest_core = 0;
+        uint32_t core_rand = butil::fast_rand();
+        uint16_t dest_core = static_cast<uint16_t>(core_rand % ccs.core_cnt_);
         std::vector<ReplayLogCc *> replay_cc_list;
         replay_cc_list.reserve(160);
         while (offset < log_records_sv_.size())
@@ -5259,10 +5293,19 @@ public:
                 uint32_t kv_len = *reinterpret_cast<const uint32_t *>(
                     blob.data() + blob_offset);
                 blob_offset += sizeof(uint32_t);
-                size_t hash = ccs.GetCatalogFactory(table_engine)
-                                  ->KeyHash(blob.data(), blob_offset, nullptr);
-                dest_core = hash ? (hash & 0x3FF) % ccs.core_cnt_
-                                 : (dest_core + 1) % ccs.core_cnt_;
+                if (table_engine == TableEngine::EloqSql ||
+                    table_engine == TableEngine::EloqDoc)
+                {
+                    dest_core = (dest_core + 1) % ccs.core_cnt_;
+                }
+                else
+                {
+                    size_t hash =
+                        ccs.GetCatalogFactory(table_engine)
+                            ->KeyHash(blob.data(), blob_offset, nullptr);
+                    dest_core = hash ? (hash & 0x3FF) % ccs.core_cnt_
+                                     : (dest_core + 1) % ccs.core_cnt_;
+                }
                 ReplayLogCc *cc_req = replay_cc_pool_.NextRequest();
                 replay_cc_list.push_back(cc_req);
                 assert(cc_ng_term_ >= 0);
@@ -5283,7 +5326,8 @@ public:
                     nullptr,
                     nullptr,
                     dest_core,
-                    this);
+                    this,
+                    split_range_info_);
 
                 blob_offset += kv_len;
             }
@@ -5321,6 +5365,8 @@ private:
     std::atomic<uint64_t> *on_fly_cnt_;
     bool *recovery_error_;
     bool is_lock_recovery_;
+    const std::unordered_map<TableName, std::unordered_map<int32_t, uint64_t>>
+        *split_range_info_{nullptr};
 };
 
 struct BroadcastStatisticsCc

--- a/tx_service/include/cc/range_cc_map.h
+++ b/tx_service/include/cc/range_cc_map.h
@@ -1159,6 +1159,14 @@ public:
             // add new range entry to range cc map
             auto bucket_map = static_cast<RangeBucketCcMap *>(
                 shard_->GetCcm(range_bucket_ccm_name, this->cc_ng_id_));
+            TableType data_table_type =
+                TableName::Type(this->table_name_.StringView());
+            TableName data_table_name(this->table_name_.StringView(),
+                                      data_table_type,
+                                      this->table_name_.Engine());
+            CcMap *data_ccm = shard_->GetCcm(data_table_name, this->cc_ng_id_);
+            assert(data_ccm != nullptr);
+
             for (uint idx = 0; idx < new_range_infos.size(); idx++)
             {
                 const TemplateRangeInfo<KeyT> *new_range_info =
@@ -1181,6 +1189,51 @@ public:
                         new_range_info->PartitionId()));
                 cce->SetCommitTsPayloadStatus(new_range_info->version_ts_,
                                               RecordStatus::Normal);
+
+                // Reset new range size on data table ccmap if this core owns
+                // it.
+                int32_t new_range_id = new_range_info->PartitionId();
+                NodeGroupId new_range_owner =
+                    shard_->GetRangeOwner(new_range_id, this->cc_ng_id_)
+                        ->BucketOwner();
+                if (new_range_owner == this->cc_ng_id_ &&
+                    static_cast<uint16_t>((new_range_id & 0x3FF) %
+                                          shard_->core_cnt_) ==
+                        shard_->core_id_)
+                {
+                    const TableRangeEntry *new_range_entry =
+                        shard_->GetTableRangeEntry(
+                            this->table_name_, this->cc_ng_id_, new_range_id);
+                    assert(new_range_entry != nullptr);
+                    size_t range_size =
+                        static_cast<const TemplateTableRangeEntry<KeyT> *>(
+                            new_range_entry)
+                            ->TypedStoreRange()
+                            ->PostCkptSize();
+                    data_ccm->InitRangeSize(static_cast<uint32_t>(new_range_id),
+                                            static_cast<int32_t>(range_size),
+                                            true,
+                                            true);
+                }
+            }
+
+            // Reset old range size on the data table ccmap if this core owns
+            // it.
+            int32_t old_range_id =
+                old_table_range_entry->GetRangeInfo()->PartitionId();
+            NodeGroupId range_owner =
+                shard_->GetRangeOwner(old_range_id, this->cc_ng_id_)
+                    ->BucketOwner();
+            if (range_owner == this->cc_ng_id_ &&
+                static_cast<uint16_t>((old_range_id & 0x3FF) %
+                                      shard_->core_cnt_) == shard_->core_id_)
+            {
+                size_t old_range_size =
+                    old_table_range_entry->RangeSlices()->PostCkptSize();
+                data_ccm->InitRangeSize(static_cast<uint32_t>(old_range_id),
+                                        static_cast<int32_t>(old_range_size),
+                                        true,
+                                        true);
             }
         }
 

--- a/tx_service/include/cc/template_cc_map.h
+++ b/tx_service/include/cc/template_cc_map.h
@@ -6858,7 +6858,114 @@ public:
 
             offset += sizeof(uint8_t);
 
-            uint16_t core_id = (key.Hash() & 0x3FF) % shard_->core_cnt_;
+            uint16_t core_id = 0;
+            bool is_dirty = false;
+            bool need_update_size = true;
+            int32_t partition_id = -1;
+
+            if constexpr (RangePartitioned)
+            {
+                const TableRangeEntry *range_entry = shard_->GetTableRangeEntry(
+                    table_name_, cc_ng_id_, TxKey(&key));
+                if (range_entry == nullptr)
+                {
+                    // range metadata missing, conservative handling: only
+                    // consume value / skip.
+                    if (op_type == OperationType::Insert ||
+                        op_type == OperationType::Update)
+                    {
+                        rec.Deserialize(log_blob.data(), offset);
+                    }
+                    continue;
+                }
+
+                partition_id = range_entry->GetRangeInfo()->PartitionId();
+                const BucketInfo *bucket_info = shard_->GetBucketInfo(
+                    Sharder::MapRangeIdToBucketId(partition_id), cc_ng_id_);
+
+                // Old range bucket does not belong to this ng, nor is it a
+                // "dirty bucket" migrating to this ng.
+                if (bucket_info->BucketOwner() != cc_ng_id_ &&
+                    bucket_info->DirtyBucketOwner() != cc_ng_id_)
+                {
+                    int32_t new_range_id =
+                        range_entry->GetRangeInfo()->GetKeyNewRangeId(
+                            TxKey(&key));
+                    // If range is splitting, check if new range belongs to
+                    // this ng.
+                    if (new_range_id >= 0)
+                    {
+                        const BucketInfo *new_bucket_info =
+                            shard_->GetBucketInfo(
+                                Sharder::MapRangeIdToBucketId(new_range_id),
+                                cc_ng_id_);
+                        if (new_bucket_info->BucketOwner() != cc_ng_id_ &&
+                            new_bucket_info->DirtyBucketOwner() != cc_ng_id_)
+                        {
+                            // Neither old bucket nor new bucket belongs to this
+                            // ng: only consume value and continue.
+                            if (op_type != OperationType::Delete)
+                            {
+                                rec.Deserialize(log_blob.data(), offset);
+                            }
+                            continue;
+                        }
+
+                        // new range belongs to this ng: determine core based on
+                        // new_range_id and mark dirty.
+                        core_id = static_cast<uint16_t>((new_range_id & 0x3FF) %
+                                                        shard_->core_cnt_);
+                        is_dirty = true;
+
+                        uint64_t range_split_commit_ts =
+                            req.RangeSplitCommitTs(partition_id);
+                        // Only update range size for keys updated during the
+                        // double-write phase.
+                        need_update_size =
+                            (range_split_commit_ts == 0) ||
+                            (req.CommitTs() > range_split_commit_ts);
+                    }
+                    else
+                    {
+                        // new_range_id < 0: key still belongs to old range, but
+                        // old range bucket does not belong to this ng.
+                        // Semantically, it should not be applied to this ng:
+                        // only consume and continue.
+                        if (op_type != OperationType::Delete)
+                        {
+                            rec.Deserialize(log_blob.data(), offset);
+                        }
+                        continue;
+                    }
+                }
+                else
+                {
+                    // Old range bucket belongs to this ng or is migrating to
+                    // this ng.
+                    core_id = static_cast<uint16_t>((partition_id & 0x3FF) %
+                                                    shard_->core_cnt_);
+                    is_dirty = range_entry->GetRangeInfo()->IsDirty();
+
+                    uint64_t range_split_commit_ts =
+                        req.RangeSplitCommitTs(partition_id);
+                    need_update_size = (range_split_commit_ts == 0) ||
+                                       (req.CommitTs() > range_split_commit_ts);
+                }
+            }
+            else
+            {
+                uint16_t bucket_id = Sharder::MapKeyHashToBucketId(key.Hash());
+                const BucketInfo *bucket_info =
+                    shard_->GetBucketInfo(bucket_id, cc_ng_id_);
+                if (bucket_info->BucketOwner() != cc_ng_id_ &&
+                    bucket_info->DirtyBucketOwner() != cc_ng_id_)
+                {
+                    continue;
+                }
+                core_id = static_cast<uint16_t>((key.Hash() & 0x3FF) %
+                                                shard_->core_cnt_);
+            }
+
             if (core_id != shard_->core_id_)
             {
                 // Skips the key in the log record that is not sharded
@@ -6875,57 +6982,6 @@ public:
                     next_core = std::min(core_id, next_core);
                 }
                 continue;
-            }
-
-            // Skip records that no longer belong to this ng.
-            if (RangePartitioned)
-            {
-                const TableRangeEntry *range_entry = shard_->GetTableRangeEntry(
-                    table_name_, cc_ng_id_, TxKey(&key));
-
-                const BucketInfo *bucket_info = shard_->GetBucketInfo(
-                    Sharder::MapRangeIdToBucketId(
-                        range_entry->GetRangeInfo()->PartitionId()),
-                    cc_ng_id_);
-                // Check if range bucket belongs to this ng or is migrating
-                // to this ng.
-                if (bucket_info->BucketOwner() != cc_ng_id_ &&
-                    bucket_info->DirtyBucketOwner() != cc_ng_id_)
-                {
-                    int32_t new_range_id =
-                        range_entry->GetRangeInfo()->GetKeyNewRangeId(
-                            TxKey(&key));
-                    // If range is splitting, check if new range belongs to
-                    // this ng.
-                    if (new_range_id >= 0)
-                    {
-                        const BucketInfo *new_bucket_info =
-                            shard_->GetBucketInfo(
-                                Sharder::MapRangeIdToBucketId(
-                                    range_entry->GetRangeInfo()->PartitionId()),
-                                cc_ng_id_);
-                        if (new_bucket_info->BucketOwner() != cc_ng_id_ &&
-                            new_bucket_info->DirtyBucketOwner() != cc_ng_id_)
-                        {
-                            if (op_type != OperationType::Delete)
-                            {
-                                rec.Deserialize(log_blob.data(), offset);
-                            }
-                            continue;
-                        }
-                    }
-                }
-            }
-            else
-            {
-                uint16_t bucket_id = Sharder::MapKeyHashToBucketId(key.Hash());
-                const BucketInfo *bucket_info =
-                    shard_->GetBucketInfo(bucket_id, cc_ng_id_);
-                if (bucket_info->BucketOwner() != cc_ng_id_ &&
-                    bucket_info->DirtyBucketOwner() != cc_ng_id_)
-                {
-                    continue;
-                }
             }
 
             Iterator it = FindEmplace(key);
@@ -7000,6 +7056,12 @@ public:
                 {
                     cce->ArchiveBeforeUpdate();
                 }
+
+                [[maybe_unused]] const size_t old_payload_size =
+                    cce->PayloadSize();
+                [[maybe_unused]] const RecordStatus cce_old_status =
+                    cce->PayloadStatus();
+
                 RecordStatus rec_status;
                 if (op_type == OperationType::Insert ||
                     op_type == OperationType::Update)
@@ -7020,6 +7082,26 @@ public:
                 bool was_dirty = cce->IsDirty();
                 cce->SetCommitTsPayloadStatus(commit_ts, rec_status);
                 OnCommittedUpdate(cce, was_dirty);
+
+                if constexpr (RangePartitioned)
+                {
+                    if (need_update_size)
+                    {
+                        int32_t delta_size =
+                            (rec_status == RecordStatus::Deleted)
+                                ? -static_cast<int32_t>(key.Size() +
+                                                        old_payload_size)
+                                : static_cast<int32_t>(
+                                      cce_old_status != RecordStatus::Normal
+                                          ? (key.Size() + cce->PayloadSize())
+                                          : (cce->PayloadSize() -
+                                             old_payload_size));
+
+                        UpdateRangeSize(static_cast<uint32_t>(partition_id),
+                                        delta_size,
+                                        is_dirty);
+                    }
+                }
 
                 if (commit_ts > last_dirty_commit_ts_)
                 {

--- a/tx_service/include/fault/log_replay_service.h
+++ b/tx_service/include/fault/log_replay_service.h
@@ -35,6 +35,7 @@
 #include <unordered_map>
 
 #include "txlog.h"
+#include "type.h"
 
 namespace txservice
 {
@@ -174,6 +175,17 @@ private:
 
     void ProcessRecoverTxTask(RecoverTxTask &task);
 
+    // Range split info management.
+    void SetSplitRangeInfo(uint32_t ng_id,
+                           TableName table_name,
+                           int32_t range_id,
+                           uint64_t commit_ts);
+
+    const std::unordered_map<TableName, std::unordered_map<int32_t, uint64_t>> *
+    GetSplitRangeInfo(uint32_t ng_id) const;
+
+    void CleanSplitRangeInfo(uint32_t ng_id);
+
     struct ConnectionInfo
     {
         ConnectionInfo() = default;
@@ -237,6 +249,13 @@ private:
     uint16_t port_;
 
     void ClearTx(uint64_t tx_number);
+
+    // Range split info for each node group:
+    // ng_id -> <data_table_name -> <partition id -> split range commit ts>>
+    std::unordered_map<
+        uint32_t,
+        std::unordered_map<TableName, std::unordered_map<int32_t, uint64_t>>>
+        split_range_info_;
 };
 }  // namespace fault
 }  // namespace txservice

--- a/tx_service/src/fault/log_replay_service.cpp
+++ b/tx_service/src/fault/log_replay_service.cpp
@@ -584,6 +584,21 @@ int RecoveryService::on_received_messages(brpc::StreamId stream_id,
             auto res_pair = table_range_split_cnt.try_emplace(
                 base_table_name, std::make_shared<std::atomic_uint32_t>(0));
 
+            // Record split range commit ts for data log replay.
+            ::txlog::SplitRangeOpMessage ds_split_range_op_msg;
+            if (!ds_split_range_op_msg.ParseFromArray(
+                    split_range_op_blob.data() + blob_offset,
+                    split_range_op_blob.length() - blob_offset))
+            {
+                recovery_error = true;
+                CleanSplitRangeInfo(cc_ng_id);
+                return 0;
+            }
+            int32_t range_id = ds_split_range_op_msg.partition_id();
+            uint64_t split_commit_ts = split_range_msg.commit_ts();
+            SetSplitRangeInfo(
+                cc_ng_id, base_table_name, range_id, split_commit_ts);
+
             // Replay Split
             ReplayLogCc *cc_req = replay_cc_pool_.NextRequest();
             cc_req->Reset(
@@ -611,6 +626,7 @@ int RecoveryService::on_received_messages(brpc::StreamId stream_id,
                 stream_id, mux, on_fly_cnt, status, recovery_error);
             if (recovery_error)
             {
+                CleanSplitRangeInfo(cc_ng_id);
                 return 0;
             }
         }
@@ -618,6 +634,7 @@ int RecoveryService::on_received_messages(brpc::StreamId stream_id,
         // parse and process log records
         if (!msg.has_finish())
         {
+            const auto *split_range_info = GetSplitRangeInfo(cc_ng_id);
             ParseDataLogCc *cc_req = parse_datalog_cc_pool_.NextRequest();
             cc_req->Reset(std::move(msg),
                           cc_ng_id,
@@ -626,7 +643,8 @@ int RecoveryService::on_received_messages(brpc::StreamId stream_id,
                           status,
                           on_fly_cnt,
                           recovery_error,
-                          is_lock_recovery);
+                          is_lock_recovery,
+                          split_range_info);
             on_fly_cnt.fetch_add(1, std::memory_order_release);
             local_shards_.EnqueueCcRequest(next_core, cc_req);
             next_core = (next_core + 1) % local_shards_.Count();
@@ -634,6 +652,7 @@ int RecoveryService::on_received_messages(brpc::StreamId stream_id,
         else  // has finish message
         {
             const std::string &log_records = msg.binary_log_records();
+            const auto *split_range_info = GetSplitRangeInfo(cc_ng_id);
             ParseDataLogCc *cc_req = parse_datalog_cc_pool_.NextRequest();
             cc_req->Reset(log_records,
                           cc_ng_id,
@@ -642,7 +661,8 @@ int RecoveryService::on_received_messages(brpc::StreamId stream_id,
                           status,
                           on_fly_cnt,
                           recovery_error,
-                          is_lock_recovery);
+                          is_lock_recovery,
+                          split_range_info);
             on_fly_cnt.fetch_add(1, std::memory_order_release);
             local_shards_.EnqueueCcRequest(next_core, cc_req);
             next_core = (next_core + 1) % local_shards_.Count();
@@ -687,6 +707,8 @@ int RecoveryService::on_received_messages(brpc::StreamId stream_id,
                           << ", log group: " << info->log_group_id_
                           << ", set recovering status to finished";
             }
+            // Clean up split range info for this node group.
+            CleanSplitRangeInfo(cc_ng_id);
             brpc::StreamClose(stream_id);
             // assumption: finish message must be the last message so return
             return 0;
@@ -1058,6 +1080,41 @@ void RecoveryService::ProcessRecoverTxTask(RecoverTxTask &task)
             // the coordinator.
         }
     }
+}
+
+void RecoveryService::SetSplitRangeInfo(uint32_t ng_id,
+                                        TableName table_name,
+                                        int32_t range_id,
+                                        uint64_t commit_ts)
+{
+    auto ng_it = split_range_info_.try_emplace(ng_id).first;
+    auto &table_map = ng_it->second;
+    auto table_it =
+        table_map
+            .try_emplace(table_name, std::unordered_map<int32_t, uint64_t>{})
+            .first;
+    auto &range_map = table_it->second;
+    auto [it, inserted] = range_map.try_emplace(range_id, commit_ts);
+    if (!inserted)
+    {
+        it->second = commit_ts;
+    }
+}
+
+const std::unordered_map<TableName, std::unordered_map<int32_t, uint64_t>> *
+RecoveryService::GetSplitRangeInfo(uint32_t ng_id) const
+{
+    auto ng_it = split_range_info_.find(ng_id);
+    if (ng_it == split_range_info_.end())
+    {
+        return nullptr;
+    }
+    return &ng_it->second;
+}
+
+void RecoveryService::CleanSplitRangeInfo(uint32_t ng_id)
+{
+    split_range_info_.erase(ng_id);
 }
 
 }  // namespace fault


### PR DESCRIPTION
1. Update the range size during data log replay.

2. For post commit range split log, update range size for each newly splitting ranges.

3. Update the data log replay process to accommodate the new key sharding logic.
