### PR TITLE
Adapt datasync with new keysharding

### DIFF
--- a/tx_service/include/cc/cc_request.h
+++ b/tx_service/include/cc/cc_request.h
@@ -4037,7 +4037,6 @@ public:
         uint64_t data_sync_ts,
         uint64_t node_group_id,
         int64_t node_group_term,
-        uint16_t core_cnt,
         size_t scan_batch_size,
         uint64_t txn,
         const TxKey *target_start_key,
@@ -4052,14 +4051,13 @@ public:
           table_name_(&table_name),
           node_group_id_(node_group_id),
           node_group_term_(node_group_term),
-          core_cnt_(core_cnt),
           last_data_sync_ts_(last_data_sync_ts),
           data_sync_ts_(data_sync_ts),
           start_key_(target_start_key),
           end_key_(target_end_key),
           scan_batch_size_(scan_batch_size),
           err_(CcErrorCode::NO_ERROR),
-          unfinished_cnt_(core_cnt_),
+          finished_(false),
           mux_(),
           cv_(),
           export_base_table_item_(export_base_table_item),
@@ -4082,24 +4080,19 @@ public:
                                   false);
                           });
         }
-        for (size_t i = 0; i < core_cnt; i++)
+        data_sync_vec_.resize(scan_batch_size);
+        if (!export_base_table_item_only_)
         {
-            data_sync_vec_.emplace_back();
-            data_sync_vec_.back().resize(scan_batch_size);
-            if (!export_base_table_item_only_)
-            {
-                archive_vec_.emplace_back();
-                archive_vec_.back().reserve(scan_batch_size);
-                mv_base_idx_vec_.emplace_back();
-                mv_base_idx_vec_.back().reserve(scan_batch_size);
-            }
-
-            pause_pos_.emplace_back(TxKey(), false);
-            curr_slice_index_.emplace_back(0);
-            accumulated_scan_cnt_.emplace_back(0);
-            accumulated_flush_data_size_.emplace_back(0);
-            scan_heap_is_full_.emplace_back(0);
+            archive_vec_.reserve(scan_batch_size);
+            mv_base_idx_vec_.reserve(scan_batch_size);
         }
+
+        pause_pos_.first = std::move(TxKey());
+        pause_pos_.second = false;
+        curr_slice_index_ = 0;
+        accumulated_scan_cnt_ = 0;
+        accumulated_flush_data_size_ = 0;
+        scan_heap_is_full_ = 0;
     }
 
     bool ValidTermCheck()
@@ -4133,7 +4126,6 @@ public:
             SetError(CcErrorCode::REQUESTED_NODE_NOT_LEADER);
             return false;
         }
-        scan_count_++;
         CcMap *ccm = ccs.GetCcm(*table_name_, node_group_id_);
         if (ccm == nullptr)
         {
@@ -4169,49 +4161,44 @@ public:
         return false;
     }
 
-    bool IsDrained(size_t core_idx) const
+    bool IsDrained() const
     {
-        return pause_pos_[core_idx].second;
+        return pause_pos_.second;
     }
 
-    std::pair<TxKey, bool> &PausePos(size_t core_idx)
+    std::pair<TxKey, bool> &PausePos()
     {
-        return pause_pos_[core_idx];
+        return pause_pos_;
     }
 
     void Wait()
     {
         std::unique_lock<std::mutex> lk(mux_);
-        cv_.wait(lk, [this] { return unfinished_cnt_ == 0; });
+        cv_.wait(lk, [this] { return finished_; });
     }
 
     void Reset(OpType op_type = OpType::Normal)
     {
         std::lock_guard<std::mutex> lk(mux_);
-        unfinished_cnt_ = 1;
-        for (size_t i = 0; i < core_cnt_; i++)
+        finished_ = false;
+        if (!export_base_table_item_only_)
         {
-            if (!export_base_table_item_only_)
-            {
-                archive_vec_.at(i).clear();
-                archive_vec_.at(i).reserve(scan_batch_size_);
-                mv_base_idx_vec_.at(i).clear();
-                mv_base_idx_vec_.at(i).reserve(scan_batch_size_);
-            }
+            archive_vec_.clear();
+            mv_base_idx_vec_.clear();
+        }
 
-            accumulated_scan_cnt_.at(i) = 0;
-            accumulated_flush_data_size_.at(i) = 0;
-            if (scan_heap_is_full_[i] == 1)
-            {
-                // vec has been cleared during ReleaseDataSyncScanHeapCc,
-                // resize to prepared size
-                data_sync_vec_[i].resize(scan_batch_size_);
-                scan_heap_is_full_[i] = 0;
-            }
-            if (export_base_table_item_)
-            {
-                curr_slice_index_[i] = 0;
-            }
+        accumulated_scan_cnt_ = 0;
+        accumulated_flush_data_size_ = 0;
+        if (scan_heap_is_full_ == 1)
+        {
+            // vec has been cleared during ReleaseDataSyncScanHeapCc,
+            // resize to prepared size
+            data_sync_vec_.resize(scan_batch_size_);
+            scan_heap_is_full_ = 0;
+        }
+        if (export_base_table_item_)
+        {
+            curr_slice_index_ = 0;
         }
 
         err_ = CcErrorCode::NO_ERROR;
@@ -4223,12 +4210,9 @@ public:
     {
         std::lock_guard<std::mutex> lk(mux_);
         err_ = err;
-        --unfinished_cnt_;
-        if (unfinished_cnt_ == 0)
-        {
-            UnpinSlices();
-            cv_.notify_one();
-        }
+        finished_ = true;
+        UnpinSlices();
+        cv_.notify_one();
     }
 
     void AbortCcRequest(CcErrorCode err_code) override
@@ -4249,26 +4233,22 @@ public:
         return err_;
     }
 
-    void SetFinish(size_t core_id)
+    void SetFinish()
     {
         std::unique_lock<std::mutex> lk(mux_);
-        --unfinished_cnt_;
-        if (export_base_table_item_ && !pause_pos_[core_id].second)
+        finished_ = true;
+        if (export_base_table_item_ && !pause_pos_.second)
         {
             // Only not drained on this core, should set the paused key.
-            UpdateMinPausedSlice(&pause_pos_[core_id].first);
+            UpdateMinPausedSlice(&pause_pos_.first);
         }
         else if (!export_base_table_item_)
         {
-            UpdateMinPausedSlice(curr_slice_index_[core_id]);
+            UpdateMinPausedSlice(curr_slice_index_);
         }
-
-        if (unfinished_cnt_ == 0)
-        {
-            // Unpin the slices
-            UnpinSlices();
-            cv_.notify_one();
-        }
+        // Unpin the slices
+        UnpinSlices();
+        cv_.notify_one();
     }
 
     uint32_t NodeGroupId()
@@ -4276,19 +4256,19 @@ public:
         return node_group_id_;
     }
 
-    std::vector<FlushRecord> &DataSyncVec(uint16_t core_id)
+    std::vector<FlushRecord> &DataSyncVec()
     {
-        return data_sync_vec_[core_id];
+        return data_sync_vec_;
     }
 
-    std::vector<FlushRecord> &ArchiveVec(uint16_t core_id)
+    std::vector<FlushRecord> &ArchiveVec()
     {
-        return archive_vec_[core_id];
+        return archive_vec_;
     }
 
-    std::vector<size_t> &MoveBaseIdxVec(uint16_t core_id)
+    std::vector<size_t> &MoveBaseIdxVec()
     {
-        return mv_base_idx_vec_[core_id];
+        return mv_base_idx_vec_;
     }
 
     int64_t NodeGroupTerm() const
@@ -4312,76 +4292,52 @@ public:
         return store_range_;
     }
 
-    void FixCurrentSliceIndex(uint16_t core_id)
+    StoreSlice *CurrentSlice() const
     {
-        assert(export_base_table_item_);
-        if (pause_pos_[core_id].first.KeyPtr() != nullptr)
-        {
-            size_t curr_slice_idx = 0;
-            StoreSlice *curr_slice =
-                slice_coordinator_.pinned_slices_[curr_slice_idx];
-            while (curr_slice->EndTxKey() < pause_pos_[core_id].first)
-            {
-                ++curr_slice_idx;
-                assert(curr_slice_idx <
-                       slice_coordinator_.pinned_slices_.size());
-                curr_slice = slice_coordinator_.pinned_slices_[curr_slice_idx];
-            }
-            curr_slice_index_[core_id] = curr_slice_idx;
-        }
-    }
-
-    StoreSlice *CurrentSlice(uint16_t core_id) const
-    {
-        size_t curr_slice_idx = curr_slice_index_[core_id];
         if (export_base_table_item_)
         {
-            assert(curr_slice_idx < slice_coordinator_.pinned_slices_.size());
-            return slice_coordinator_.pinned_slices_.at(curr_slice_idx);
+            assert(curr_slice_index_ <
+                   slice_coordinator_.pinned_slices_.size());
+            return slice_coordinator_.pinned_slices_.at(curr_slice_index_);
         }
-        assert(curr_slice_idx < slices_to_scan_.size());
-        const TxKey &curr_slice_key = slices_to_scan_.at(curr_slice_idx).first;
+        assert(curr_slice_index_ < slices_to_scan_.size());
+        const TxKey &curr_slice_key =
+            slices_to_scan_.at(curr_slice_index_).first;
         return store_range_->FindSlice(curr_slice_key);
     }
 
-    const TxKey &CurrentSliceKey(uint16_t core_id) const
+    const TxKey &CurrentSliceKey() const
     {
         assert(!export_base_table_item_);
-        size_t curr_slice_index = curr_slice_index_[core_id];
-        assert(curr_slice_index < slices_to_scan_.size());
-        return slices_to_scan_[curr_slice_index].first;
+        assert(curr_slice_index_ < slices_to_scan_.size());
+        return slices_to_scan_[curr_slice_index_].first;
     }
 
-    void MoveToNextSlice(uint16_t core_id)
+    void MoveToNextSlice()
     {
-        curr_slice_index_[core_id]++;
+        curr_slice_index_++;
     }
 
-    bool TheBatchEnd(uint16_t core_id) const
+    bool TheBatchEnd() const
     {
-        return curr_slice_index_[core_id] >=
+        return curr_slice_index_ >=
                (export_base_table_item_
                     ? slice_coordinator_.pinned_slices_.size()
                     : slice_coordinator_.batch_end_slice_index_);
     }
 
-    bool IsSlicePinned(uint16_t core_id) const
+    bool IsSlicePinned() const
     {
         assert(export_base_table_item_ ||
-               curr_slice_index_[core_id] < slices_to_scan_.size());
+               curr_slice_index_ < slices_to_scan_.size());
         return export_base_table_item_
                    ? true
-                   : slices_to_scan_[curr_slice_index_[core_id]].second;
+                   : slices_to_scan_[curr_slice_index_].second;
     }
 
     uint64_t SchemaVersion() const override
     {
         return schema_version_;
-    }
-
-    void SetUnfinishedCoreCnt(uint16_t core_cnt)
-    {
-        unfinished_cnt_ = core_cnt;
     }
 
     void UnpinSlices()
@@ -4427,13 +4383,10 @@ public:
         return last_data_sync_ts_;
     }
 
-    std::vector<size_t> accumulated_scan_cnt_;
-    std::vector<uint64_t> accumulated_flush_data_size_;
+    size_t accumulated_scan_cnt_;
+    uint64_t accumulated_flush_data_size_;
 
-    // std::vector<bool> is not safe to use in multi-threaded environment,
-    std::vector<uint32_t> scan_heap_is_full_{0};
-
-    size_t scan_count_{0};
+    uint32_t scan_heap_is_full_{0};
 
 private:
     struct SliceCoordinator
@@ -4553,7 +4506,6 @@ private:
     const TableName *table_name_{nullptr};
     uint32_t node_group_id_;
     int64_t node_group_term_;
-    uint16_t core_cnt_;
     // It is used as a hint to decide if a page has dirty data since last round
     // of checkpoint. It is guaranteed that all entries committed before this ts
     // are synced into data store.
@@ -4561,10 +4513,10 @@ private:
     // Target ts. Collect all data changes committed before this ts into data
     // sync vec.
     uint64_t data_sync_ts_;
-    std::vector<std::vector<FlushRecord>> data_sync_vec_;
-    std::vector<std::vector<FlushRecord>> archive_vec_;
+    std::vector<FlushRecord> data_sync_vec_;
+    std::vector<FlushRecord> archive_vec_;
     // Cache the entries to move record from "base" table to "archive" table
-    std::vector<std::vector<size_t>> mv_base_idx_vec_;
+    std::vector<size_t> mv_base_idx_vec_;
 
     // Start/end key of target range if the scan is on a range only, nullptr if
     // it's on entire table.
@@ -4573,11 +4525,11 @@ private:
     // Position that we left off during last round of ckpt scan.
     // pause_pos_.first is the key that we stopped at (has not been scanned
     // though), bool is if this core has finished scanning all keys already.
-    std::vector<std::pair<TxKey, bool>> pause_pos_;
+    std::pair<TxKey, bool> pause_pos_;
     size_t scan_batch_size_;
 
     CcErrorCode err_{CcErrorCode::NO_ERROR};
-    uint32_t unfinished_cnt_;
+    bool finished_{false};
     std::mutex mux_;
     std::condition_variable cv_;
 
@@ -4595,7 +4547,7 @@ private:
     // The index of the current slice to be scanned. If export_base_table_item_
     // is true, it is the index of the SliceCoordinator::pinned_slices_ vector,
     // and if false, it is the index of the slices_to_scan_ vector.
-    std::vector<size_t> curr_slice_index_;
+    size_t curr_slice_index_;
     // keep schema vesion after acquire read lock on catalog, to prevent the
     // concurrency issue with Truncate Table, detail ref to tx issue #1130
     // If schema_version_ is 0, the check will be bypassed, since this data sync
@@ -8747,7 +8699,6 @@ struct ScanSliceDeltaSizeCcForRangePartition : public CcRequestBase
                                           uint64_t scan_ts,
                                           uint64_t ng_id,
                                           int64_t ng_term,
-                                          uint64_t core_cnt,
                                           uint64_t txn,
                                           const TxKey &target_start_key,
                                           const TxKey &target_end_key,
@@ -8764,20 +8715,14 @@ struct ScanSliceDeltaSizeCcForRangePartition : public CcRequestBase
           store_range_(store_range),
           is_dirty_(is_dirty),
           has_dml_since_ddl_(false),
-          unfinished_cnt_(core_cnt),
+          finished_(false),
           schema_version_(schema_version)
     {
         tx_number_ = txn;
-        pause_pos_.resize(core_cnt);
+        pause_pos_.first = std::move(TxKey());
+        pause_pos_.second = nullptr;
         size_t slice_cnt = store_range ? store_range->SlicesCount() : 0;
-        for (size_t i = 0; i < core_cnt; ++i)
-        {
-            slice_delta_size_.emplace_back();
-            if (slice_cnt > 0)
-            {
-                slice_delta_size_.back().reserve(slice_cnt);
-            }
-        }
+        slice_delta_size_.reserve(slice_cnt);
     }
 
     bool ValidTermCheck() const
@@ -8820,26 +8765,22 @@ struct ScanSliceDeltaSizeCcForRangePartition : public CcRequestBase
     void Wait()
     {
         std::unique_lock<std::mutex> lk(mux_);
-        cv_.wait(lk, [this] { return unfinished_cnt_ == 0; });
+        cv_.wait(lk, [this] { return finished_; });
     }
 
     void SetFinish()
     {
         std::unique_lock<std::mutex> lk(mux_);
-        if (--unfinished_cnt_ == 0)
-        {
-            cv_.notify_one();
-        }
+        finished_ = true;
+        cv_.notify_one();
     }
 
     void SetError(CcErrorCode err)
     {
         std::unique_lock<std::mutex> lk(mux_);
         err_ = err;
-        if (--unfinished_cnt_ == 0)
-        {
-            cv_.notify_one();
-        }
+        finished_ = true;
+        cv_.notify_one();
     }
 
     bool IsError()
@@ -8901,18 +8842,18 @@ struct ScanSliceDeltaSizeCcForRangePartition : public CcRequestBase
         assert(store_range);
         bool res = store_range_.compare_exchange_strong(
             expect, store_range, std::memory_order_acq_rel);
-        slice_delta_size_[core_id].reserve(store_range->SlicesCount());
+        slice_delta_size_.reserve(store_range->SlicesCount());
         return res;
     }
 
-    std::pair<TxKey, StoreSlice *> &PausedPos(size_t core_id)
+    std::pair<TxKey, StoreSlice *> &PausedPos()
     {
-        return pause_pos_[core_id];
+        return pause_pos_;
     }
 
-    std::vector<std::pair<TxKey, int64_t>> &SliceDeltaSize(size_t core_id)
+    std::vector<std::pair<TxKey, int64_t>> &SliceDeltaSize()
     {
-        return slice_delta_size_[core_id];
+        return slice_delta_size_;
     }
 
     bool IsDirty() const
@@ -8956,10 +8897,10 @@ private:
     // pause_pos_.first is the key that we stopped at (has not been scanned
     // though), .second is the slice that we stopped in (has not been scanned
     // completed yet).
-    std::vector<std::pair<TxKey, StoreSlice *>> pause_pos_;
+    std::pair<TxKey, StoreSlice *> pause_pos_;
     // The delta size of the slices. First is the TxKey of the slice, second is
     // the delta size. The TxKey is not the owner of the key.
-    std::vector<std::vector<std::pair<TxKey, int64_t>>> slice_delta_size_;
+    std::vector<std::pair<TxKey, int64_t>> slice_delta_size_;
 
     // Generally, if the size of a key in the data store is unknown (the
     // data_store_size_ is INT32_MAX), we need to read the storage (via
@@ -8977,7 +8918,7 @@ private:
     std::atomic<bool> has_dml_since_ddl_{false};
 
     CcErrorCode err_{CcErrorCode::NO_ERROR};
-    uint32_t unfinished_cnt_;
+    bool finished_{false};
     uint64_t schema_version_;
     std::mutex mux_;
     std::condition_variable cv_;

--- a/tx_service/include/cc/template_cc_map.h
+++ b/tx_service/include/cc/template_cc_map.h
@@ -5524,37 +5524,17 @@ public:
             req.slice_coordinator_.UpdatePreparedSliceCnt(prepared_slice_cnt);
             req.slice_coordinator_.UpdateBatchEnd();
 
-            if (req.export_base_table_item_)
-            {
-                // Fix the slice index of the current core
-                for (uint16_t core_id = 0; core_id < shard_->core_cnt_;
-                     ++core_id)
-                {
-                    req.FixCurrentSliceIndex(core_id);
-                }
-            }
             req.slice_coordinator_.SetReadyForScan();
-            req.SetUnfinishedCoreCnt(shard_->core_cnt_);
-
-            // Dispatch the request to the cores
-            for (uint16_t core_id = 0; core_id < shard_->core_cnt_; ++core_id)
-            {
-                if (core_id == shard_->core_id_)
-                {
-                    continue;
-                }
-                shard_->Enqueue(shard_->LocalCoreId(), core_id, &req);
-            }
         }
 
-        if (req.IsDrained(shard_->core_id_))
+        if (req.IsDrained())
         {
             // scan is already finished on this core
-            req.SetFinish(shard_->core_id_);
+            req.SetFinish();
             return false;
         }
 
-        auto &pause_key_and_is_drained = req.PausePos(shard_->core_id_);
+        auto &pause_key_and_is_drained = req.PausePos();
 
         auto find_non_empty_slice =
             [this, &req, &deduce_iterator](const KeyT &search_key)
@@ -5568,8 +5548,7 @@ public:
             }
             else
             {
-                const TxKey &curr_start_tx_key =
-                    req.CurrentSliceKey(shard_->core_id_);
+                const TxKey &curr_start_tx_key = req.CurrentSliceKey();
                 const KeyT *curr_start_key = curr_start_tx_key.GetKey<KeyT>();
                 start_key = (*curr_start_key < search_key ? &search_key
                                                           : curr_start_key);
@@ -5594,7 +5573,7 @@ public:
             const KeyT *slice_end_key = nullptr;
             do
             {
-                store_slice = req.CurrentSlice(shard_->core_id_);
+                store_slice = req.CurrentSlice();
                 const TemplateStoreSlice<KeyT> *typed_slice =
                     static_cast<const TemplateStoreSlice<KeyT> *>(store_slice);
                 start_key =
@@ -5611,11 +5590,11 @@ public:
                 }
 
                 // The current slice is empty, try to find next slice.
-                req.MoveToNextSlice(shard_->core_id_);
+                req.MoveToNextSlice();
                 start_key = nullptr;
 
                 // Continue to handle the next slice if not the batch end
-            } while (!req.TheBatchEnd(shard_->core_id_));
+            } while (!req.TheBatchEnd());
 
             return {it, end_it, slice_end_key};
         };
@@ -5656,16 +5635,14 @@ public:
 
         // If reach to the batch end, it means there are no slices that need to
         // be scanned.
-        bool slice_pinned = req.TheBatchEnd(shard_->core_id_)
-                                ? false
-                                : req.IsSlicePinned(shard_->core_id_);
+        bool slice_pinned = req.TheBatchEnd() ? false : req.IsSlicePinned();
         // The following flag is used to mark the behavior of one slice.
         // Only need to export the key if the key is already persisted, this
         // will happen when the slice need to split, and should export all the
         // keys in this slice to get the subslice keys.
         bool export_persisted_key_only =
             !req.export_base_table_item_ && slice_pinned;
-        assert(key_it != slice_end_it || req.TheBatchEnd(shard_->core_id_));
+        assert(key_it != slice_end_it || req.TheBatchEnd());
 
         // 3. Loop to scan keys
         // DataSyncScanCc is running on TxProcessor thread. To avoid
@@ -5674,8 +5651,7 @@ public:
         for (size_t scan_cnt = 0;
              key_it != slice_end_it && key_it != slice_end_next_page_it &&
              scan_cnt < RangePartitionDataSyncScanCc::DataSyncScanBatchSize &&
-             req.accumulated_scan_cnt_.at(shard_->core_id_) <
-                 req.scan_batch_size_;
+             req.accumulated_scan_cnt_ < req.scan_batch_size_;
              ++scan_cnt)
         {
             const KeyT *key = key_it->first;
@@ -5708,8 +5684,8 @@ public:
                 {
                     // Reach to the end of current slice.
                     // Move to the next slice.
-                    req.MoveToNextSlice(shard_->core_id_);
-                    if (!req.TheBatchEnd(shard_->core_id_))
+                    req.MoveToNextSlice();
+                    if (!req.TheBatchEnd())
                     {
                         search_start_key = slice_end_key;
                         std::tie(key_it, slice_end_it, slice_end_key) =
@@ -5720,9 +5696,7 @@ public:
                         // If reach to the batch end, it means there are no
                         // slices that need to be scanned.
                         slice_pinned =
-                            req.TheBatchEnd(shard_->core_id_)
-                                ? false
-                                : req.IsSlicePinned(shard_->core_id_);
+                            req.TheBatchEnd() ? false : req.IsSlicePinned();
                         export_persisted_key_only =
                             !req.export_base_table_item_ && slice_pinned;
                     }
@@ -5776,20 +5750,19 @@ public:
                 auto export_result =
                     ExportForCkpt(cce,
                                   *key,
-                                  req.DataSyncVec(shard_->core_id_),
-                                  req.ArchiveVec(shard_->core_id_),
-                                  req.MoveBaseIdxVec(shard_->core_id_),
+                                  req.DataSyncVec(),
+                                  req.ArchiveVec(),
+                                  req.MoveBaseIdxVec(),
                                   req.data_sync_ts_,
                                   recycle_ts,
                                   shard_->EnableMvcc(),
-                                  req.accumulated_scan_cnt_[shard_->core_id_],
+                                  req.accumulated_scan_cnt_,
                                   req.export_base_table_item_,
                                   req.export_base_table_item_only_,
                                   export_persisted_key_only,
                                   flush_size);
 
-                req.accumulated_flush_data_size_[shard_->core_id_] +=
-                    flush_size;
+                req.accumulated_flush_data_size_ += flush_size;
 
                 if (export_result.second)
                 {
@@ -5806,8 +5779,8 @@ public:
             {
                 slice_pinned = false;
                 // Reach to the end of current slice. Move to the next slice.
-                req.MoveToNextSlice(shard_->core_id_);
-                if (!req.TheBatchEnd(shard_->core_id_))
+                req.MoveToNextSlice();
+                if (!req.TheBatchEnd())
                 {
                     search_start_key = slice_end_key;
                     std::tie(key_it, slice_end_it, slice_end_key) =
@@ -5817,9 +5790,8 @@ public:
 
                     // If reach to the batch end, it means there are no slices
                     // that need to be scanned.
-                    slice_pinned = req.TheBatchEnd(shard_->core_id_)
-                                       ? false
-                                       : req.IsSlicePinned(shard_->core_id_);
+                    slice_pinned =
+                        req.TheBatchEnd() ? false : req.IsSlicePinned();
                     export_persisted_key_only =
                         !req.export_base_table_item_ && slice_pinned;
                 }
@@ -5830,7 +5802,7 @@ public:
         // scan batch size, or reach to the end slice of the current batch
         // slices.
         assert((key_it != slice_end_it && key_it != slice_end_next_page_it) ||
-               req.TheBatchEnd(shard_->core_id_));
+               req.TheBatchEnd());
         // 4. Check whether the request is finished.
         TxKey next_pause_key;
         bool no_more_data =
@@ -5852,16 +5824,15 @@ public:
 
         if (is_scan_mem_full)
         {
-            req.scan_heap_is_full_[shard_->core_id_] = 1;
+            req.scan_heap_is_full_ = 1;
         }
 
         if (is_scan_mem_full || no_more_data ||
-            req.accumulated_scan_cnt_[shard_->core_id_] >=
-                req.scan_batch_size_ ||
-            req.TheBatchEnd(shard_->core_id_))
+            req.accumulated_scan_cnt_ >= req.scan_batch_size_ ||
+            req.TheBatchEnd())
         {
             // Request is finished
-            req.SetFinish(shard_->core_id_);
+            req.SetFinish();
             return false;
         }
 
@@ -8050,7 +8021,7 @@ public:
         const KeyT *const req_start_key = req.StartTxKey().GetKey<KeyT>();
         const KeyT *const req_end_key = req.EndTxKey().GetKey<KeyT>();
 
-        auto &paused_position = req.PausedPos(shard_->core_id_);
+        auto &paused_position = req.PausedPos();
 
         bool is_dirty = req.IsDirty();
 
@@ -8121,8 +8092,7 @@ public:
 
             slice_end_next_page_it = next_page_it(slice_end_it);
 
-            curr_slice_delta_size =
-                &(req.SliceDeltaSize(shard_->core_id_).back().second);
+            curr_slice_delta_size = &(req.SliceDeltaSize().back().second);
         }
 
         bool has_dml_since_ddl = false;
@@ -8324,8 +8294,7 @@ public:
 
                         slice_end_next_page_it = next_page_it(slice_end_it);
 
-                        auto &slice_delta_size =
-                            req.SliceDeltaSize(shard_->core_id_);
+                        auto &slice_delta_size = req.SliceDeltaSize();
                         slice_delta_size.emplace_back(slice->StartTxKey(), 0);
                         curr_slice_delta_size = &slice_delta_size.back().second;
                     }

--- a/tx_service/src/cc/local_cc_shards.cpp
+++ b/tx_service/src/cc/local_cc_shards.cpp
@@ -3871,7 +3871,6 @@ void LocalCcShards::DataSyncForRangePartition(
         data_sync_task->data_sync_ts_,
         ng_id,
         ng_term,
-        cc_shards_.size(),
         tx_number,
         start_tx_key,
         end_tx_key,
@@ -3879,10 +3878,10 @@ void LocalCcShards::DataSyncForRangePartition(
         is_dirty,
         schema_version);
 
-    for (size_t i = 0; i < cc_shards_.size(); i++)
-    {
-        EnqueueLowPriorityCcRequestToShard(i, &scan_delta_size_cc);
-    }
+    uint16_t dest_core = static_cast<uint16_t>(
+        (range_entry->GetRangeInfo()->PartitionId() & 0x3FF) % Count());
+    EnqueueLowPriorityCcRequestToShard(dest_core, &scan_delta_size_cc);
+
     scan_delta_size_cc.Wait();
 
     if (scan_delta_size_cc.IsError())
@@ -3905,14 +3904,10 @@ void LocalCcShards::DataSyncForRangePartition(
         return;
     }
 
-    for (size_t i = 0; i < cc_shards_.size(); ++i)
+    auto &delta_size = scan_delta_size_cc.SliceDeltaSize();
+    for (auto &delta : delta_size)
     {
-        auto &delta_size = scan_delta_size_cc.SliceDeltaSize(i);
-        for (size_t j = 0; j < delta_size.size(); ++j)
-        {
-            slices_delta_size[std::move(delta_size[j].first)] +=
-                delta_size[j].second;
-        }
+        slices_delta_size[std::move(delta.first)] += delta.second;
     }
 
     if (!export_base_table_items && slices_delta_size.size() == 0)
@@ -4007,40 +4002,6 @@ void LocalCcShards::DataSyncForRangePartition(
     }
 
     // 3. Scan records.
-    // The data sync worker thread is the owner of those vectors.
-
-    // Sort output vectors in key sorting order.
-    auto key_greater = [](const std::pair<TxKey, int32_t> &r1,
-                          const std::pair<TxKey, int32_t> &r2) -> bool
-    { return r2.first < r1.first; };
-    auto rec_greater = [](const FlushRecord &r1, const FlushRecord &r2) -> bool
-    { return r2.Key() < r1.Key(); };
-
-    std::vector<std::vector<FlushRecord>> data_sync_vecs;
-    std::vector<std::vector<FlushRecord>> archive_vecs;
-    std::vector<std::vector<std::pair<TxKey, int32_t>>> mv_base_vecs;
-
-    // Add an extra vector as a remaining vector to store the remaining keys
-    // of the current batch of FlushRecords.
-    // DataSyncScanCc request is executed in parallel on all cores. For a
-    // batch of scan results, the end keys among the cores are different.
-    // In order to ensure the accuracy of the calculated subslice keys, for
-    // this batch of FlushRecords, the minimum end key of all cores's scan
-    // result is obtained, and the FlushRecords after this key is placed in
-    // this remaining vector, which will be merged with the next batch of
-    // FlushRecords. For example: core1[10,15,20], core2[8,16,24,32], only
-    // [8,10,15,16,20] will be flushed into data store in this round，and
-    // the remaining vector stores [24,32]
-    for (size_t i = 0; i < (cc_shards_.size() + 1); ++i)
-    {
-        data_sync_vecs.emplace_back();
-        data_sync_vecs.back().reserve(DATA_SYNC_SCAN_BATCH_SIZE);
-        archive_vecs.emplace_back();
-        archive_vecs.back().reserve(DATA_SYNC_SCAN_BATCH_SIZE);
-        mv_base_vecs.emplace_back();
-        mv_base_vecs.back().reserve(DATA_SYNC_SCAN_BATCH_SIZE);
-    }
-
     // Scan the FlushRecords.
     // Paused position
     UpdateSliceStatus update_slice_status;
@@ -4073,7 +4034,6 @@ void LocalCcShards::DataSyncForRangePartition(
                                          data_sync_task->data_sync_ts_,
                                          ng_id,
                                          ng_term,
-                                         cc_shards_.size(),
                                          DATA_SYNC_SCAN_BATCH_SIZE,
                                          tx_number,
                                          &start_tx_key,
@@ -4095,12 +4055,7 @@ void LocalCcShards::DataSyncForRangePartition(
 
     while (!scan_data_drained)
     {
-        uint32_t core_rand = butil::fast_rand();
-        // The scan slice request is dispatched to the first core. The first
-        // core tries to pin the slice if necessary and if succeeds, further
-        // dispatches the request to remaining cores for parallel scans.
-        EnqueueLowPriorityCcRequestToShard(core_rand % cc_shards_.size(),
-                                           &scan_cc);
+        EnqueueLowPriorityCcRequestToShard(dest_core, &scan_cc);
         scan_cc.Wait();
 
         if (scan_cc.IsError())
@@ -4119,61 +4074,51 @@ void LocalCcShards::DataSyncForRangePartition(
         else
         {
             scan_data_drained = true;
-            assert(scan_cc.accumulated_flush_data_size_.size() ==
-                   cc_shards_.size());
-            uint64_t flush_data_size = 0;
-            for (size_t flush_data_size_per_core :
-                 scan_cc.accumulated_flush_data_size_)
-            {
-                flush_data_size += flush_data_size_per_core;
-            }
+            uint64_t flush_data_size = scan_cc.accumulated_flush_data_size_;
 
             // The cost of FlushRecord also needs to be considered.
-            for (size_t i = 0; i < cc_shards_.size(); ++i)
-            {
 #ifdef WITH_JEMALLOC
-                flush_data_size +=
-                    (scan_cc.DataSyncVec(i).size() * sizeof(FlushRecord) +
-                     scan_cc.ArchiveVec(i).size() * sizeof(FlushRecord) +
-                     scan_cc.MoveBaseIdxVec(i).size() *
-                         sizeof(std::pair<TxKey, int32_t>));
+            flush_data_size +=
+                (scan_cc.DataSyncVec().size() * sizeof(FlushRecord) +
+                 scan_cc.ArchiveVec().size() * sizeof(FlushRecord) +
+                 scan_cc.MoveBaseIdxVec().size() *
+                     sizeof(std::pair<TxKey, int32_t>));
 #else
-                // Check if vectors are empty before calling malloc_usable_size
-                // to avoid SEGV on nullptr or invalid pointers.
-                // Use malloc_usable_size when ASan is enabled (vectors may be
-                // allocated by ASan's allocator), otherwise use
-                // mi_malloc_usable_size for mimalloc-allocated memory.
-                auto &data_sync_vec_ref = scan_cc.DataSyncVec(i);
-                auto &archive_vec_ref = scan_cc.ArchiveVec(i);
-                auto &move_base_idx_vec_ref = scan_cc.MoveBaseIdxVec(i);
+            // Check if vectors are empty before calling malloc_usable_size
+            // to avoid SEGV on nullptr or invalid pointers.
+            // Use malloc_usable_size when ASan is enabled (vectors may be
+            // allocated by ASan's allocator), otherwise use
+            // mi_malloc_usable_size for mimalloc-allocated memory.
+            auto &data_sync_vec_ref = scan_cc.DataSyncVec();
+            auto &archive_vec_ref = scan_cc.ArchiveVec();
+            auto &move_base_idx_vec_ref = scan_cc.MoveBaseIdxVec();
 
 #ifdef __SANITIZE_ADDRESS__
-                // When ASan is enabled, use standard malloc_usable_size
-                flush_data_size +=
-                    (data_sync_vec_ref.empty()
-                         ? 0
-                         : malloc_usable_size(data_sync_vec_ref.data())) +
-                    (archive_vec_ref.empty()
-                         ? 0
-                         : malloc_usable_size(archive_vec_ref.data())) +
-                    (move_base_idx_vec_ref.empty()
-                         ? 0
-                         : malloc_usable_size(move_base_idx_vec_ref.data()));
+            // When ASan is enabled, use standard malloc_usable_size
+            flush_data_size +=
+                (data_sync_vec_ref.empty()
+                     ? 0
+                     : malloc_usable_size(data_sync_vec_ref.data())) +
+                (archive_vec_ref.empty()
+                     ? 0
+                     : malloc_usable_size(archive_vec_ref.data())) +
+                (move_base_idx_vec_ref.empty()
+                     ? 0
+                     : malloc_usable_size(move_base_idx_vec_ref.data()));
 #else
-                // When ASan is not enabled, use mimalloc's API
-                flush_data_size +=
-                    (data_sync_vec_ref.empty()
-                         ? 0
-                         : mi_malloc_usable_size(data_sync_vec_ref.data())) +
-                    (archive_vec_ref.empty()
-                         ? 0
-                         : mi_malloc_usable_size(archive_vec_ref.data())) +
-                    (move_base_idx_vec_ref.empty()
-                         ? 0
-                         : mi_malloc_usable_size(move_base_idx_vec_ref.data()));
+            // When ASan is not enabled, use mimalloc's API
+            flush_data_size +=
+                (data_sync_vec_ref.empty()
+                     ? 0
+                     : mi_malloc_usable_size(data_sync_vec_ref.data())) +
+                (archive_vec_ref.empty()
+                     ? 0
+                     : mi_malloc_usable_size(archive_vec_ref.data())) +
+                (move_base_idx_vec_ref.empty()
+                     ? 0
+                     : mi_malloc_usable_size(move_base_idx_vec_ref.data()));
 #endif
 #endif
-            }
 
             // This thread will wait in AllocatePendingFlushDataMemQuota if
             // quota is not available
@@ -4189,53 +4134,6 @@ void LocalCcShards::DataSyncForRangePartition(
                        << " of range: " << range_id
                        << " for table: " << table_name.StringView();
 
-            // The minimum end key of this batch data between all the cores.
-            TxKey min_scanned_end_key =
-                GetCatalogFactory(table_name.Engine())->PositiveInfKey();
-            for (size_t i = 0; i < cc_shards_.size(); ++i)
-            {
-                for (size_t j = 0; j < scan_cc.accumulated_scan_cnt_[i]; ++j)
-                {
-                    auto &rec = scan_cc.DataSyncVec(i)[j];
-                    // Clone key
-                    data_sync_vecs[i].emplace_back(
-                        rec.Key().Clone(),
-                        rec.ReleaseVersionedPayload(),
-                        rec.payload_status_,
-                        rec.commit_ts_,
-                        rec.cce_,
-                        rec.post_flush_size_,
-                        range_id);
-                }
-
-                // Get the minimum end key.
-                if (!data_sync_vecs[i].empty() &&
-                    data_sync_vecs[i].back().Key() < min_scanned_end_key)
-                {
-                    min_scanned_end_key = data_sync_vecs[i].back().Key();
-                }
-
-                for (size_t j = 0; j < scan_cc.ArchiveVec(i).size(); ++j)
-                {
-                    auto &rec = scan_cc.ArchiveVec(i)[j];
-                    rec.SetKey(data_sync_vecs[i][rec.GetKeyIndex()].Key());
-                }
-
-                for (size_t j = 0; j < scan_cc.MoveBaseIdxVec(i).size(); ++j)
-                {
-                    size_t key_idx = scan_cc.MoveBaseIdxVec(i)[j];
-                    TxKey key_raw = data_sync_vecs[i][key_idx].Key();
-                    mv_base_vecs[i].emplace_back(std::move(key_raw), range_id);
-                }
-
-                // Move the bucket into the tank
-                std::move(scan_cc.ArchiveVec(i).begin(),
-                          scan_cc.ArchiveVec(i).end(),
-                          std::back_inserter(archive_vecs.at(i)));
-
-                scan_data_drained = scan_cc.IsDrained(i) && scan_data_drained;
-            }
-
             std::unique_ptr<std::vector<FlushRecord>> data_sync_vec =
                 std::make_unique<std::vector<FlushRecord>>();
             std::unique_ptr<std::vector<FlushRecord>> archive_vec =
@@ -4244,90 +4142,46 @@ void LocalCcShards::DataSyncForRangePartition(
                 mv_base_vec =
                     std::make_unique<std::vector<std::pair<TxKey, int32_t>>>();
 
-            MergeSortedVectors(
-                std::move(mv_base_vecs), *mv_base_vec, key_greater, false);
+            data_sync_vec->reserve(DATA_SYNC_SCAN_BATCH_SIZE);
+            archive_vec->reserve(DATA_SYNC_SCAN_BATCH_SIZE);
+            mv_base_vec->reserve(DATA_SYNC_SCAN_BATCH_SIZE);
 
-            // Set the ckpt_ts_ of a cc entry repeatedly, which might cause the
-            // ccentry become invalid in between. But, there should be no
-            // duplication here. we don't need to remove duplicate record.
-            MergeSortedVectors(
-                std::move(data_sync_vecs), *data_sync_vec, rec_greater, false);
-
-            // For archive vec we don't need to worry about duplicate causing
-            // issue since we're not visiting their cc entry. Also we cannot
-            // rely on key compare to dedup archive vec since a key could have
-            // multiple version of archive versions.
-            MergeSortedVectors(
-                std::move(archive_vecs), *archive_vec, rec_greater, false);
-
-            data_sync_vecs.resize(cc_shards_.size() + 1);
-            archive_vecs.resize(cc_shards_.size() + 1);
-            mv_base_vecs.resize(cc_shards_.size() + 1);
-            for (size_t i = 0; i <= cc_shards_.size(); ++i)
+            for (size_t j = 0; j < scan_cc.accumulated_scan_cnt_; ++j)
             {
-                data_sync_vecs.at(i).clear();
-                archive_vecs.at(i).clear();
-                mv_base_vecs.at(i).clear();
+                auto &rec = scan_cc.DataSyncVec()[j];
+                // Clone key
+                data_sync_vec->emplace_back(rec.Key().Clone(),
+                                            rec.ReleaseVersionedPayload(),
+                                            rec.payload_status_,
+                                            rec.commit_ts_,
+                                            rec.cce_,
+                                            rec.post_flush_size_,
+                                            range_id);
             }
 
-            size_t data_sync_vec_size = data_sync_vec->size();
-            // Fix the vector of FlushRecords.
-            if (!scan_data_drained)
+            for (size_t j = 0; j < scan_cc.ArchiveVec().size(); ++j)
             {
-                // Only flush the keys that are not greater than the
-                // min_scanned_end_key
-                auto iter = std::upper_bound(
-                    data_sync_vec->begin(),
-                    data_sync_vec->end(),
-                    min_scanned_end_key,
-                    [](const TxKey &key, const FlushRecord &rec)
-                    { return key < rec.Key(); });
-
-                auto &remaining_vec = data_sync_vecs[cc_shards_.size()];
-                remaining_vec.clear();
-                remaining_vec.insert(
-                    remaining_vec.begin(),
-                    std::make_move_iterator(iter),
-                    std::make_move_iterator(data_sync_vec->end()));
-                data_sync_vec->erase(iter, data_sync_vec->end());
-
-                // archive vector
-                auto archive_iter = std::upper_bound(
-                    archive_vec->begin(),
-                    archive_vec->end(),
-                    min_scanned_end_key,
-                    [](const TxKey &key, const FlushRecord &rec)
-                    { return key < rec.Key(); });
-                auto &archive_remaining_vec = archive_vecs[cc_shards_.size()];
-                archive_remaining_vec.clear();
-                archive_remaining_vec.insert(
-                    archive_remaining_vec.begin(),
-                    std::make_move_iterator(archive_iter),
-                    std::make_move_iterator(archive_vec->end()));
-                archive_vec->erase(archive_iter, archive_vec->end());
-
-                // mv base vector
-                auto mv_base_iter = std::upper_bound(
-                    mv_base_vec->begin(),
-                    mv_base_vec->end(),
-                    min_scanned_end_key,
-                    [](const TxKey &t_key,
-                       const std::pair<TxKey, int32_t> &key_and_partition_id)
-                    { return t_key < key_and_partition_id.first; });
-                auto &mv_base_remaining_vec = mv_base_vecs[cc_shards_.size()];
-                mv_base_remaining_vec.clear();
-                mv_base_remaining_vec.insert(
-                    mv_base_remaining_vec.begin(),
-                    std::make_move_iterator(mv_base_iter),
-                    std::make_move_iterator(mv_base_vec->end()));
-                mv_base_vec->erase(mv_base_iter, mv_base_vec->end());
+                auto &rec = scan_cc.ArchiveVec()[j];
+                rec.SetKey(data_sync_vec->at(rec.GetKeyIndex()).Key());
             }
+
+            for (size_t j = 0; j < scan_cc.MoveBaseIdxVec().size(); ++j)
+            {
+                size_t key_idx = scan_cc.MoveBaseIdxVec()[j];
+                TxKey key_raw = data_sync_vec->at(key_idx).Key();
+                mv_base_vec->emplace_back(std::move(key_raw), range_id);
+            }
+
+            // Move the bucket into the tank
+            std::move(scan_cc.ArchiveVec().begin(),
+                      scan_cc.ArchiveVec().end(),
+                      std::back_inserter(*archive_vec));
+
+            scan_data_drained = scan_cc.IsDrained();
 
             if (data_sync_vec->empty())
             {
-                LOG(WARNING) << "data_sync_vec becomes empty after erase, old "
-                                "size of data_sync_vec_size: "
-                             << data_sync_vec_size;
+                LOG(WARNING) << "data_sync_vec is empty.";
                 // Reset
                 scan_cc.Reset();
                 // Return the quota to flush data memory usage pool since the
@@ -4403,20 +4257,17 @@ void LocalCcShards::DataSyncForRangePartition(
                                                  table_schema,
                                                  flush_data_size));
 
-            for (size_t i = 0; i < cc_shards_.size(); ++i)
+            if (scan_cc.scan_heap_is_full_ == 1)
             {
-                if (scan_cc.scan_heap_is_full_[i] == 1)
-                {
-                    // Clear the FlushRecords' memory of scan cc since the
-                    // DataSyncScan heap is full.
-                    auto &data_sync_vec_ref = scan_cc.DataSyncVec(i);
-                    auto &archive_vec_ref = scan_cc.ArchiveVec(i);
-                    ReleaseDataSyncScanHeapCc release_scan_heap_cc(
-                        &data_sync_vec_ref, &archive_vec_ref);
-                    EnqueueLowPriorityCcRequestToShard(i,
-                                                       &release_scan_heap_cc);
-                    release_scan_heap_cc.Wait();
-                }
+                // Clear the FlushRecords' memory of scan cc since the
+                // DataSyncScan heap is full.
+                auto &data_sync_vec_ref = scan_cc.DataSyncVec();
+                auto &archive_vec_ref = scan_cc.ArchiveVec();
+                ReleaseDataSyncScanHeapCc release_scan_heap_cc(
+                    &data_sync_vec_ref, &archive_vec_ref);
+                EnqueueLowPriorityCcRequestToShard(dest_core,
+                                                   &release_scan_heap_cc);
+                release_scan_heap_cc.Wait();
             }
             // Reset
             scan_cc.Reset();
@@ -4431,19 +4282,12 @@ void LocalCcShards::DataSyncForRangePartition(
     }
 
     // Release scan heap memory after scan finish.
-    std::list<ReleaseDataSyncScanHeapCc> req_vec;
-    for (size_t core_idx = 0; core_idx < Count(); ++core_idx)
-    {
-        auto &data_sync_vec_ref = scan_cc.DataSyncVec(core_idx);
-        auto &archive_vec_ref = scan_cc.ArchiveVec(core_idx);
-        req_vec.emplace_back(&data_sync_vec_ref, &archive_vec_ref);
-        EnqueueLowPriorityCcRequestToShard(core_idx, &req_vec.back());
-    }
-    while (req_vec.size() > 0)
-    {
-        req_vec.back().Wait();
-        req_vec.pop_back();
-    }
+    auto &data_sync_vec_ref = scan_cc.DataSyncVec();
+    auto &archive_vec_ref = scan_cc.ArchiveVec();
+    ReleaseDataSyncScanHeapCc release_scan_heap_cc(&data_sync_vec_ref,
+                                                   &archive_vec_ref);
+    EnqueueLowPriorityCcRequestToShard(dest_core, &release_scan_heap_cc);
+    release_scan_heap_cc.Wait();
 
     PostProcessRangePartitionDataSyncTask(std::move(data_sync_task),
                                           data_sync_txm,
@@ -5874,7 +5718,9 @@ void LocalCcShards::FlushData(std::unique_lock<std::mutex> &flush_worker_lk)
                         size_t key_core_idx = 0;
                         if (!table_name.IsHashPartitioned())
                         {
-                            key_core_idx = (rec.Key().Hash() & 0x3FF) % Count();
+                            int32_t range_id = entry->data_sync_task_->id_;
+                            key_core_idx = static_cast<size_t>(
+                                (range_id & 0x3FF) % Count());
                         }
                         else
                         {


### PR DESCRIPTION
1. Update the structure definitions and related processing procedures of DataSyncScanCc and ScanSliceDeltaSizeCc, as well as the DataSync processing procedure, to adapt to the new key sharding logic.

2. Update key shard code for UpdateCkptTs request.