### PR TITLE
feat: add RocksDB Cloud bloom filter config

### DIFF
--- a/store_handler/eloq_data_store_service/RocksDB_Configuration_Flags.md
+++ b/store_handler/eloq_data_store_service/RocksDB_Configuration_Flags.md
@@ -138,6 +138,16 @@ These flags are only applicable when RocksDB Cloud is enabled with either S3 or 
 | `rocksdb_cloud_db_file_deletion_delay_sec` | No | `3600` | Integer | Delay for file deletion in cloud storage (seconds) |
 | `rocksdb_cloud_warm_up_thread_num` | No | `1` | Integer | Number of warm-up threads |
 | `rocksdb_cloud_purger_periodicity_secs` | No | `600` (10 minutes) | Integer | Periodicity for cloud purger in seconds |
+| `rocksdb_cloud_enable_bloom_filter` | No | `false` | Boolean | Whether to enable Bloom filter for newly generated RocksDB Cloud SST files |
+| `rocksdb_cloud_bloom_filter_bits_per_key` | No | `10` | Real number | Bloom filter bits per key when `rocksdb_cloud_enable_bloom_filter` is true |
+
+Example:
+
+```ini
+[store]
+rocksdb_cloud_enable_bloom_filter = true
+rocksdb_cloud_bloom_filter_bits_per_key = 10
+```
 
 ### AWS S3-specific Configuration
 
@@ -155,8 +165,9 @@ Different flags have different format requirements:
 1. **String Flags**: Can be any valid string value.
 2. **Boolean Flags**: Must be `true` or `false`.
 3. **Integer Flags**: Must be valid integers.
-4. **Size Flags**: Must be in the format of a number followed by `MB`, `GB`, or `TB` (case insensitive). For example: `64MB`, `20GB`, `1TB`.
-5. **Time Range Flags**: Must be in the format `HH:MM-HH:MM` in UTC time.
+4. **Real Number Flags**: Must be valid numbers. For example: `10`, `9.5`.
+5. **Size Flags**: Must be in the format of a number followed by `MB`, `GB`, or `TB` (case insensitive). For example: `64MB`, `20GB`, `1TB`.
+6. **Time Range Flags**: Must be in the format `HH:MM-HH:MM` in UTC time.
 
 ## Notes
 
@@ -166,4 +177,3 @@ Different flags have different format requirements:
 4. Size values must include units (`MB`, `GB`, or `TB`).
 5. A write rate limit of "0MB" means no limit is applied.
 6. The off-peak time is converted from local time to UTC by default.
-

--- a/store_handler/eloq_data_store_service/RocksDB_Configuration_Flags.md
+++ b/store_handler/eloq_data_store_service/RocksDB_Configuration_Flags.md
@@ -139,6 +139,16 @@ These flags are only applicable when RocksDB Cloud is enabled with either S3 or 
 | `rocksdb_cloud_db_file_deletion_delay_sec` | No | `3600` | Integer | Delay for file deletion in cloud storage (seconds) |
 | `rocksdb_cloud_warm_up_thread_num` | No | `1` | Integer | Number of warm-up threads |
 | `rocksdb_cloud_purger_periodicity_secs` | No | `600` (10 minutes) | Integer | Periodicity for cloud purger in seconds |
+| `rocksdb_cloud_enable_bloom_filter` | No | `false` | Boolean | Whether to enable Bloom filter for newly generated RocksDB Cloud SST files |
+| `rocksdb_cloud_bloom_filter_bits_per_key` | No | `10` | Real number | Bloom filter bits per key when `rocksdb_cloud_enable_bloom_filter` is true |
+
+Example:
+
+```ini
+[store]
+rocksdb_cloud_enable_bloom_filter = true
+rocksdb_cloud_bloom_filter_bits_per_key = 10
+```
 
 ### AWS S3-specific Configuration
 
@@ -156,8 +166,9 @@ Different flags have different format requirements:
 1. **String Flags**: Can be any valid string value.
 2. **Boolean Flags**: Must be `true` or `false`.
 3. **Integer Flags**: Must be valid integers.
-4. **Size Flags**: Must be in the format of a number followed by `MB`, `GB`, or `TB` (case insensitive). For example: `64MB`, `20GB`, `1TB`.
-5. **Time Range Flags**: Must be in the format `HH:MM-HH:MM` in UTC time.
+4. **Real Number Flags**: Must be valid numbers. For example: `10`, `9.5`.
+5. **Size Flags**: Must be in the format of a number followed by `MB`, `GB`, or `TB` (case insensitive). For example: `64MB`, `20GB`, `1TB`.
+6. **Time Range Flags**: Must be in the format `HH:MM-HH:MM` in UTC time.
 
 ## Notes
 

--- a/store_handler/eloq_data_store_service/rocksdb_cloud_data_store.cpp
+++ b/store_handler/eloq_data_store_service/rocksdb_cloud_data_store.cpp
@@ -575,9 +575,8 @@ bool RocksDBCloudDataStore::OpenCloudDB(
     if (cloud_config_.enable_bloom_filter_)
     {
         rocksdb::BlockBasedTableOptions table_options;
-        table_options.filter_policy.reset(
-            rocksdb::NewBloomFilterPolicy(
-                cloud_config_.bloom_filter_bits_per_key_, false));
+        table_options.filter_policy.reset(rocksdb::NewBloomFilterPolicy(
+            cloud_config_.bloom_filter_bits_per_key_, false));
         table_options.whole_key_filtering = true;
         options.table_factory.reset(
             rocksdb::NewBlockBasedTableFactory(table_options));

--- a/store_handler/eloq_data_store_service/rocksdb_cloud_data_store.cpp
+++ b/store_handler/eloq_data_store_service/rocksdb_cloud_data_store.cpp
@@ -25,9 +25,11 @@
 #include <aws/s3/S3Client.h>
 #include <bthread/condition_variable.h>
 #include <rocksdb/db.h>
+#include <rocksdb/filter_policy.h>
 #include <rocksdb/listener.h>
 #include <rocksdb/rate_limiter.h>
 #include <rocksdb/statistics.h>
+#include <rocksdb/table.h>
 
 #include <algorithm>
 #include <boost/lexical_cast.hpp>
@@ -569,6 +571,17 @@ bool RocksDBCloudDataStore::OpenCloudDB(
     options.skip_stats_update_on_db_open = true;
     // Important! keep atomic_flush true, since we disabled WAL
     options.atomic_flush = true;
+
+    if (cloud_config_.enable_bloom_filter_)
+    {
+        rocksdb::BlockBasedTableOptions table_options;
+        table_options.filter_policy.reset(
+            rocksdb::NewBloomFilterPolicy(
+                cloud_config_.bloom_filter_bits_per_key_, false));
+        table_options.whole_key_filtering = true;
+        options.table_factory.reset(
+            rocksdb::NewBlockBasedTableFactory(table_options));
+    }
 
     // The following two configuration items are setup for purpose of removing
     // expired kv data items according to their ttl Rocksdb will compact all sst

--- a/store_handler/eloq_data_store_service/rocksdb_config.cpp
+++ b/store_handler/eloq_data_store_service/rocksdb_config.cpp
@@ -277,6 +277,12 @@ DEFINE_bool(rocksdb_cloud_run_purger, true, "Rocksdb cloud run purger");
 DEFINE_uint32(rocksdb_cloud_purger_periodicity_secs,
               10 * 60, /*10 minutes*/
               "Rocksdb cloud purger periodicity seconds");
+DEFINE_bool(rocksdb_cloud_enable_bloom_filter,
+            false,
+            "Enable RocksDB Cloud bloom filter");
+DEFINE_double(rocksdb_cloud_bloom_filter_bits_per_key,
+              10,
+              "RocksDB Cloud bloom filter bits per key");
 #endif
 #if (defined(DATA_STORE_TYPE_ELOQDSS_ROCKSDB_CLOUD_S3))
 DEFINE_string(aws_access_key_id, "", "AWS SDK access key id");
@@ -590,6 +596,19 @@ RocksDBCloudConfig::RocksDBCloudConfig(const INIReader &config)
             : config.GetInteger("store",
                                 "rocksdb_cloud_purger_periodicity_secs",
                                 FLAGS_rocksdb_cloud_purger_periodicity_secs);
+    bool rocksdb_cloud_enable_bloom_filter =
+        !CheckCommandLineFlagIsDefault("rocksdb_cloud_enable_bloom_filter")
+            ? FLAGS_rocksdb_cloud_enable_bloom_filter
+            : config.GetBoolean("store",
+                                "rocksdb_cloud_enable_bloom_filter",
+                                FLAGS_rocksdb_cloud_enable_bloom_filter);
+    double rocksdb_cloud_bloom_filter_bits_per_key =
+        !CheckCommandLineFlagIsDefault(
+            "rocksdb_cloud_bloom_filter_bits_per_key")
+            ? FLAGS_rocksdb_cloud_bloom_filter_bits_per_key
+            : config.GetReal("store",
+                             "rocksdb_cloud_bloom_filter_bits_per_key",
+                             FLAGS_rocksdb_cloud_bloom_filter_bits_per_key);
 
     sst_file_cache_size_ =
         parse_size(rocksdb_cloud_sst_file_cache_size.c_str());
@@ -599,6 +618,8 @@ RocksDBCloudConfig::RocksDBCloudConfig(const INIReader &config)
     db_file_deletion_delay_ = rocksdb_cloud_db_file_deletion_delay_sec;
     run_purger_ = rocksdb_cloud_run_purger;
     purger_periodicity_millis_ = rocksdb_cloud_purger_periodicity_secs * 1000;
+    enable_bloom_filter_ = rocksdb_cloud_enable_bloom_filter;
+    bloom_filter_bits_per_key_ = rocksdb_cloud_bloom_filter_bits_per_key;
 
     s3_endpoint_url_ =
         !CheckCommandLineFlagIsDefault("rocksdb_cloud_s3_endpoint_url")

--- a/store_handler/eloq_data_store_service/rocksdb_config.cpp
+++ b/store_handler/eloq_data_store_service/rocksdb_config.cpp
@@ -280,6 +280,12 @@ DEFINE_bool(rocksdb_cloud_run_purger, true, "Rocksdb cloud run purger");
 DEFINE_uint32(rocksdb_cloud_purger_periodicity_secs,
               10 * 60, /*10 minutes*/
               "Rocksdb cloud purger periodicity seconds");
+DEFINE_bool(rocksdb_cloud_enable_bloom_filter,
+            false,
+            "Enable RocksDB Cloud bloom filter");
+DEFINE_double(rocksdb_cloud_bloom_filter_bits_per_key,
+              10,
+              "RocksDB Cloud bloom filter bits per key");
 #endif
 #if (defined(DATA_STORE_TYPE_ELOQDSS_ROCKSDB_CLOUD_S3))
 DEFINE_string(aws_access_key_id, "", "AWS SDK access key id");
@@ -601,6 +607,19 @@ RocksDBCloudConfig::RocksDBCloudConfig(const INIReader &config)
             : config.GetInteger("store",
                                 "rocksdb_cloud_purger_periodicity_secs",
                                 FLAGS_rocksdb_cloud_purger_periodicity_secs);
+    bool rocksdb_cloud_enable_bloom_filter =
+        !CheckCommandLineFlagIsDefault("rocksdb_cloud_enable_bloom_filter")
+            ? FLAGS_rocksdb_cloud_enable_bloom_filter
+            : config.GetBoolean("store",
+                                "rocksdb_cloud_enable_bloom_filter",
+                                FLAGS_rocksdb_cloud_enable_bloom_filter);
+    double rocksdb_cloud_bloom_filter_bits_per_key =
+        !CheckCommandLineFlagIsDefault(
+            "rocksdb_cloud_bloom_filter_bits_per_key")
+            ? FLAGS_rocksdb_cloud_bloom_filter_bits_per_key
+            : config.GetReal("store",
+                             "rocksdb_cloud_bloom_filter_bits_per_key",
+                             FLAGS_rocksdb_cloud_bloom_filter_bits_per_key);
 
     sst_file_cache_size_ =
         parse_size(rocksdb_cloud_sst_file_cache_size.c_str());
@@ -610,6 +629,8 @@ RocksDBCloudConfig::RocksDBCloudConfig(const INIReader &config)
     db_file_deletion_delay_ = rocksdb_cloud_db_file_deletion_delay_sec;
     run_purger_ = rocksdb_cloud_run_purger;
     purger_periodicity_millis_ = rocksdb_cloud_purger_periodicity_secs * 1000;
+    enable_bloom_filter_ = rocksdb_cloud_enable_bloom_filter;
+    bloom_filter_bits_per_key_ = rocksdb_cloud_bloom_filter_bits_per_key;
 
     s3_endpoint_url_ =
         !CheckCommandLineFlagIsDefault("rocksdb_cloud_s3_endpoint_url")

--- a/store_handler/eloq_data_store_service/rocksdb_config.h
+++ b/store_handler/eloq_data_store_service/rocksdb_config.h
@@ -213,6 +213,8 @@ struct RocksDBCloudConfig
     size_t warm_up_thread_num_;
     bool run_purger_{true};
     size_t purger_periodicity_millis_{10 * 60 * 1000};  // 10 minutes
+    bool enable_bloom_filter_{false};
+    double bloom_filter_bits_per_key_{10};
     std::string branch_name_;
 
     // Returns true if OSS URL configuration is being used

--- a/store_handler/eloq_data_store_service/rocksdb_config.h
+++ b/store_handler/eloq_data_store_service/rocksdb_config.h
@@ -215,6 +215,8 @@ struct RocksDBCloudConfig
     size_t warm_up_thread_num_;
     bool run_purger_{true};
     size_t purger_periodicity_millis_{10 * 60 * 1000};  // 10 minutes
+    bool enable_bloom_filter_{false};
+    double bloom_filter_bits_per_key_{10};
     std::string branch_name_;
 
     // Returns true if OSS URL configuration is being used


### PR DESCRIPTION
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Reference the link of issue using `fixes eloqdb/tx_service#issue_id`
- [ ] Reference the link of RFC if exists
- [ ] Pass `./mtr --suite=mono_main,mono_multi,mono_basic`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Bloom filter support for RocksDB Cloud storage, including an enable/disable switch and a configurable bits-per-key setting to tune read performance.

* **Documentation**
  * Updated RocksDB Cloud configuration documentation with the new Bloom filter flags, default values, and an example INI snippet.
  * Expanded value-format requirements to explicitly document supported “real number” formats (e.g., `10`, `9.5`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->