### PR TITLE
Adapt cache sender with new keysharding

### DIFF
--- a/tx_service/include/cc/cc_request.h
+++ b/tx_service/include/cc/cc_request.h
@@ -8270,25 +8270,19 @@ public:
     void Reset(const TableName &table_name,
                txservice::NodeGroupId ng_id,
                int64_t &ng_term,
-               size_t core_cnt,
                const WriteEntryTuple &entry_tuple,
                std::shared_ptr<SliceUpdation> slice_info)
     {
         table_name_ = &table_name;
         node_group_id_ = ng_id;
         node_group_term_ = &ng_term;
-        core_cnt_ = core_cnt;
-        partitioned_slice_data_.resize(core_cnt);
-        next_idxs_.resize(core_cnt);
-        for (size_t i = 0; i < core_cnt; i++)
-        {
-            next_idxs_[i] = 0;
-        }
+        slice_data_.clear();
+        next_idx_ = 0;
 
         entry_tuples_ = &entry_tuple;
         slices_info_ = slice_info;
 
-        unfinished_cnt_ = core_cnt;
+        finished_ = false;
         err_code_ = CcErrorCode::NO_ERROR;
     }
 
@@ -8354,14 +8348,12 @@ public:
     std::pair<bool, std::shared_ptr<SliceUpdation>> SetFinish()
     {
         std::unique_lock<bthread::Mutex> req_lk(req_mux_);
-        if (--unfinished_cnt_ == 0)
-        {
-            // Make a copy of slices_info_ to avoid race condition.
-            std::shared_ptr<SliceUpdation> slices_info = slices_info_;
-            req_cv_.notify_one();
-            return {true, std::move(slices_info)};
-        }
-        return {false, nullptr};
+        finished_ = true;
+
+        // Make a copy of slices_info_ to avoid race condition.
+        std::shared_ptr<SliceUpdation> slices_info = slices_info_;
+        req_cv_.notify_one();
+        return {true, std::move(slices_info)};
     }
 
     bool SetError(CcErrorCode err_code)
@@ -8371,13 +8363,9 @@ public:
         {
             err_code_ = err_code;
         }
-        if (--unfinished_cnt_ == 0)
-        {
-            req_cv_.notify_one();
-
-            return true;
-        }
-        return false;
+        finished_ = true;
+        req_cv_.notify_one();
+        return true;
     }
 
     void AbortCcRequest(CcErrorCode err_code) override
@@ -8394,7 +8382,7 @@ public:
     void Wait()
     {
         std::unique_lock<bthread::Mutex> lk(req_mux_);
-        while (unfinished_cnt_ != 0)
+        while (!finished_)
         {
             req_cv_.wait(lk);
         }
@@ -8457,7 +8445,7 @@ public:
     }
     void SetParsed()
     {
-        parsed_.store(true, std::memory_order_release);
+        parsed_ = true;
     }
 
     void AddDataItem(TxKey key,
@@ -8465,34 +8453,26 @@ public:
                      uint64_t version_ts,
                      bool is_deleted)
     {
-        size_t hash = key.Hash();
-        // Uses the lower 10 bits of the hash code to shard the key across
-        // CPU cores at this node.
-        uint16_t core_code = hash & 0x3FF;
-        uint16_t core_id = core_code % core_cnt_;
-
-        partitioned_slice_data_[core_id].emplace_back(
+        slice_data_.emplace_back(
             std::move(key), std::move(record), version_ts, is_deleted);
     }
 
-    size_t NextIndex(size_t core_idx) const
+    size_t NextIndex() const
     {
-        size_t next_idx = next_idxs_[core_idx];
-        assert(next_idx <= partitioned_slice_data_[core_idx].size());
-        return next_idx;
+        assert(next_idx_ <= slice_data_.size());
+        return next_idx_;
     }
 
-    void SetNextIndex(size_t core_idx, size_t index)
+    void SetNextIndex(size_t index)
     {
-        assert(index <= partitioned_slice_data_[core_idx].size());
-        next_idxs_[core_idx] = index;
+        assert(index <= slice_data_.size());
+        next_idx_ = index;
     }
 
     // Notice: these data items belong to multi slices.
-    std::deque<SliceDataItem> &SliceData(uint16_t core_id)
+    std::deque<SliceDataItem> &SliceData()
     {
-        assert(core_id < partitioned_slice_data_.size());
-        return partitioned_slice_data_[core_id];
+        return slice_data_;
     }
 
     bool AbortIfOom() const override
@@ -8501,7 +8481,6 @@ public:
     }
 
 private:
-    uint16_t core_cnt_;
     const TableName *table_name_{nullptr};
     uint32_t node_group_id_{0};
     int64_t *node_group_term_{nullptr};
@@ -8514,17 +8493,16 @@ private:
     // key offset, record offset, ts offset, record status offset
     // when parse items
     std::tuple<size_t, size_t, size_t, size_t> parse_offset_{0, 0, 0, 0};
-    // parse items on one core, then put the req to other cores.
-    std::atomic_bool parsed_{false};
+    bool parsed_{false};
 
-    std::vector<std::deque<SliceDataItem>> partitioned_slice_data_;
+    std::deque<SliceDataItem> slice_data_;
     // pause position when emplace keys into ccmap in batches
-    std::vector<size_t> next_idxs_;
+    size_t next_idx_;
 
     bthread::Mutex req_mux_{};
     bthread::ConditionVariable req_cv_{};
     // This two variables may be accessed by multi-cores.
-    size_t unfinished_cnt_{0};
+    bool finished_{false};
     CcErrorCode err_code_{CcErrorCode::NO_ERROR};
 };
 

--- a/tx_service/include/cc/local_cc_shards.h
+++ b/tx_service/include/cc/local_cc_shards.h
@@ -2120,7 +2120,6 @@ private:
                                    .GetLocalCcShards()
                                    ->GetRangeOwner(new_range_id_, ng_id_)
                                    ->BucketOwner();
-            assert(new_range_owner_ != ng_id_);
 
             dest_node_id_ = Sharder::Instance().LeaderNodeId(new_range_owner_);
             channel_ =

--- a/tx_service/include/cc/template_cc_map.h
+++ b/tx_service/include/cc/template_cc_map.h
@@ -7902,22 +7902,12 @@ public:
             {
                 // Parsed all records
                 req.SetParsed();
-
-                // Emplace key on all cores
-                for (size_t core = 0; core < shard_->core_cnt_; ++core)
-                {
-                    if (core != shard_->core_id_)
-                    {
-                        shard_->Enqueue(shard_->core_id_, core, &req);
-                    }
-                }
             }
-
         }  // end-parsed
 
-        std::deque<SliceDataItem> &slice_vec = req.SliceData(shard_->core_id_);
+        std::deque<SliceDataItem> &slice_vec = req.SliceData();
 
-        size_t index = req.NextIndex(shard_->core_id_);
+        size_t index = req.NextIndex();
         size_t last_index = std::min(
             index + UploadBatchSlicesCc::MaxEmplaceBatchSize, slice_vec.size());
 
@@ -7953,7 +7943,7 @@ public:
         else
         {
             index = last_index;
-            req.SetNextIndex(shard_->core_id_, index);
+            req.SetNextIndex(index);
             shard_->Enqueue(shard_->LocalCoreId(), &req);
         }
         return false;

--- a/tx_service/src/cc/local_cc_shards.cpp
+++ b/tx_service/src/cc/local_cc_shards.cpp
@@ -4053,8 +4053,11 @@ void LocalCcShards::DataSyncForRangePartition(
             GetRangeOwner(old_range_id, ng_id)->BucketOwner();
         NodeGroupId new_range_owner =
             GetRangeOwner(range_id, ng_id)->BucketOwner();
+        uint16_t old_range_owner_shard = (old_range_id & 0x3FF) % Count();
+        uint16_t new_range_owner_shard = (range_id & 0x3FF) % Count();
 
-        need_send_range_cache = new_range_owner != old_range_owner;
+        need_send_range_cache = new_range_owner != old_range_owner ||
+                                new_range_owner_shard != old_range_owner_shard;
         if (need_send_range_cache)
         {
             range_cache_sender = std::make_unique<RangeCacheSender>(
@@ -6967,79 +6970,84 @@ void LocalCcShards::RangeCacheSender::SendRangeCacheRequest(
 
     // 1- upload dirty range slices info (with PartiallyCached)
     int64_t ng_term = INIT_TERM;
-    remote::CcRpcService_Stub stub(channel_.get());
-
-    brpc::Controller cntl;
-    cntl.set_timeout_ms(10000);
-    cntl.set_write_to_socket_in_background(true);
-    // cntl.ignore_eovercrowded(true);
-    remote::UploadRangeSlicesRequest req;
-    remote::UploadRangeSlicesResponse resp;
-
-    req.set_node_group_id(new_range_owner_);
-    req.set_ng_term(ng_term);
-    req.set_table_name_str(table_name_.String());
-    req.set_table_engine(
-        remote::ToRemoteType::ConvertTableEngine(table_name_.Engine()));
-    req.set_old_partition_id(old_range_id_);
-    req.set_version_ts(version_ts_);
-    req.set_new_partition_id(new_range_id_);
-    req.set_new_slices_num(slices_vec_.size());
-    std::string *keys_str = req.mutable_new_slices_keys();
-    std::string *sizes_str = req.mutable_new_slices_sizes();
-    std::string *status_str = req.mutable_new_slices_status();
-    for (const StoreSlice *slice : slices_vec_)
+    if (new_range_owner_ != ng_id_)
     {
-        // key
-        TxKey slice_key = slice->StartTxKey();
-        slice_key.Serialize(*keys_str);
-        // size
-        // If post ckpt size of the slice is UINT64_MAX, it means that there is
-        // no item need to be ckpt in this slice, so should use the current size
-        // of the slice.
-        uint32_t slice_size =
-            (slice->PostCkptSize() == UINT64_MAX ? slice->Size()
-                                                 : slice->PostCkptSize());
-        const char *slice_size_ptr =
-            reinterpret_cast<const char *>(&slice_size);
-        sizes_str->append(slice_size_ptr, sizeof(slice_size));
-        // status
-        int8_t slice_status = static_cast<int8_t>(SliceStatus::PartiallyCached);
-        const char *slice_status_ptr =
-            reinterpret_cast<const char *>(&slice_status);
-        status_str->append(slice_status_ptr, sizeof(slice_status));
-    }
-    req.set_has_dml_since_ddl(store_range_->HasDmlSinceDdl());
-    stub.UploadRangeSlices(&cntl, &req, &resp, nullptr);
+        remote::CcRpcService_Stub stub(channel_.get());
 
-    if (cntl.Failed())
-    {
-        LOG(WARNING) << "SendRangeCacheRequest: Fail to upload dirty range "
-                        "slices RPC ng#"
-                     << new_range_owner_ << ". Error code: " << cntl.ErrorCode()
-                     << ". Msg: " << cntl.ErrorText();
-        return;
-    }
+        brpc::Controller cntl;
+        cntl.set_timeout_ms(10000);
+        cntl.set_write_to_socket_in_background(true);
+        // cntl.ignore_eovercrowded(true);
+        remote::UploadRangeSlicesRequest req;
+        remote::UploadRangeSlicesResponse resp;
 
-    if (remote::ToLocalType::ConvertCcErrorCode(resp.error_code()) !=
-        CcErrorCode::NO_ERROR)
-    {
-        LOG(WARNING) << "SendRangeCacheRequest: New owner ng#"
-                     << new_range_owner_
-                     << " reject to receive dirty range data";
-        return;
-    }
+        req.set_node_group_id(new_range_owner_);
+        req.set_ng_term(ng_term);
+        req.set_table_name_str(table_name_.String());
+        req.set_table_engine(
+            remote::ToRemoteType::ConvertTableEngine(table_name_.Engine()));
+        req.set_old_partition_id(old_range_id_);
+        req.set_version_ts(version_ts_);
+        req.set_new_partition_id(new_range_id_);
+        req.set_new_slices_num(slices_vec_.size());
+        std::string *keys_str = req.mutable_new_slices_keys();
+        std::string *sizes_str = req.mutable_new_slices_sizes();
+        std::string *status_str = req.mutable_new_slices_status();
+        for (const StoreSlice *slice : slices_vec_)
+        {
+            // key
+            TxKey slice_key = slice->StartTxKey();
+            slice_key.Serialize(*keys_str);
+            // size
+            // If post ckpt size of the slice is UINT64_MAX, it means that there
+            // is no item need to be ckpt in this slice, so should use the
+            // current size of the slice.
+            uint32_t slice_size =
+                (slice->PostCkptSize() == UINT64_MAX ? slice->Size()
+                                                     : slice->PostCkptSize());
+            const char *slice_size_ptr =
+                reinterpret_cast<const char *>(&slice_size);
+            sizes_str->append(slice_size_ptr, sizeof(slice_size));
+            // status
+            int8_t slice_status =
+                static_cast<int8_t>(SliceStatus::PartiallyCached);
+            const char *slice_status_ptr =
+                reinterpret_cast<const char *>(&slice_status);
+            status_str->append(slice_status_ptr, sizeof(slice_status));
+        }
+        req.set_has_dml_since_ddl(store_range_->HasDmlSinceDdl());
+        stub.UploadRangeSlices(&cntl, &req, &resp, nullptr);
 
-    ng_term = resp.ng_term();
-    LOG(INFO) << "SendRangeCacheRequest: Uploaded new range slices info to "
-                 "future owner, range#"
-              << old_range_id_ << ", new_range#" << new_range_id_;
+        if (cntl.Failed())
+        {
+            LOG(WARNING) << "SendRangeCacheRequest: Fail to upload dirty range "
+                            "slices RPC ng#"
+                         << new_range_owner_
+                         << ". Error code: " << cntl.ErrorCode()
+                         << ". Msg: " << cntl.ErrorText();
+            return;
+        }
+
+        if (remote::ToLocalType::ConvertCcErrorCode(resp.error_code()) !=
+            CcErrorCode::NO_ERROR)
+        {
+            LOG(WARNING) << "SendRangeCacheRequest: New owner ng#"
+                         << new_range_owner_
+                         << " reject to receive dirty range data";
+            return;
+        }
+
+        ng_term = resp.ng_term();
+        LOG(INFO) << "SendRangeCacheRequest: Uploaded new range slices info to "
+                     "future owner, range#"
+                  << old_range_id_ << ", new_range#" << new_range_id_;
+    }
 
     // 2- upload records belongs to dirty range
     assert(closure_vec_->size() > 0);
     LOG(INFO) << "SendRangeCacheRequest: Sending range data, old_range_id: "
               << old_range_id_ << ", to upload " << closure_vec_->size()
-              << " batches to ng#" << new_range_owner_;
+              << " batches to ng#" << new_range_owner_ << " from ng#" << ng_id_;
 
     uint32_t sender_cnt = 5;
     auto closures_idx = std::make_shared<std::atomic_uint64_t>(sender_cnt);
@@ -7059,6 +7067,8 @@ void LocalCcShards::RangeCacheSender::SendRangeCacheRequest(
                     size_t vec_size = vec.size();
                     size_t end_idx = std::min(begin_idx + 5, vec_size);
                     bool rejected = false;
+                    int64_t term =
+                        ng_term == INIT_TERM ? dest_ng_term : ng_term;
                     while (begin_idx < end_idx)
                     {
                         std::unique_ptr<UploadBatchSlicesClosure> closure(
@@ -7071,6 +7081,7 @@ void LocalCcShards::RangeCacheSender::SendRangeCacheRequest(
                             end_idx = std::min(begin_idx + 5, vec_size);
                         }
 
+                        rejected = rejected || term != dest_ng_term;
                         if (rejected)
                         {
                             // Must continue to delete left closures in
@@ -7085,7 +7096,7 @@ void LocalCcShards::RangeCacheSender::SendRangeCacheRequest(
                         cntl_ptr->set_timeout_ms(closure->TimeoutValue());
                         // Fix the term
                         closure->UploadBatchRequest()->set_node_group_term(
-                            ng_term);
+                            term);
                         stub.UploadBatchSlices(cntl_ptr,
                                                closure->UploadBatchRequest(),
                                                closure->UploadBatchResponse(),
@@ -7106,6 +7117,7 @@ void LocalCcShards::RangeCacheSender::SendRangeCacheRequest(
                                        << closure->NodeId()
                                        << " is reject for no free memory";
                         }
+                        term = resp->ng_term();
                     }
 
                     LOG(INFO) << "Old_Range#" << range_id

--- a/tx_service/src/remote/cc_node_service.cpp
+++ b/tx_service/src/remote/cc_node_service.cpp
@@ -1383,30 +1383,32 @@ void CcNodeService::UploadBatchSlices(
     }
 
     UploadBatchSlicesCc req;
-    req.Reset(
-        table_name, ng_id, ng_term, core_cnt, write_entry_tuple, slices_info);
+    req.Reset(table_name, ng_id, ng_term, write_entry_tuple, slices_info);
 
-    // Select a core randomly to parse items. After parsed, this core will push
-    // the request to other cores to emplace keys.
-    uint16_t rand_core = std::rand() % core_cnt;
-    cc_shards->EnqueueToCcShard(rand_core, &req);
+    uint16_t dest_core =
+        static_cast<uint16_t>((slices_info->new_range_ & 0x3FF) % core_cnt);
+    cc_shards->EnqueueToCcShard(dest_core, &req);
     req.Wait();
 
     CcErrorCode err = CcErrorCode::NO_ERROR;
     if (req.ErrorCode() != CcErrorCode::NO_ERROR)
     {
-        LOG(INFO) << "CcNodeService UploadBatch RPC of #ng" << ng_id
+        LOG(INFO) << "CcNodeService UploadBatchRecordCache RPC of #ng" << ng_id
+                  << " for range#" << slices_info->range_ << ", new_range#"
+                  << slices_info->new_range_
                   << " finished with error: " << static_cast<uint32_t>(err);
         err = req.ErrorCode();
     }
     else
     {
-        DLOG(INFO) << "CcNodeService UploadBatch RPC of #ng" << ng_id
+        DLOG(INFO) << "CcNodeService UploadBatchRecordCache RPC of #ng" << ng_id
+                   << " for range#" << slices_info->range_ << ", new_range#"
+                   << slices_info->new_range_
                    << " finished with error: " << static_cast<uint32_t>(err);
     }
 
     response->set_error_code(ToRemoteType::ConvertCcErrorCode(err));
-    response->set_ng_term(ng_term);
+    response->set_ng_term(req.CcNgTerm());
 }
 
 void CcNodeService::FetchPayload(


### PR DESCRIPTION
To reduce cache hit rate, during range splitting, keys located on the new range that fall on other cores (local nodes or remote nodes) can be sent to the corresponding core.

1. Update the logic and related requests for sending range cache during range split

2. Update key shard for UploadBatchSlices rpc.
