### PR TITLE
feat: add lazy delete scheduling of txobject

### DIFF
--- a/tx_service/include/cc/cc_shard.h
+++ b/tx_service/include/cc/cc_shard.h
@@ -69,6 +69,7 @@
 
 namespace txservice
 {
+struct TxObject;
 class SingleShardScanner;
 class CcMapScanner;
 class TxProcessor;
@@ -442,12 +443,18 @@ public:
     bool IsIdle()
     {
         return cc_queue_size_.load(std::memory_order_relaxed) == 0 &&
-               low_priority_cc_queue_size_.load(std::memory_order_relaxed) == 0;
+               low_priority_cc_queue_size_.load(std::memory_order_relaxed) ==
+                   0 &&
+               lazy_free_queue_size_.load(std::memory_order_relaxed) == 0;
     }
 
     size_t ProcessRequests();
 
     size_t ProcessLowPriorityRequests();
+
+    void EnqueueLazyFree(std::unique_ptr<TxObject> obj);
+
+    size_t ProcessLazyFreeQueue();
 
     /**
      * @brief Find an available TEntry in tranaction array and initialize it.
@@ -1295,6 +1302,8 @@ private:
     moodycamel::ConcurrentQueue<CcRequestBase *> low_priority_cc_queue_;
     std::atomic<uint32_t> low_priority_cc_queue_size_{0};
     std::vector<moodycamel::ProducerToken> low_priority_thd_token_;
+    std::vector<std::unique_ptr<TxObject>> lazy_free_queue_;
+    std::atomic<uint32_t> lazy_free_queue_size_{0};
     // Cc requests waiting for the free memory.
     std::list<CcRequestBase *> cc_wait_list_for_memory_;
 

--- a/tx_service/include/cc/local_cc_shards.h
+++ b/tx_service/include/cc/local_cc_shards.h
@@ -270,6 +270,11 @@ public:
         return cc_shards_[thd_id]->ProcessLowPriorityRequests();
     }
 
+    size_t ProcessLazyFreeQueue(size_t thd_id)
+    {
+        return cc_shards_[thd_id]->ProcessLazyFreeQueue();
+    }
+
     size_t QueueSize(size_t thd_id)
     {
         return cc_shards_[thd_id]->QueueSize();

--- a/tx_service/include/cc/object_cc_map.h
+++ b/tx_service/include/cc/object_cc_map.h
@@ -2846,7 +2846,15 @@ private:
             {
                 // This is a DEL command and the object is deleted.
                 payload_status = RecordStatus::Deleted;
-                payload = nullptr;
+                if (cmd.IsLazyDelete())
+                {
+                    shard_->EnqueueLazyFree(
+                        std::unique_ptr<TxObject>(std::move(payload)));
+                }
+                else
+                {
+                    payload = nullptr;
+                }
             }
             else
             {
@@ -2871,8 +2879,16 @@ private:
             if (new_obj_ptr == nullptr)
             {
                 // This is a DEL command and the object is deleted.
-                dirty_payload = nullptr;
                 dirty_payload_status = RecordStatus::Deleted;
+                if (cmd.IsLazyDelete())
+                {
+                    shard_->EnqueueLazyFree(
+                        std::unique_ptr<TxObject>(std::move(dirty_payload)));
+                }
+                else
+                {
+                    dirty_payload = nullptr;
+                }
             }
             else
             {

--- a/tx_service/include/tx_command.h
+++ b/tx_service/include/tx_command.h
@@ -86,6 +86,11 @@ public:
     {
         return false;
     }
+    // Only true for delete commands that should release object memory later.
+    virtual bool IsLazyDelete() const
+    {
+        return false;
+    }
     // If this commands does not need previous object value. Note that
     // this is different with IsOverwrite since some of the commands overwrites
     // old value but need to return the status / value of the old object.

--- a/tx_service/include/tx_service.h
+++ b/tx_service/include/tx_service.h
@@ -408,6 +408,7 @@ public:
         size_t low_priority_req_cnt =
             local_cc_shards_.ProcessLowPriorityRequests(thd_id_);
         req_cnt += low_priority_req_cnt;
+        req_cnt += local_cc_shards_.ProcessLazyFreeQueue(thd_id_);
         active_cnt =
             on_fly_txs_.Size() + new_tx_cnt_.load(std::memory_order_relaxed);
 

--- a/tx_service/src/cc/cc_shard.cpp
+++ b/tx_service/src/cc/cc_shard.cpp
@@ -47,6 +47,7 @@
 #include "sharder.h"  // Sharder
 #include "store/data_store_handler.h"
 #include "tx_id.h"
+#include "tx_object.h"
 #include "tx_service_common.h"
 #include "tx_start_ts_collector.h"
 #include "type.h"
@@ -241,6 +242,9 @@ CcShard::CcShard(
 
 CcShard::~CcShard()
 {
+    lazy_free_queue_.clear();
+    lazy_free_queue_size_.store(0, std::memory_order_relaxed);
+
     // Free all remaining entries in history queue (unique_ptr will auto-delete)
     history_standby_msg_.clear();
 
@@ -765,6 +769,53 @@ size_t CcShard::ProcessLowPriorityRequests()
             // Wraparound detected, use max value to break loop
             total_elapsed_microseconds = MAX_PROCESSING_TIME_MICROSECONDS;
         }
+    }
+
+    return total;
+}
+
+void CcShard::EnqueueLazyFree(std::unique_ptr<TxObject> obj)
+{
+    if (obj == nullptr)
+    {
+        return;
+    }
+
+    lazy_free_queue_.emplace_back(std::move(obj));
+    lazy_free_queue_size_.fetch_add(1, std::memory_order_relaxed);
+    NotifyTxProcessor();
+}
+
+size_t CcShard::ProcessLazyFreeQueue()
+{
+    constexpr uint64_t MAX_PROCESSING_TIME_MICROSECONDS = 50;
+
+    if (lazy_free_queue_.empty())
+    {
+        return 0;
+    }
+
+    uint64_t start_time_microseconds = ReadTimeMicroseconds();
+    size_t total = 0;
+
+    while (!lazy_free_queue_.empty())
+    {
+        lazy_free_queue_.pop_back();
+        lazy_free_queue_size_.fetch_sub(1, std::memory_order_relaxed);
+        ++total;
+
+        uint64_t current_time_microseconds = ReadTimeMicroseconds();
+        if (current_time_microseconds < start_time_microseconds ||
+            current_time_microseconds - start_time_microseconds >=
+                MAX_PROCESSING_TIME_MICROSECONDS)
+        {
+            break;
+        }
+    }
+
+    if (!lazy_free_queue_.empty())
+    {
+        NotifyTxProcessor();
     }
 
     return total;

--- a/tx_service/src/cc/cc_shard.cpp
+++ b/tx_service/src/cc/cc_shard.cpp
@@ -813,7 +813,11 @@ size_t CcShard::ProcessLazyFreeQueue()
         }
     }
 
-    if (!lazy_free_queue_.empty())
+    if (lazy_free_queue_.empty())
+    {
+        lazy_free_queue_.shrink_to_fit();
+    }
+    else
     {
         NotifyTxProcessor();
     }


### PR DESCRIPTION
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Reference the link of issue using `fixes eloqdb/tx_service#issue_id`
- [ ] Reference the link of RFC if exists
- [ ] Pass `./mtr --suite=mono_main,mono_multi,mono_basic`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced lazy deletion capability that allows object memory release to be deferred to dedicated processing phases rather than immediate deallocation

* **Performance Improvements**
  * Deleted objects are now queued and processed in time-budgeted batches, reducing immediate processing overhead and distributing cleanup work more efficiently across processing cycles

<!-- end of auto-generated comment: release notes by coderabbit.ai -->