### PR TITLE
feat: normal standby sync do not let master node snapshot

### DIFF
--- a/store_handler/data_store_service_client.cpp
+++ b/store_handler/data_store_service_client.cpp
@@ -4018,8 +4018,7 @@ bool DataStoreServiceClient::OnUpdateStandbyCkptTs(uint32_t ng_id,
     if (!skip_reload_data)
     {
         const bool reload_ok =
-            data_store_service_->ReloadData(
-                ng_id, ng_term, snapshot_ts, false);
+            data_store_service_->ReloadData(ng_id, ng_term, snapshot_ts, false);
         if (!reload_ok)
         {
             LOG(WARNING)
@@ -4062,8 +4061,7 @@ bool DataStoreServiceClient::RequestSyncSnapshot(uint32_t ng_id,
         data_store_service_->OpenDataStore(
             ng_id, std::move(bucket_ids), ng_term);
     }
-    return data_store_service_->ReloadData(
-        ng_id, ng_term, snapshot_ts, true);
+    return data_store_service_->ReloadData(ng_id, ng_term, snapshot_ts, true);
 #else
     (void) ng_id;
     (void) ng_term;

--- a/store_handler/data_store_service_client.cpp
+++ b/store_handler/data_store_service_client.cpp
@@ -4018,7 +4018,8 @@ bool DataStoreServiceClient::OnUpdateStandbyCkptTs(uint32_t ng_id,
     if (!skip_reload_data)
     {
         const bool reload_ok =
-            data_store_service_->ReloadData(ng_id, ng_term, snapshot_ts);
+            data_store_service_->ReloadData(
+                ng_id, ng_term, snapshot_ts, false);
         if (!reload_ok)
         {
             LOG(WARNING)
@@ -4061,7 +4062,7 @@ bool DataStoreServiceClient::RequestSyncSnapshot(uint32_t ng_id,
         data_store_service_->OpenDataStore(
             ng_id, std::move(bucket_ids), ng_term);
     }
-    return data_store_service_->ReloadData(ng_id, ng_term, snapshot_ts);
+    return data_store_service_->ReloadData(ng_id, ng_term, snapshot_ts, true);
 #else
     (void) ng_id;
     (void) ng_term;

--- a/store_handler/data_store_service_client.cpp
+++ b/store_handler/data_store_service_client.cpp
@@ -4062,7 +4062,8 @@ bool DataStoreServiceClient::RequestSyncSnapshot(uint32_t ng_id,
         data_store_service_->OpenDataStore(
             ng_id, std::move(bucket_ids), ng_term);
     }
-    return data_store_service_->ReloadData(ng_id, ng_term, snapshot_ts, true);
+    return data_store_service_->ReloadData(
+        ng_id, ng_term, snapshot_ts, true);
 #else
     (void) ng_id;
     (void) ng_term;

--- a/store_handler/eloq_data_store_service/data_store.h
+++ b/store_handler/eloq_data_store_service/data_store.h
@@ -163,10 +163,13 @@ public:
      * @brief Reload data for standby sync (both cloud and local modes).
      * Default no-op for stores that don't need this path.
      */
-    virtual bool ReloadData(int64_t term, uint64_t snapshot_ts)
+    virtual bool ReloadData(int64_t term,
+                            uint64_t snapshot_ts,
+                            bool from_snapshot)
     {
         (void) term;
         (void) snapshot_ts;
+        (void) from_snapshot;
         return true;
     }
 

--- a/store_handler/eloq_data_store_service/data_store_service.cpp
+++ b/store_handler/eloq_data_store_service/data_store_service.cpp
@@ -2410,8 +2410,7 @@ bool DataStoreService::ReloadData(uint32_t shard_id,
         LOG(INFO) << "ReloadData for DSS shard " << shard_id << ", term "
                   << term << ", snapshot_ts " << snapshot_ts
                   << ", from_snapshot=" << from_snapshot;
-        ok = ds_ref.data_store_->ReloadData(
-            term, snapshot_ts, from_snapshot);
+        ok = ds_ref.data_store_->ReloadData(term, snapshot_ts, from_snapshot);
         if (ok)
         {
             ds_ref.latest_term_.store(term, std::memory_order_release);

--- a/store_handler/eloq_data_store_service/data_store_service.cpp
+++ b/store_handler/eloq_data_store_service/data_store_service.cpp
@@ -2378,7 +2378,8 @@ void DataStoreService::SetEnableLocalStandbyForEloqStore(bool enable)
 
 bool DataStoreService::ReloadData(uint32_t shard_id,
                                   int64_t term,
-                                  uint64_t snapshot_ts)
+                                  uint64_t snapshot_ts,
+                                  bool from_snapshot)
 {
 #ifdef DATA_STORE_TYPE_ELOQDSS_ELOQSTORE
     auto &ds_ref = data_shards_.at(shard_id);
@@ -2407,8 +2408,10 @@ bool DataStoreService::ReloadData(uint32_t shard_id,
         ds_ref.shard_status_.load() != DSShardStatus::Closed)
     {
         LOG(INFO) << "ReloadData for DSS shard " << shard_id << ", term "
-                  << term << ", snapshot_ts " << snapshot_ts;
-        ok = ds_ref.data_store_->ReloadData(term, snapshot_ts);
+                  << term << ", snapshot_ts " << snapshot_ts
+                  << ", from_snapshot=" << from_snapshot;
+        ok = ds_ref.data_store_->ReloadData(
+            term, snapshot_ts, from_snapshot);
         if (ok)
         {
             ds_ref.latest_term_.store(term, std::memory_order_release);
@@ -2423,13 +2426,15 @@ bool DataStoreService::ReloadData(uint32_t shard_id,
                    << shard_id;
     }
     DLOG(INFO) << "ReloadData finished, shard " << shard_id << ", term " << term
-               << ", snapshot_ts " << snapshot_ts << ", ok=" << ok;
+               << ", snapshot_ts " << snapshot_ts
+               << ", from_snapshot=" << from_snapshot << ", ok=" << ok;
     return ok;
 #else
     LOG(INFO) << "ReloadData no-op for non-eloqstore data store";
     (void) shard_id;
     (void) term;
     (void) snapshot_ts;
+    (void) from_snapshot;
     return false;
 #endif
 }

--- a/store_handler/eloq_data_store_service/data_store_service.h
+++ b/store_handler/eloq_data_store_service/data_store_service.h
@@ -677,7 +677,10 @@ public:
                                    const std::string &snapshot_path);
     // When primary flush data to cloud, the standby node will call this
     // function to sync the data from cloud.
-    bool ReloadData(uint32_t shard_id, int64_t ng_term, uint64_t snapshot_ts);
+    bool ReloadData(uint32_t shard_id,
+                    int64_t ng_term,
+                    uint64_t snapshot_ts,
+                    bool from_snapshot);
     bool CreateSnapshotForStandby(uint32_t shard_id,
                                   uint32_t ng_id,
                                   uint64_t snapshot_ts);

--- a/store_handler/eloq_data_store_service/eloq_store_data_store.cpp
+++ b/store_handler/eloq_data_store_service/eloq_store_data_store.cpp
@@ -999,10 +999,13 @@ void EloqStoreDataStore::OnFloor(::eloqstore::KvRequest *req)
     ds_scan_req->SetFinish(::EloqDS::remote::DataStoreError::NO_ERROR);
 }
 
-bool EloqStoreDataStore::ReloadData(int64_t term, uint64_t snapshot_ts)
+bool EloqStoreDataStore::ReloadData(int64_t term,
+                                    uint64_t snapshot_ts,
+                                    bool from_snapshot)
 {
     LOG(INFO) << "EloqStoreDataStore::ReloadData, term: " << term
-              << ", snapshot_ts: " << snapshot_ts;
+              << ", snapshot_ts: " << snapshot_ts
+              << ", from_snapshot: " << from_snapshot;
     if (eloq_store_service_->Term() != static_cast<uint64_t>(term))
     {
         LOG(ERROR) << "EloqStoreDataStore::ReloadData, term mismatch, "
@@ -1011,23 +1014,34 @@ bool EloqStoreDataStore::ReloadData(int64_t term, uint64_t snapshot_ts)
                    << ")";
         return false;
     }
-    const std::string reopen_tag = "snapshot_" + std::to_string(snapshot_ts);
-    DLOG(INFO) << "EloqStoreDataStore::ReloadData issue reopen, term: " << term
-               << ", snapshot_ts: " << snapshot_ts << ", tag: " << reopen_tag;
     ::eloqstore::GlobalReopenRequest global_reopen_req;
-    global_reopen_req.SetTag(reopen_tag);
+    if (from_snapshot)
+    {
+        const std::string reopen_tag =
+            "snapshot_" + std::to_string(snapshot_ts);
+        DLOG(INFO) << "EloqStoreDataStore::ReloadData issue reopen, term: "
+                   << term << ", snapshot_ts: " << snapshot_ts
+                   << ", tag: " << reopen_tag;
+        global_reopen_req.SetTag(reopen_tag);
+    }
+    else
+    {
+        DLOG(INFO) << "EloqStoreDataStore::ReloadData issue reopen, term: "
+                   << term << ", snapshot_ts: " << snapshot_ts
+                   << ", tag: <latest>";
+    }
     eloq_store_service_->ExecSync(&global_reopen_req);
 
     if (global_reopen_req.Error() != ::eloqstore::KvError::NoError)
     {
         LOG(ERROR) << "ReloadData reopen failed, snapshot_ts=" << snapshot_ts
-                   << ", tag=" << reopen_tag << ", error="
+                   << ", from_snapshot=" << from_snapshot << ", error="
                    << static_cast<uint32_t>(global_reopen_req.Error())
                    << ", msg=" << global_reopen_req.ErrMessage();
         return false;
     }
     DLOG(INFO) << "ReloadData reopen succeeded, snapshot_ts=" << snapshot_ts
-               << ", tag=" << reopen_tag;
+               << ", from_snapshot=" << from_snapshot;
     return true;
 }
 

--- a/store_handler/eloq_data_store_service/eloq_store_data_store.h
+++ b/store_handler/eloq_data_store_service/eloq_store_data_store.h
@@ -265,7 +265,9 @@ public:
     bool ListArchiveTags(std::string_view prefix,
                          std::vector<ArchiveEntry> *entries);
 
-    bool ReloadData(int64_t term, uint64_t snapshot_ts) override;
+    bool ReloadData(int64_t term,
+                    uint64_t snapshot_ts,
+                    bool from_snapshot) override;
     void UpdateStandbyMasterStorePaths(
         const std::vector<std::string> &store_paths,
         const std::vector<uint64_t> &store_path_weights) override;

--- a/store_handler/eloq_data_store_service/rocksdb_data_store_common.h
+++ b/store_handler/eloq_data_store_service/rocksdb_data_store_common.h
@@ -283,10 +283,13 @@ protected:
     rocksdb::InfoLogLevel StringToInfoLogLevel(
         const std::string &log_level_str);
 
-    virtual bool ReloadData(int64_t term, uint64_t snapshot_ts) override
+    virtual bool ReloadData(int64_t term,
+                            uint64_t snapshot_ts,
+                            bool from_snapshot) override
     {
         (void) term;
         (void) snapshot_ts;
+        (void) from_snapshot;
         LOG(ERROR) << "RocksDBDataStoreCommon::ReloadData, not implemented";
         return false;
     }

--- a/tx_service/include/proto/cc_request.proto
+++ b/tx_service/include/proto/cc_request.proto
@@ -327,7 +327,6 @@ message UpdateStandbyCkptTsRequest
 message UpdateStandbyCkptTsResponse
 {
     bool error = 1;
-    uint64 current_ckpt_ts = 2;
 }
 
 message UpdateStandbyConsistentTsRequest

--- a/tx_service/include/remote/cc_node_service.h
+++ b/tx_service/include/remote/cc_node_service.h
@@ -270,10 +270,9 @@ private:
         std::function<void()> fn;
     };
 
+#ifdef DATA_STORE_TYPE_ELOQDSS_ELOQSTORE
     void EnqueueStandbyTask(StandbyTask task);
     void StandbyTaskWorkerMain();
-
-    LocalCcShards &local_shards_;
     // This queue is only used for standby snapshot/checkpoint coordination,
     // which is low-frequency compared with the normal tx path, so a std::mutex
     // is acceptable here. A generic MPSC queue is not suitable because it does
@@ -285,6 +284,9 @@ private:
     std::deque<StandbyTask> standby_tasks_;
     bool standby_task_running_{true};
     std::thread standby_task_worker_;
+#endif
+
+    LocalCcShards &local_shards_;
 };
 }  // namespace remote
 }  // namespace txservice

--- a/tx_service/include/store/snapshot_manager.h
+++ b/tx_service/include/store/snapshot_manager.h
@@ -25,6 +25,7 @@
 #include <tx_worker_pool.h>
 
 #include <atomic>
+#include <chrono>
 #include <string>
 #include <thread>
 #include <unordered_map>
@@ -135,17 +136,36 @@ private:
     bool GetCompletedSnapshotTsLocked(uint32_t standby_node_id,
                                       int64_t standby_node_term,
                                       uint64_t *standby_snapshot_ts) const;
+    void EnqueueStandbySnapshotCleanupLocked(uint32_t ng_id,
+                                             uint64_t snapshot_ts);
+    void CollectStandbySnapshotCleanupLocked(
+        std::chrono::system_clock::time_point now,
+        std::vector<std::pair<uint32_t, uint64_t>> *snapshots_to_delete);
+    std::chrono::system_clock::time_point
+    NextStandbySnapshotCleanupDeadlineLocked();
 #endif
     void MarkSnapshotSyncCompletedLocked(uint32_t standby_node_id,
                                          int64_t standby_node_term,
                                          uint64_t standby_snapshot_ts);
     void EraseSnapshotSyncCompletedByNodeLocked(uint32_t standby_node_id);
+#ifdef DATA_STORE_TYPE_ELOQDSS_ELOQSTORE
+    void EraseSnapshotSyncCompletedBySnapshotTsLocked(uint64_t snapshot_ts);
+#endif
 
     struct PendingSnapshotSyncTask
     {
         txservice::remote::StorageSnapshotSyncRequest req;
         uint64_t subscription_active_tx_max_ts{0};
     };
+
+#ifdef DATA_STORE_TYPE_ELOQDSS_ELOQSTORE
+    struct PendingStandbySnapshotCleanup
+    {
+        uint32_t ng_id{0};
+        uint64_t snapshot_ts{0};
+        std::chrono::system_clock::time_point expire_at{};
+    };
+#endif
 
     SnapshotManager() = default;
     ~SnapshotManager() = default;
@@ -174,6 +194,7 @@ private:
     // standby node id -> (completed standby term -> standby snapshot ts)
     std::unordered_map<uint32_t, std::unordered_map<int64_t, uint64_t>>
         completed_snapshot_term_and_ts_;
+    std::deque<PendingStandbySnapshotCleanup> pending_cleanup_;
 #else
     // standby node id -> completed standby terms
     std::unordered_map<uint32_t, std::unordered_set<int64_t>>

--- a/tx_service/include/store/snapshot_manager.h
+++ b/tx_service/include/store/snapshot_manager.h
@@ -26,6 +26,7 @@
 
 #include <atomic>
 #include <chrono>
+#include <deque>
 #include <string>
 #include <thread>
 #include <unordered_map>
@@ -36,6 +37,11 @@
 
 namespace txservice
 {
+
+namespace remote
+{
+class StorageSnapshotSyncRequest;
+}  // namespace remote
 
 namespace store
 {
@@ -136,13 +142,12 @@ private:
     bool GetCompletedSnapshotTsLocked(uint32_t standby_node_id,
                                       int64_t standby_node_term,
                                       uint64_t *standby_snapshot_ts) const;
-    void EnqueueStandbySnapshotCleanupLocked(uint32_t ng_id,
-                                             uint64_t snapshot_ts);
-    void CollectStandbySnapshotCleanupLocked(
+    void TrackSnapshotLocked(uint32_t ng_id, uint64_t snapshot_ts);
+    void CollectExpiredSnapshotsLocked(
         std::chrono::system_clock::time_point now,
         std::vector<std::pair<uint32_t, uint64_t>> *snapshots_to_delete);
-    std::chrono::system_clock::time_point
-    NextStandbySnapshotCleanupDeadlineLocked();
+    std::chrono::system_clock::time_point NextSnapshotCleanupDeadlineLocked()
+        const;
 #endif
     void MarkSnapshotSyncCompletedLocked(uint32_t standby_node_id,
                                          int64_t standby_node_term,
@@ -159,12 +164,13 @@ private:
     };
 
 #ifdef DATA_STORE_TYPE_ELOQDSS_ELOQSTORE
-    struct PendingStandbySnapshotCleanup
+    struct SnapshotCleanupEntry
     {
         uint32_t ng_id{0};
         uint64_t snapshot_ts{0};
         std::chrono::system_clock::time_point expire_at{};
     };
+
 #endif
 
     SnapshotManager() = default;
@@ -194,7 +200,7 @@ private:
     // standby node id -> (completed standby term -> standby snapshot ts)
     std::unordered_map<uint32_t, std::unordered_map<int64_t, uint64_t>>
         completed_snapshot_term_and_ts_;
-    std::deque<PendingStandbySnapshotCleanup> pending_cleanup_;
+    std::deque<SnapshotCleanupEntry> snapshot_cleanup_queue_;
 #else
     // standby node id -> completed standby terms
     std::unordered_map<uint32_t, std::unordered_set<int64_t>>

--- a/tx_service/src/remote/cc_node_service.cpp
+++ b/tx_service/src/remote/cc_node_service.cpp
@@ -116,10 +116,11 @@ void CcNodeService::StandbyTaskWorkerMain()
             std::unique_lock<std::mutex> lk(standby_task_mu_);
             while (standby_task_running_ && standby_tasks_.empty())
             {
-                standby_task_cv_.wait(
-                    lk,
-                    [this]
-                    { return !standby_task_running_ || !standby_tasks_.empty(); });
+                standby_task_cv_.wait(lk,
+                                      [this] {
+                                          return !standby_task_running_ ||
+                                                 !standby_tasks_.empty();
+                                      });
             }
             if (!standby_task_running_)
             {

--- a/tx_service/src/remote/cc_node_service.cpp
+++ b/tx_service/src/remote/cc_node_service.cpp
@@ -1914,7 +1914,6 @@ void CcNodeService::UpdateStandbyCkptTs(
 
     // response does not matter
     response->set_error(false);
-    response->set_current_ckpt_ts(Sharder::Instance().NativeNodeGroupCkptTs());
     DLOG(INFO) << "Finished UpdateStandbyCkptTs req, req ckpt ts:"
                << request->primary_succ_ckpt_ts() << ", current ckpt ts:"
                << Sharder::Instance().NativeNodeGroupCkptTs();

--- a/tx_service/src/remote/cc_node_service.cpp
+++ b/tx_service/src/remote/cc_node_service.cpp
@@ -71,11 +71,14 @@ int64_t CurrentSyncedPrimaryTerm()
 CcNodeService::CcNodeService(LocalCcShards &local_shards)
     : local_shards_(local_shards)
 {
+#ifdef DATA_STORE_TYPE_ELOQDSS_ELOQSTORE
     standby_task_worker_ = std::thread([this]() { StandbyTaskWorkerMain(); });
+#endif
 }
 
 CcNodeService::~CcNodeService()
 {
+#ifdef DATA_STORE_TYPE_ELOQDSS_ELOQSTORE
     {
         std::lock_guard<std::mutex> lk(standby_task_mu_);
         standby_task_running_ = false;
@@ -85,8 +88,10 @@ CcNodeService::~CcNodeService()
     {
         standby_task_worker_.join();
     }
+#endif
 }
 
+#ifdef DATA_STORE_TYPE_ELOQDSS_ELOQSTORE
 void CcNodeService::EnqueueStandbyTask(StandbyTask task)
 {
     {
@@ -95,7 +100,6 @@ void CcNodeService::EnqueueStandbyTask(StandbyTask task)
     }
     standby_task_cv_.notify_one();
 }
-
 void CcNodeService::StandbyTaskWorkerMain()
 {
     std::optional<StandbyTask> deferred_task;
@@ -112,11 +116,18 @@ void CcNodeService::StandbyTaskWorkerMain()
             std::unique_lock<std::mutex> lk(standby_task_mu_);
             while (standby_task_running_ && standby_tasks_.empty())
             {
-                standby_task_cv_.wait_for(lk, std::chrono::milliseconds(100));
+                standby_task_cv_.wait(
+                    lk,
+                    [this]
+                    { return !standby_task_running_ || !standby_tasks_.empty(); });
             }
             if (!standby_task_running_)
             {
                 break;
+            }
+            if (standby_tasks_.empty())
+            {
+                continue;
             }
             task = std::move(standby_tasks_.front());
             standby_tasks_.pop_front();
@@ -191,6 +202,7 @@ void CcNodeService::StandbyTaskWorkerMain()
         task.fn();
     }
 }
+#endif
 
 void CcNodeService::OnLeaderStart(::google::protobuf::RpcController *controller,
                                   const OnLeaderStartRequest *request,
@@ -2055,6 +2067,7 @@ void CcNodeService::RequestSyncSnapshot(
     ::google::protobuf::Closure *done)
 {
     brpc::ClosureGuard done_guard(done);
+#ifdef DATA_STORE_TYPE_ELOQDSS_ELOQSTORE
     const uint32_t local_node_id = Sharder::Instance().NodeId();
     DLOG(INFO) << "RequestSyncSnapshot RPC received, ng_id=" << request->ng_id()
                << ", snapshot_ts=" << request->snapshot_ts()
@@ -2129,6 +2142,14 @@ void CcNodeService::RequestSyncSnapshot(
                << ", local_node_id=" << local_node_id;
     response->set_error(false);
     response->set_current_ckpt_ts(current_ckpt_ts);
+#else
+    (void) controller;
+    DLOG(INFO) << "RequestSyncSnapshot noop for non-eloqstore datastore, "
+               << "ng_id=" << request->ng_id()
+               << ", snapshot_ts=" << request->snapshot_ts();
+    response->set_error(false);
+    response->set_current_ckpt_ts(Sharder::Instance().NativeNodeGroupCkptTs());
+#endif
 }
 
 void CcNodeService::FetchNodeInfo(

--- a/tx_service/src/remote/cc_stream_receiver.cpp
+++ b/tx_service/src/remote/cc_stream_receiver.cpp
@@ -36,6 +36,7 @@
 #include "error_messages.h"  //CcErrorCode
 #include "remote/remote_type.h"
 #include "sharder.h"
+#include "store/snapshot_manager.h"
 #include "tx_execution.h"
 #include "tx_operation_result.h"
 #include "tx_trace.h"

--- a/tx_service/src/standby.cpp
+++ b/tx_service/src/standby.cpp
@@ -21,10 +21,6 @@
  */
 #include "standby.h"
 
-#include <bthread/condition_variable.h>
-#include <bthread/mutex.h>
-
-#include <limits>
 #include <memory>
 
 #include "cc_request.h"
@@ -34,21 +30,12 @@ namespace txservice
 {
 namespace
 {
-struct UpdateStandbyCkptAgg
-{
-    bthread::Mutex mux;
-    bthread::ConditionVariable cv;
-    size_t pending{0};
-    size_t total{0};
-    size_t success{0};
-    uint64_t min_ack_ckpt_ts{std::numeric_limits<uint64_t>::max()};
-};
-
 struct UpdateStandbyCkptRpcCtx
 {
     brpc::Controller cntl;
     remote::UpdateStandbyCkptTsResponse resp;
-    UpdateStandbyCkptAgg *agg{nullptr};
+    uint32_t node_id{0};
+    uint64_t snapshot_ts{0};
 };
 
 class UpdateStandbyCkptDone : public google::protobuf::Closure
@@ -62,19 +49,20 @@ public:
     void Run() override
     {
         std::unique_ptr<UpdateStandbyCkptDone> self_guard(this);
-        auto *agg = ctx_->agg;
-        const bool succ = !ctx_->cntl.Failed() && !ctx_->resp.error();
+        if (ctx_->cntl.Failed())
         {
-            std::lock_guard<bthread::Mutex> lk(agg->mux);
-            if (succ)
-            {
-                agg->success++;
-                agg->min_ack_ckpt_ts = std::min(agg->min_ack_ckpt_ts,
-                                                ctx_->resp.current_ckpt_ts());
-            }
-            agg->pending--;
+            LOG(WARNING) << "UpdateStandbyCkptTs RPC failed for node "
+                         << ctx_->node_id
+                         << ", snapshot_ts=" << ctx_->snapshot_ts
+                         << ", error=" << ctx_->cntl.ErrorText();
+            return;
         }
-        agg->cv.notify_all();
+        if (ctx_->resp.error())
+        {
+            LOG(WARNING) << "UpdateStandbyCkptTs RPC returned error for node "
+                         << ctx_->node_id
+                         << ", snapshot_ts=" << ctx_->snapshot_ts;
+        }
     }
 
 private:
@@ -137,16 +125,6 @@ void BrocastPrimaryCkptTs(NodeGroupId node_group_id,
 
     if (!subscribe_node_ids.empty())
     {
-#ifdef DATA_STORE_TYPE_ELOQDSS_ELOQSTORE
-        if (has_data_store_write)
-        {
-            auto *store_hd = Sharder::Instance().GetDataStoreHandler();
-            std::vector<std::string> snapshot_files;
-            store_hd->CreateSnapshotForStandby(
-                node_group_id, snapshot_files, primary_ckpt_ts);
-        }
-#endif
-
         remote::UpdateStandbyCkptTsRequest update_standby_ckpt_ts_req;
 
         update_standby_ckpt_ts_req.set_ng_term(node_group_term);
@@ -155,7 +133,6 @@ void BrocastPrimaryCkptTs(NodeGroupId node_group_id,
         update_standby_ckpt_ts_req.set_has_data_store_write(
             has_data_store_write);
 
-        UpdateStandbyCkptAgg agg;
         for (uint32_t node_id : subscribe_node_ids)
         {
             auto channel = Sharder::Instance().GetCcNodeServiceChannel(node_id);
@@ -166,12 +143,8 @@ void BrocastPrimaryCkptTs(NodeGroupId node_group_id,
             remote::CcRpcService_Stub stub(channel.get());
             auto rpc_ctx = std::make_shared<UpdateStandbyCkptRpcCtx>();
             rpc_ctx->cntl.set_timeout_ms(300);
-            rpc_ctx->agg = &agg;
-            {
-                std::lock_guard<bthread::Mutex> lk(agg.mux);
-                agg.pending++;
-                agg.total++;
-            }
+            rpc_ctx->node_id = node_id;
+            rpc_ctx->snapshot_ts = primary_ckpt_ts;
             DLOG(INFO) << "send UpdateStandbyCkptTs to node " << node_id
                        << ", snapshot_ts " << primary_ckpt_ts;
             stub.UpdateStandbyCkptTs(&rpc_ctx->cntl,
@@ -179,40 +152,6 @@ void BrocastPrimaryCkptTs(NodeGroupId node_group_id,
                                      &rpc_ctx->resp,
                                      new UpdateStandbyCkptDone(rpc_ctx));
         }
-
-        {
-            std::unique_lock<bthread::Mutex> lk(agg.mux);
-            while (agg.pending != 0)
-            {
-                agg.cv.wait(lk);
-            }
-        }
-
-#ifdef DATA_STORE_TYPE_ELOQDSS_ELOQSTORE
-        auto *store_hd = Sharder::Instance().GetDataStoreHandler();
-        DLOG(INFO) << "BrocastPrimaryCkptTs cleanup check, ng_id="
-                   << node_group_id
-                   << ", has_data_store_write=" << has_data_store_write
-                   << ", ack_total=" << agg.total
-                   << ", ack_success=" << agg.success
-                   << ", min_ack_ckpt_ts=" << agg.min_ack_ckpt_ts;
-        if (agg.total > 0 && agg.success == agg.total &&
-            agg.min_ack_ckpt_ts != std::numeric_limits<uint64_t>::max())
-        {
-            store_hd->DeleteStandbySnapshotsBefore(node_group_id,
-                                                   agg.min_ack_ckpt_ts);
-        }
-        else
-        {
-            DLOG(INFO) << "BrocastPrimaryCkptTs skip "
-                          "DeleteStandbySnapshotsBefore, ng_id="
-                       << node_group_id
-                       << ", has_data_store_write=" << has_data_store_write
-                       << ", ack_total=" << agg.total
-                       << ", ack_success=" << agg.success
-                       << ", min_ack_ckpt_ts=" << agg.min_ack_ckpt_ts;
-        }
-#endif
     }
 }
 

--- a/tx_service/src/store/snapshot_manager.cpp
+++ b/tx_service/src/store/snapshot_manager.cpp
@@ -25,6 +25,7 @@
 #include <bthread/mutex.h>
 #include <gflags/gflags.h>
 
+#include <chrono>
 #include <limits>
 #include <memory>
 #include <utility>
@@ -40,7 +41,7 @@ namespace store
 namespace
 {
 #ifdef DATA_STORE_TYPE_ELOQDSS_ELOQSTORE
-constexpr auto kStandbySnapshotCleanupTtl = std::chrono::minutes(5);
+constexpr auto kStandbySnapshotTtl = std::chrono::hours(1);
 
 struct RequestSyncSnapshotAggregate
 {
@@ -157,6 +158,17 @@ bool DispatchRequestSyncSnapshotAsync(uint32_t ng_id,
 
 void SnapshotManager::Start()
 {
+#ifdef DATA_STORE_TYPE_ELOQDSS_ELOQSTORE
+    if (store_hd_ != nullptr)
+    {
+        auto local_ngs = Sharder::Instance().LocalNodeGroups();
+        for (uint32_t ng_id : local_ngs)
+        {
+            store_hd_->DeleteStandbySnapshotsBefore(
+                ng_id, std::numeric_limits<uint64_t>::max());
+        }
+    }
+#endif
     standby_sync_worker_ = std::thread([this] { StandbySyncWorker(); });
     pthread_setname_np(standby_sync_worker_.native_handle(), "ss_standby_sync");
 }
@@ -177,14 +189,40 @@ void SnapshotManager::Shutdown()
 void SnapshotManager::StandbySyncWorker()
 {
     constexpr auto kBlockedTaskRetryInterval = std::chrono::milliseconds(200);
+#ifndef DATA_STORE_TYPE_ELOQDSS_ELOQSTORE
+    while (true)
+    {
+        std::unique_lock<std::mutex> lk(standby_sync_mux_);
+        standby_sync_cv_.wait(
+            lk, [this] { return !pending_req_.empty() || terminated_; });
+        if (terminated_)
+        {
+            return;
+        }
+        assert(!pending_req_.empty());
+        lk.unlock();
+        SyncWithStandby();
+        lk.lock();
+
+        if (terminated_)
+        {
+            return;
+        }
+
+        if (!pending_req_.empty())
+        {
+            // Pending requests are still blocked by subscribe/barrier checks.
+            // Back off to avoid tight checkpoint retry loops.
+            standby_sync_cv_.wait_for(lk, kBlockedTaskRetryInterval);
+        }
+    }
+#else
     while (true)
     {
         std::unique_lock<std::mutex> lk(standby_sync_mux_);
         std::vector<std::pair<uint32_t, uint64_t>> snapshots_to_delete;
-#ifdef DATA_STORE_TYPE_ELOQDSS_ELOQSTORE
-        CollectStandbySnapshotCleanupLocked(std::chrono::system_clock::now(),
-                                            &snapshots_to_delete);
-#endif
+        CollectExpiredSnapshotsLocked(std::chrono::system_clock::now(),
+                                      &snapshots_to_delete);
         if (terminated_)
         {
             return;
@@ -201,17 +239,16 @@ void SnapshotManager::StandbySyncWorker()
 
         if (pending_req_.empty())
         {
-#ifdef DATA_STORE_TYPE_ELOQDSS_ELOQSTORE
-            const auto deadline = NextStandbySnapshotCleanupDeadlineLocked();
+            const auto deadline = NextSnapshotCleanupDeadlineLocked();
             if (deadline == std::chrono::system_clock::time_point::max())
             {
-                standby_sync_cv_.wait(lk,
-                                      [this]
-                                      {
-                                          return !pending_req_.empty() ||
-                                                 !pending_cleanup_.empty() ||
-                                                 terminated_;
-                                      });
+                standby_sync_cv_.wait(
+                    lk,
+                    [this]
+                    {
+                        return !pending_req_.empty() ||
+                               !snapshot_cleanup_queue_.empty() || terminated_;
+                    });
             }
             else
             {
@@ -221,14 +258,9 @@ void SnapshotManager::StandbySyncWorker()
                     [this, deadline]
                     {
                         return !pending_req_.empty() || terminated_ ||
-                               NextStandbySnapshotCleanupDeadlineLocked() <
-                                   deadline;
+                               NextSnapshotCleanupDeadlineLocked() < deadline;
                     });
             }
-#else
-            standby_sync_cv_.wait(
-                lk, [this] { return !pending_req_.empty() || terminated_; });
-#endif
         }
 
         if (terminated_)
@@ -236,10 +268,8 @@ void SnapshotManager::StandbySyncWorker()
             return;
         }
 
-#ifdef DATA_STORE_TYPE_ELOQDSS_ELOQSTORE
-        CollectStandbySnapshotCleanupLocked(std::chrono::system_clock::now(),
-                                            &snapshots_to_delete);
-#endif
+        CollectExpiredSnapshotsLocked(std::chrono::system_clock::now(),
+                                      &snapshots_to_delete);
         if (!snapshots_to_delete.empty())
         {
             lk.unlock();
@@ -271,56 +301,8 @@ void SnapshotManager::StandbySyncWorker()
             standby_sync_cv_.wait_for(lk, kBlockedTaskRetryInterval);
         }
     }
-}
-
-#ifdef DATA_STORE_TYPE_ELOQDSS_ELOQSTORE
-void SnapshotManager::EnqueueStandbySnapshotCleanupLocked(uint32_t ng_id,
-                                                          uint64_t snapshot_ts)
-{
-    if (snapshot_ts == 0)
-    {
-        return;
-    }
-
-    pending_cleanup_.push_back(
-        {ng_id,
-         snapshot_ts,
-         std::chrono::system_clock::now() + kStandbySnapshotCleanupTtl});
-}
-
-void SnapshotManager::CollectStandbySnapshotCleanupLocked(
-    std::chrono::system_clock::time_point now,
-    std::vector<std::pair<uint32_t, uint64_t>> *snapshots_to_delete)
-{
-    if (snapshots_to_delete == nullptr)
-    {
-        return;
-    }
-
-    while (!pending_cleanup_.empty())
-    {
-        const auto &entry = pending_cleanup_.front();
-        if (entry.expire_at > now)
-        {
-            break;
-        }
-        EraseSnapshotSyncCompletedBySnapshotTsLocked(entry.snapshot_ts);
-        snapshots_to_delete->emplace_back(entry.ng_id, entry.snapshot_ts);
-        pending_cleanup_.pop_front();
-    }
-}
-
-std::chrono::system_clock::time_point
-SnapshotManager::NextStandbySnapshotCleanupDeadlineLocked()
-{
-    if (!pending_cleanup_.empty())
-    {
-        return pending_cleanup_.front().expire_at;
-    }
-
-    return std::chrono::system_clock::time_point::max();
-}
 #endif
+}
 
 bool SnapshotManager::OnSnapshotSyncRequested(
     const txservice::remote::StorageSnapshotSyncRequest *req)
@@ -363,11 +345,11 @@ bool SnapshotManager::OnSnapshotSyncRequested(
                                                   req->standby_node_term(),
                                                   &completed_snapshot_ts))
                 {
-                    LOG(WARNING)
-                        << "Completed term found without snapshot ts, "
-                        << "standby node #" << req->standby_node_id()
-                        << ", standby term: " << req->standby_node_term();
-                    return false;
+                    return true;
+                }
+                if (completed_snapshot_ts == 0)
+                {
+                    return true;
                 }
                 DLOG(INFO) << "Received duplicate snapshot sync request for "
                               "completed standby node #"
@@ -404,11 +386,11 @@ bool SnapshotManager::OnSnapshotSyncRequested(
                                                       req->standby_node_term(),
                                                       &completed_snapshot_ts))
                     {
-                        LOG(WARNING)
-                            << "Completed term found without snapshot ts, "
-                            << "standby node #" << req->standby_node_id()
-                            << ", standby term: " << req->standby_node_term();
-                        return false;
+                        return true;
+                    }
+                    if (completed_snapshot_ts == 0)
+                    {
+                        return true;
                     }
                     DLOG(INFO)
                         << "Received duplicate snapshot sync request for "
@@ -722,6 +704,46 @@ bool SnapshotManager::IsSnapshotSyncCompletedLocked(
 }
 
 #ifdef DATA_STORE_TYPE_ELOQDSS_ELOQSTORE
+void SnapshotManager::TrackSnapshotLocked(uint32_t ng_id, uint64_t snapshot_ts)
+{
+    snapshot_cleanup_queue_.push_back(
+        {ng_id,
+         snapshot_ts,
+         std::chrono::system_clock::now() + kStandbySnapshotTtl});
+}
+
+void SnapshotManager::CollectExpiredSnapshotsLocked(
+    std::chrono::system_clock::time_point now,
+    std::vector<std::pair<uint32_t, uint64_t>> *snapshots_to_delete)
+{
+    if (snapshots_to_delete == nullptr)
+    {
+        return;
+    }
+
+    while (!snapshot_cleanup_queue_.empty())
+    {
+        const auto &entry = snapshot_cleanup_queue_.front();
+        if (entry.expire_at > now)
+        {
+            break;
+        }
+        snapshots_to_delete->emplace_back(entry.ng_id, entry.snapshot_ts);
+        EraseSnapshotSyncCompletedBySnapshotTsLocked(entry.snapshot_ts);
+        snapshot_cleanup_queue_.pop_front();
+    }
+}
+
+std::chrono::system_clock::time_point
+SnapshotManager::NextSnapshotCleanupDeadlineLocked() const
+{
+    if (snapshot_cleanup_queue_.empty())
+    {
+        return std::chrono::system_clock::time_point::max();
+    }
+    return snapshot_cleanup_queue_.front().expire_at;
+}
+
 bool SnapshotManager::GetCompletedSnapshotTsLocked(
     uint32_t standby_node_id,
     int64_t standby_node_term,
@@ -861,7 +883,7 @@ void SnapshotManager::SyncWithStandby()
         subscription_barrier_.clear();
 #ifdef DATA_STORE_TYPE_ELOQDSS_ELOQSTORE
         completed_snapshot_term_and_ts_.clear();
-        pending_cleanup_.clear();
+        snapshot_cleanup_queue_.clear();
 #else
         completed_snapshot_terms_.clear();
 #endif
@@ -978,8 +1000,7 @@ void SnapshotManager::SyncWithStandby()
     }
     {
         std::unique_lock<std::mutex> lk(standby_sync_mux_);
-        EnqueueStandbySnapshotCleanupLocked(node_group, standby_snapshot_ts);
-        standby_sync_cv_.notify_all();
+        TrackSnapshotLocked(node_group, standby_snapshot_ts);
     }
     DLOG(INFO) << "SyncWithStandby created standby snapshot, ng_id="
                << node_group << ", term=" << leader_term
@@ -1177,6 +1198,14 @@ void SnapshotManager::SyncWithStandby()
         }
         sync_snapshot_success = sync_snapshot_agg.success;
     }
+#endif
+
+#ifdef DATA_STORE_TYPE_ELOQDSS_ELOQSTORE
+    DLOG(INFO) << "SyncWithStandby dispatched bootstrap snapshot, ng_id="
+               << node_group << ", term=" << leader_term
+               << ", current_snapshot_ts=" << standby_snapshot_ts
+               << ", sync_snapshot_rpc_count=" << sync_snapshot_rpc_count
+               << ", sync_snapshot_success=" << sync_snapshot_success;
 #endif
 }
 

--- a/tx_service/src/store/snapshot_manager.cpp
+++ b/tx_service/src/store/snapshot_manager.cpp
@@ -27,6 +27,7 @@
 
 #include <limits>
 #include <memory>
+#include <utility>
 #include <vector>
 
 #include "cc/local_cc_shards.h"
@@ -39,6 +40,8 @@ namespace store
 namespace
 {
 #ifdef DATA_STORE_TYPE_ELOQDSS_ELOQSTORE
+constexpr auto kStandbySnapshotCleanupTtl = std::chrono::minutes(5);
+
 struct RequestSyncSnapshotAggregate
 {
     bthread::Mutex mux;
@@ -177,12 +180,79 @@ void SnapshotManager::StandbySyncWorker()
     while (true)
     {
         std::unique_lock<std::mutex> lk(standby_sync_mux_);
-        standby_sync_cv_.wait(
-            lk, [this] { return !pending_req_.empty() || terminated_; });
+        std::vector<std::pair<uint32_t, uint64_t>> snapshots_to_delete;
+#ifdef DATA_STORE_TYPE_ELOQDSS_ELOQSTORE
+        CollectStandbySnapshotCleanupLocked(std::chrono::system_clock::now(),
+                                            &snapshots_to_delete);
+#endif
+        if (terminated_)
+        {
+            return;
+        }
+        if (!snapshots_to_delete.empty())
+        {
+            lk.unlock();
+            for (const auto &[ng_id, snapshot_ts] : snapshots_to_delete)
+            {
+                store_hd_->DeleteStandbySnapshot(ng_id, snapshot_ts);
+            }
+            continue;
+        }
+
+        if (pending_req_.empty())
+        {
+#ifdef DATA_STORE_TYPE_ELOQDSS_ELOQSTORE
+            const auto deadline = NextStandbySnapshotCleanupDeadlineLocked();
+            if (deadline == std::chrono::system_clock::time_point::max())
+            {
+                standby_sync_cv_.wait(lk,
+                                      [this]
+                                      {
+                                          return !pending_req_.empty() ||
+                                                 !pending_cleanup_.empty() ||
+                                                 terminated_;
+                                      });
+            }
+            else
+            {
+                standby_sync_cv_.wait_until(
+                    lk,
+                    deadline,
+                    [this, deadline]
+                    {
+                        return !pending_req_.empty() || terminated_ ||
+                               NextStandbySnapshotCleanupDeadlineLocked() <
+                                   deadline;
+                    });
+            }
+#else
+            standby_sync_cv_.wait(
+                lk, [this] { return !pending_req_.empty() || terminated_; });
+#endif
+        }
 
         if (terminated_)
         {
             return;
+        }
+
+#ifdef DATA_STORE_TYPE_ELOQDSS_ELOQSTORE
+        CollectStandbySnapshotCleanupLocked(std::chrono::system_clock::now(),
+                                            &snapshots_to_delete);
+#endif
+        if (!snapshots_to_delete.empty())
+        {
+            lk.unlock();
+            for (const auto &[ng_id, snapshot_ts] : snapshots_to_delete)
+            {
+                store_hd_->DeleteStandbySnapshot(ng_id, snapshot_ts);
+            }
+            continue;
+        }
+
+        if (pending_req_.empty())
+        {
+            continue;
         }
         assert(!pending_req_.empty());
         lk.unlock();
@@ -202,6 +272,55 @@ void SnapshotManager::StandbySyncWorker()
         }
     }
 }
+
+#ifdef DATA_STORE_TYPE_ELOQDSS_ELOQSTORE
+void SnapshotManager::EnqueueStandbySnapshotCleanupLocked(uint32_t ng_id,
+                                                          uint64_t snapshot_ts)
+{
+    if (snapshot_ts == 0)
+    {
+        return;
+    }
+
+    pending_cleanup_.push_back(
+        {ng_id,
+         snapshot_ts,
+         std::chrono::system_clock::now() + kStandbySnapshotCleanupTtl});
+}
+
+void SnapshotManager::CollectStandbySnapshotCleanupLocked(
+    std::chrono::system_clock::time_point now,
+    std::vector<std::pair<uint32_t, uint64_t>> *snapshots_to_delete)
+{
+    if (snapshots_to_delete == nullptr)
+    {
+        return;
+    }
+
+    while (!pending_cleanup_.empty())
+    {
+        const auto &entry = pending_cleanup_.front();
+        if (entry.expire_at > now)
+        {
+            break;
+        }
+        EraseSnapshotSyncCompletedBySnapshotTsLocked(entry.snapshot_ts);
+        snapshots_to_delete->emplace_back(entry.ng_id, entry.snapshot_ts);
+        pending_cleanup_.pop_front();
+    }
+}
+
+std::chrono::system_clock::time_point
+SnapshotManager::NextStandbySnapshotCleanupDeadlineLocked()
+{
+    if (!pending_cleanup_.empty())
+    {
+        return pending_cleanup_.front().expire_at;
+    }
+
+    return std::chrono::system_clock::time_point::max();
+}
+#endif
 
 bool SnapshotManager::OnSnapshotSyncRequested(
     const txservice::remote::StorageSnapshotSyncRequest *req)
@@ -681,6 +800,38 @@ void SnapshotManager::EraseSnapshotSyncCompletedByNodeLocked(
 #endif
 }
 
+#ifdef DATA_STORE_TYPE_ELOQDSS_ELOQSTORE
+void SnapshotManager::EraseSnapshotSyncCompletedBySnapshotTsLocked(
+    uint64_t snapshot_ts)
+{
+    for (auto node_it = completed_snapshot_term_and_ts_.begin();
+         node_it != completed_snapshot_term_and_ts_.end();)
+    {
+        auto &term_and_ts = node_it->second;
+        for (auto term_it = term_and_ts.begin(); term_it != term_and_ts.end();)
+        {
+            if (term_it->second == snapshot_ts)
+            {
+                term_it = term_and_ts.erase(term_it);
+            }
+            else
+            {
+                ++term_it;
+            }
+        }
+
+        if (term_and_ts.empty())
+        {
+            node_it = completed_snapshot_term_and_ts_.erase(node_it);
+        }
+        else
+        {
+            ++node_it;
+        }
+    }
+}
+#endif
+
 // If kvstore is enabled, we must flush data in-memory to kvstore firstly.
 // For non-shared kvstore, also we create and send the snapshot to standby
 // nodes.
@@ -710,6 +861,7 @@ void SnapshotManager::SyncWithStandby()
         subscription_barrier_.clear();
 #ifdef DATA_STORE_TYPE_ELOQDSS_ELOQSTORE
         completed_snapshot_term_and_ts_.clear();
+        pending_cleanup_.clear();
 #else
         completed_snapshot_terms_.clear();
 #endif
@@ -824,11 +976,14 @@ void SnapshotManager::SyncWithStandby()
         LOG(ERROR) << "Failed to create snpashot for sync with standby";
         return;
     }
+    {
+        std::unique_lock<std::mutex> lk(standby_sync_mux_);
+        EnqueueStandbySnapshotCleanupLocked(node_group, standby_snapshot_ts);
+        standby_sync_cv_.notify_all();
+    }
     DLOG(INFO) << "SyncWithStandby created standby snapshot, ng_id="
                << node_group << ", term=" << leader_term
                << ", snapshot_ts=" << standby_snapshot_ts;
-
-    uint64_t min_ack_ckpt_ts = std::numeric_limits<uint64_t>::max();
     size_t sync_snapshot_rpc_count = 0;
     size_t sync_snapshot_success = 0;
     RequestSyncSnapshotAggregate sync_snapshot_agg;
@@ -1020,34 +1175,7 @@ void SnapshotManager::SyncWithStandby()
         {
             sync_snapshot_agg.cv.wait(lk);
         }
-        min_ack_ckpt_ts = sync_snapshot_agg.min_ack_ckpt_ts;
         sync_snapshot_success = sync_snapshot_agg.success;
-    }
-#endif
-
-#ifdef DATA_STORE_TYPE_ELOQDSS_ELOQSTORE
-    if (standby_snapshot_ts != 0 && sync_snapshot_rpc_count > 0 &&
-        sync_snapshot_success == sync_snapshot_rpc_count &&
-        min_ack_ckpt_ts != std::numeric_limits<uint64_t>::max())
-    {
-        DLOG(INFO)
-            << "SyncWithStandby deleting standby snapshot archives by min "
-               "acked ts, ng_id="
-            << node_group << ", term=" << leader_term
-            << ", current_snapshot_ts=" << standby_snapshot_ts
-            << ", sync_snapshot_rpc_count=" << sync_snapshot_rpc_count
-            << ", sync_snapshot_success=" << sync_snapshot_success
-            << ", min_ack_ckpt_ts=" << min_ack_ckpt_ts;
-        store_hd_->DeleteStandbySnapshotsBefore(node_group, min_ack_ckpt_ts);
-    }
-    else if (standby_snapshot_ts != 0)
-    {
-        DLOG(INFO) << "SyncWithStandby skip DeleteStandbySnapshotsBefore, "
-                   << "ng_id=" << node_group << ", term=" << leader_term
-                   << ", current_snapshot_ts=" << standby_snapshot_ts
-                   << ", sync_snapshot_rpc_count=" << sync_snapshot_rpc_count
-                   << ", sync_snapshot_success=" << sync_snapshot_success
-                   << ", min_ack_ckpt_ts=" << min_ack_ckpt_ts;
     }
 #endif
 }


### PR DESCRIPTION
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Reference the link of issue using `fixes eloqdb/tx_service#issue_id`
- [ ] Reference the link of RFC if exists
- [ ] Pass `./mtr --suite=mono_main,mono_multi,mono_basic`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Better snapshot reload behavior with clearer reload context for standby operations
  * TTL-based snapshot cleanup to free storage more predictably
  * Simplified snapshot synchronization and error handling for more robust standby syncs
  * Standby broadcast made non-blocking and less stateful to reduce coordination delays
<!-- end of auto-generated comment: release notes by coderabbit.ai -->