### PR TITLE
add compaction queue, fix CkptTsCc hang bug

### DIFF
--- a/store_handler/data_store_service_client.cpp
+++ b/store_handler/data_store_service_client.cpp
@@ -585,6 +585,89 @@ bool DataStoreServiceClient::PersistKV(
     return true;
 }
 
+uint64_t DataStoreServiceClient::ApproxStoreKeyCount()
+{
+    uint64_t total_key_count = 0;
+    std::vector<uint32_t> shard_ids = GetAllDataShards();
+
+    for (uint32_t shard_id : shard_ids)
+    {
+        if (IsLocalShard(shard_id))
+        {
+            total_key_count +=
+                data_store_service_->GetApproxStoreKeyCount(shard_id);
+            continue;
+        }
+
+        uint32_t node_index = GetOwnerNodeIndexOfShard(shard_id);
+        auto *channel = dss_nodes_[node_index].Channel();
+        if (channel == nullptr)
+        {
+            continue;
+        }
+
+        remote::DataStoreRpcService_Stub stub(channel);
+        brpc::Controller cntl;
+        cntl.set_timeout_ms(60000);
+
+        remote::ApproxStoreKeyCountRequest req;
+        remote::ApproxStoreKeyCountResponse resp;
+        req.set_shard_id(shard_id);
+        stub.GetApproxStoreKeyCount(&cntl, &req, &resp, nullptr);
+
+        if (cntl.Failed() ||
+            resp.result().error_code() !=
+                remote::DataStoreError::NO_ERROR)
+        {
+            continue;
+        }
+
+        total_key_count += resp.key_count();
+    }
+
+    return total_key_count;
+}
+
+bool DataStoreServiceClient::CompactStore()
+{
+    bool success = true;
+    std::vector<uint32_t> shard_ids = GetAllDataShards();
+
+    for (uint32_t shard_id : shard_ids)
+    {
+        if (IsLocalShard(shard_id))
+        {
+            success = data_store_service_->CompactStore(shard_id) && success;
+            continue;
+        }
+
+        uint32_t node_index = GetOwnerNodeIndexOfShard(shard_id);
+        auto *channel = dss_nodes_[node_index].Channel();
+        if (channel == nullptr)
+        {
+            success = false;
+            continue;
+        }
+
+        remote::DataStoreRpcService_Stub stub(channel);
+        brpc::Controller cntl;
+        cntl.set_timeout_ms(60000);
+
+        remote::CompactStoreRequest req;
+        remote::CompactStoreResponse resp;
+        req.set_shard_id(shard_id);
+        stub.CompactStore(&cntl, &req, &resp, nullptr);
+
+        if (cntl.Failed() ||
+            resp.result().error_code() != remote::DataStoreError::NO_ERROR)
+        {
+            success = false;
+        }
+    }
+
+    return success;
+}
+
 /**
  * @brief Upserts table schema information to the data store.
  *

--- a/store_handler/data_store_service_client.cpp
+++ b/store_handler/data_store_service_client.cpp
@@ -616,8 +616,7 @@ uint64_t DataStoreServiceClient::ApproxStoreKeyCount()
         stub.GetApproxStoreKeyCount(&cntl, &req, &resp, nullptr);
 
         if (cntl.Failed() ||
-            resp.result().error_code() !=
-                remote::DataStoreError::NO_ERROR)
+            resp.result().error_code() != remote::DataStoreError::NO_ERROR)
         {
             continue;
         }

--- a/store_handler/data_store_service_client.h
+++ b/store_handler/data_store_service_client.h
@@ -243,6 +243,9 @@ public:
         return true;
     }
 
+    uint64_t ApproxStoreKeyCount() override;
+    bool CompactStore() override;
+
     /**
      * @brief indicate end of flush entries in a single ckpt for \@param
      * batch to base table or skindex table in data store, stop and return

--- a/store_handler/eloq_data_store_service/data_store.h
+++ b/store_handler/eloq_data_store_service/data_store.h
@@ -104,6 +104,16 @@ public:
      */
     virtual void FlushData(FlushDataRequest *flush_data_req) = 0;
 
+    virtual uint64_t ApproxStoreKeyCount()
+    {
+        return 0;
+    }
+
+    virtual bool CompactStore()
+    {
+        return false;
+    }
+
     /**
      * @brief Delete records in a range from data store.
      * @param delete_range_req The pointer of the request.

--- a/store_handler/eloq_data_store_service/data_store_service.cpp
+++ b/store_handler/eloq_data_store_service/data_store_service.cpp
@@ -588,6 +588,116 @@ void DataStoreService::FlushData(
     ds_ref.data_store_->FlushData(req);
 }
 
+void DataStoreService::GetApproxStoreKeyCount(
+    ::google::protobuf::RpcController *controller,
+    const ::EloqDS::remote::ApproxStoreKeyCountRequest *request,
+    ::EloqDS::remote::ApproxStoreKeyCountResponse *response,
+    ::google::protobuf::Closure *done)
+{
+    brpc::ClosureGuard done_guard(done);
+
+    uint32_t shard_id = request->shard_id();
+    auto *result = response->mutable_result();
+    response->set_key_count(0);
+
+    if (!IsOwnerOfShard(shard_id))
+    {
+        PrepareShardingError(shard_id, result);
+        return;
+    }
+
+    DataShard &ds_ref = data_shards_.at(shard_id);
+    auto shard_status = ds_ref.shard_status_.load(std::memory_order_acquire);
+    if (shard_status != DSShardStatus::ReadOnly &&
+        shard_status != DSShardStatus::ReadWrite)
+    {
+        result->set_error_code(::EloqDS::remote::DataStoreError::DB_NOT_OPEN);
+        result->set_error_msg("KV store not opened yet.");
+        return;
+    }
+
+    assert(ds_ref.data_store_ != nullptr);
+    response->set_key_count(ds_ref.data_store_->ApproxStoreKeyCount());
+    result->set_error_code(::EloqDS::remote::DataStoreError::NO_ERROR);
+}
+
+uint64_t DataStoreService::GetApproxStoreKeyCount(uint32_t shard_id)
+{
+    if (!IsOwnerOfShard(shard_id))
+    {
+        return 0;
+    }
+
+    DataShard &ds_ref = data_shards_.at(shard_id);
+    auto shard_status = ds_ref.shard_status_.load(std::memory_order_acquire);
+    if (shard_status != DSShardStatus::ReadOnly &&
+        shard_status != DSShardStatus::ReadWrite)
+    {
+        return 0;
+    }
+
+    assert(ds_ref.data_store_ != nullptr);
+    return ds_ref.data_store_->ApproxStoreKeyCount();
+}
+
+void DataStoreService::CompactStore(
+    ::google::protobuf::RpcController *controller,
+    const ::EloqDS::remote::CompactStoreRequest *request,
+    ::EloqDS::remote::CompactStoreResponse *response,
+    ::google::protobuf::Closure *done)
+{
+    brpc::ClosureGuard done_guard(done);
+
+    uint32_t shard_id = request->shard_id();
+    auto *result = response->mutable_result();
+
+    if (!IsOwnerOfShard(shard_id))
+    {
+        PrepareShardingError(shard_id, result);
+        return;
+    }
+
+    DataShard &ds_ref = data_shards_.at(shard_id);
+    auto shard_status = ds_ref.shard_status_.load(std::memory_order_acquire);
+    if (shard_status != DSShardStatus::ReadOnly &&
+        shard_status != DSShardStatus::ReadWrite)
+    {
+        result->set_error_code(::EloqDS::remote::DataStoreError::DB_NOT_OPEN);
+        result->set_error_msg("KV store not opened yet.");
+        return;
+    }
+
+    assert(ds_ref.data_store_ != nullptr);
+    if (ds_ref.data_store_->CompactStore())
+    {
+        result->set_error_code(::EloqDS::remote::DataStoreError::NO_ERROR);
+    }
+    else
+    {
+        result->set_error_code(::EloqDS::remote::DataStoreError::UNKNOWN_ERROR);
+        result->set_error_msg("Failed to compact data store.");
+    }
+}
+
+bool DataStoreService::CompactStore(uint32_t shard_id)
+{
+    if (!IsOwnerOfShard(shard_id))
+    {
+        return false;
+    }
+
+    DataShard &ds_ref = data_shards_.at(shard_id);
+    auto shard_status = ds_ref.shard_status_.load(std::memory_order_acquire);
+    if (shard_status != DSShardStatus::ReadOnly &&
+        shard_status != DSShardStatus::ReadWrite)
+    {
+        return false;
+    }
+
+    assert(ds_ref.data_store_ != nullptr);
+    return ds_ref.data_store_->CompactStore();
+}
+
 void DataStoreService::FlushData(const std::vector<std::string> &kv_table_names,
                                  const uint32_t shard_id,
                                  remote::CommonResult &result,

--- a/store_handler/eloq_data_store_service/data_store_service.h
+++ b/store_handler/eloq_data_store_service/data_store_service.h
@@ -305,11 +305,10 @@ public:
         const ::EloqDS::remote::ApproxStoreKeyCountRequest *request,
         ::EloqDS::remote::ApproxStoreKeyCountResponse *response,
         ::google::protobuf::Closure *done) override;
-    void CompactStore(
-        ::google::protobuf::RpcController *controller,
-        const ::EloqDS::remote::CompactStoreRequest *request,
-        ::EloqDS::remote::CompactStoreResponse *response,
-        ::google::protobuf::Closure *done) override;
+    void CompactStore(::google::protobuf::RpcController *controller,
+                      const ::EloqDS::remote::CompactStoreRequest *request,
+                      ::EloqDS::remote::CompactStoreResponse *response,
+                      ::google::protobuf::Closure *done) override;
 
     uint64_t GetApproxStoreKeyCount(uint32_t shard_id);
     bool CompactStore(uint32_t shard_id);

--- a/store_handler/eloq_data_store_service/data_store_service.h
+++ b/store_handler/eloq_data_store_service/data_store_service.h
@@ -300,6 +300,20 @@ public:
                    ::EloqDS::remote::FlushDataResponse *response,
                    ::google::protobuf::Closure *done) override;
 
+    void GetApproxStoreKeyCount(
+        ::google::protobuf::RpcController *controller,
+        const ::EloqDS::remote::ApproxStoreKeyCountRequest *request,
+        ::EloqDS::remote::ApproxStoreKeyCountResponse *response,
+        ::google::protobuf::Closure *done) override;
+    void CompactStore(
+        ::google::protobuf::RpcController *controller,
+        const ::EloqDS::remote::CompactStoreRequest *request,
+        ::EloqDS::remote::CompactStoreResponse *response,
+        ::google::protobuf::Closure *done) override;
+
+    uint64_t GetApproxStoreKeyCount(uint32_t shard_id);
+    bool CompactStore(uint32_t shard_id);
+
     /**
      * @brief Flush data operation
      * @param table_name Table name

--- a/store_handler/eloq_data_store_service/ds_request.proto
+++ b/store_handler/eloq_data_store_service/ds_request.proto
@@ -9,6 +9,9 @@ service DataStoreRpcService {
   rpc BatchWriteRecords(BatchWriteRecordsRequest)
       returns (BatchWriteRecordsResponse);
   rpc FlushData(FlushDataRequest) returns (FlushDataResponse);
+  rpc GetApproxStoreKeyCount(ApproxStoreKeyCountRequest)
+      returns (ApproxStoreKeyCountResponse);
+  rpc CompactStore(CompactStoreRequest) returns (CompactStoreResponse);
   rpc DeleteRange(DeleteRangeRequest) returns (DeleteRangeResponse);
   rpc CreateTable(CreateTableRequest) returns (CreateTableResponse);
   rpc DropTable(DropTableRequest) returns (DropTableResponse);
@@ -158,6 +161,23 @@ message FlushDataRequest {
 }
 
 message FlushDataResponse {
+  CommonResult result = 1;
+}
+
+message ApproxStoreKeyCountRequest {
+  uint32 shard_id = 1;
+}
+
+message ApproxStoreKeyCountResponse {
+  CommonResult result = 1;
+  uint64 key_count = 2;
+}
+
+message CompactStoreRequest {
+  uint32 shard_id = 1;
+}
+
+message CompactStoreResponse {
   CommonResult result = 1;
 }
 

--- a/store_handler/eloq_data_store_service/rocksdb_data_store_common.cpp
+++ b/store_handler/eloq_data_store_service/rocksdb_data_store_common.cpp
@@ -360,9 +360,7 @@ bool RocksDBDataStoreCommon::CompactStore()
         [this]()
         {
             auto reset_compact_running = [this]()
-            {
-                compact_running_.store(false, std::memory_order_release);
-            };
+            { compact_running_.store(false, std::memory_order_release); };
 
             std::shared_lock<std::shared_mutex> db_lk(db_mux_);
             auto *db = GetDBPtr();

--- a/store_handler/eloq_data_store_service/rocksdb_data_store_common.cpp
+++ b/store_handler/eloq_data_store_service/rocksdb_data_store_common.cpp
@@ -280,12 +280,26 @@ bool RocksDBDataStoreCommon::Initialize()
     {
         query_worker_pool_->Initialize();
     }
+    if (compact_worker_pool_ == nullptr)
+    {
+        compact_worker_pool_ =
+            std::make_unique<ThreadWorkerPool>("dss_comp", 1);
+    }
+    else
+    {
+        compact_worker_pool_->Initialize();
+    }
 
     return true;
 }
 
 void RocksDBDataStoreCommon::Shutdown()
 {
+    if (compact_worker_pool_ != nullptr)
+    {
+        compact_worker_pool_->Shutdown();
+    }
+
     // shutdown query worker pool
     if (query_worker_pool_ != nullptr)
     {
@@ -320,20 +334,59 @@ uint64_t RocksDBDataStoreCommon::ApproxStoreKeyCount()
 
 bool RocksDBDataStoreCommon::CompactStore()
 {
-    std::shared_lock<std::shared_mutex> db_lk(db_mux_);
-    auto *db = GetDBPtr();
-    if (db == nullptr)
     {
+        std::shared_lock<std::shared_mutex> db_lk(db_mux_);
+        if (GetDBPtr() == nullptr)
+        {
+            return false;
+        }
+    }
+
+    bool expected = false;
+    if (!compact_running_.compare_exchange_strong(
+            expected, true, std::memory_order_acq_rel))
+    {
+        LOG(WARNING) << "Manual RocksDB compact is already running.";
         return false;
     }
 
-    rocksdb::CompactRangeOptions compact_options;
-    rocksdb::Status compact_status =
-        db->CompactRange(compact_options, nullptr, nullptr);
-    if (!compact_status.ok())
+    if (compact_worker_pool_ == nullptr)
     {
-        LOG(WARNING) << "Failed to compact RocksDB: "
-                     << compact_status.ToString();
+        compact_running_.store(false, std::memory_order_release);
+        return false;
+    }
+
+    bool submitted = compact_worker_pool_->SubmitWork(
+        [this]()
+        {
+            auto reset_compact_running = [this]()
+            {
+                compact_running_.store(false, std::memory_order_release);
+            };
+
+            std::shared_lock<std::shared_mutex> db_lk(db_mux_);
+            auto *db = GetDBPtr();
+            if (db == nullptr)
+            {
+                LOG(WARNING) << "Skip manual RocksDB compact: DB is not open.";
+                reset_compact_running();
+                return;
+            }
+
+            rocksdb::CompactRangeOptions compact_options;
+            rocksdb::Status compact_status =
+                db->CompactRange(compact_options, nullptr, nullptr);
+            if (!compact_status.ok())
+            {
+                LOG(WARNING) << "Failed to compact RocksDB: "
+                             << compact_status.ToString();
+            }
+
+            reset_compact_running();
+        });
+    if (!submitted)
+    {
+        compact_running_.store(false, std::memory_order_release);
         return false;
     }
 

--- a/store_handler/eloq_data_store_service/rocksdb_data_store_common.cpp
+++ b/store_handler/eloq_data_store_service/rocksdb_data_store_common.cpp
@@ -300,6 +300,46 @@ void RocksDBDataStoreCommon::Shutdown()
     }
 }
 
+uint64_t RocksDBDataStoreCommon::ApproxStoreKeyCount()
+{
+    std::shared_lock<std::shared_mutex> db_lk(db_mux_);
+    auto *db = GetDBPtr();
+    if (db == nullptr)
+    {
+        return 0;
+    }
+
+    uint64_t key_count = 0;
+    if (db->GetIntProperty("rocksdb.estimate-num-keys", &key_count))
+    {
+        return key_count;
+    }
+
+    return 0;
+}
+
+bool RocksDBDataStoreCommon::CompactStore()
+{
+    std::shared_lock<std::shared_mutex> db_lk(db_mux_);
+    auto *db = GetDBPtr();
+    if (db == nullptr)
+    {
+        return false;
+    }
+
+    rocksdb::CompactRangeOptions compact_options;
+    rocksdb::Status compact_status =
+        db->CompactRange(compact_options, nullptr, nullptr);
+    if (!compact_status.ok())
+    {
+        LOG(WARNING) << "Failed to compact RocksDB: "
+                     << compact_status.ToString();
+        return false;
+    }
+
+    return true;
+}
+
 void RocksDBDataStoreCommon::FlushData(FlushDataRequest *flush_data_req)
 {
     bool res = query_worker_pool_->SubmitWork(

--- a/store_handler/eloq_data_store_service/rocksdb_data_store_common.h
+++ b/store_handler/eloq_data_store_service/rocksdb_data_store_common.h
@@ -28,13 +28,16 @@
 #include <rocksdb/listener.h>
 #include <rocksdb/slice.h>
 
+#include <atomic>
 #include <cassert>
 #include <chrono>
+#include <shared_mutex>
 #include <string>
 
 #include "data_store.h"
 #include "data_store_service.h"
 #include "rocksdb_config.h"
+#include "thread_worker_pool.h"
 
 namespace EloqDS
 {
@@ -335,6 +338,8 @@ protected:
     size_t query_worker_number_{4};
 
     std::unique_ptr<ThreadWorkerPool> query_worker_pool_;
+    std::unique_ptr<ThreadWorkerPool> compact_worker_pool_;
+    std::atomic<bool> compact_running_{false};
     std::shared_mutex db_mux_;
     std::mutex ddl_mux_;
 };

--- a/store_handler/eloq_data_store_service/rocksdb_data_store_common.h
+++ b/store_handler/eloq_data_store_service/rocksdb_data_store_common.h
@@ -172,6 +172,9 @@ public:
      */
     void FlushData(FlushDataRequest *flush_data_req) override;
 
+    uint64_t ApproxStoreKeyCount() override;
+    bool CompactStore() override;
+
     /**
      * @brief Write records to the data store.
      * @param batch_write_req The pointer of the request.

--- a/tx_service/include/cc/cc_request.h
+++ b/tx_service/include/cc/cc_request.h
@@ -2984,17 +2984,13 @@ struct CkptTsCc : public CcRequestBase
 {
 public:
     CkptTsCc(size_t shard_cnt, NodeGroupId ng_id)
-        : ckpt_ts_(UINT64_MAX),
-          mux_(),
-          cv_(),
-          unfinish_cnt_(shard_cnt),
-          cc_ng_id_(ng_id)
+        : ckpt_ts_(UINT64_MAX), unfinish_cnt_(shard_cnt), cc_ng_id_(ng_id)
     {
         for (size_t i = 0; i < unfinish_cnt_; i++)
         {
             memory_allocated_vec_.emplace_back(0);
             memory_committed_vec_.emplace_back(0);
-            heap_full_vec_.emplace_back(false);
+            heap_full_vec_.emplace_back(0);
             standby_msg_seq_id_vec_.emplace_back(0);
             total_key_cnt_vec_.emplace_back(0);
             dirty_key_cnt_vec_.emplace_back(0);
@@ -3036,30 +3032,19 @@ public:
         }
         memory_allocated_vec_[ccs.LocalCoreId()] = allocated;
         memory_committed_vec_[ccs.LocalCoreId()] = committed;
-        heap_full_vec_[ccs.LocalCoreId()] = full;
+        heap_full_vec_[ccs.LocalCoreId()] = full ? 1 : 0;
         auto [total_keys, dirty_keys] = ccs.GetDataKeyStats();
         total_key_cnt_vec_[ccs.LocalCoreId()] = total_keys;
         dirty_key_cnt_vec_[ccs.LocalCoreId()] = dirty_keys;
 
-        std::unique_lock lk(mux_);
-        if (--unfinish_cnt_ == 0)
-        {
-            cv_.notify_one();
-        }
+        unfinish_cnt_.fetch_sub(1, std::memory_order_release);
 
-        // return false since CkptTsCc is not reused and does not need to call
-        // CcRequestBase::Free
+        // return false since CkptTsCc is not reused and does not need to
+        // call CcRequestBase::Free
         return false;
     }
 
-    void Wait()
-    {
-        std::unique_lock lk(mux_);
-        while (unfinish_cnt_ > 0)
-        {
-            cv_.wait(lk);
-        }
-    }
+    void Wait();
 
     uint64_t GetCkptTs() const
     {
@@ -3100,7 +3085,7 @@ public:
         {
             uint64_t &allocated = memory_allocated_vec_[core_id];
             uint64_t &committed = memory_committed_vec_[core_id];
-            bool heap_full = heap_full_vec_[core_id];
+            bool heap_full = heap_full_vec_[core_id] != 0;
             size_t total_keys = total_key_cnt_vec_[core_id];
             size_t dirty_keys = dirty_key_cnt_vec_[core_id];
             double dirty_ratio = total_keys == 0
@@ -3159,16 +3144,14 @@ public:
 
 private:
     std::atomic<uint64_t> ckpt_ts_;
-    bthread::Mutex mux_;
-    bthread::ConditionVariable cv_;
-    size_t unfinish_cnt_;
+    std::atomic<size_t> unfinish_cnt_;
     std::vector<uint64_t> memory_allocated_vec_;
     std::vector<uint64_t> memory_committed_vec_;
     std::vector<size_t> total_key_cnt_vec_;
     std::vector<size_t> dirty_key_cnt_vec_;
     std::vector<uint64_t> standby_msg_seq_id_vec_;
     std::vector<uint32_t> subscribed_node_ids_;
-    std::vector<bool> heap_full_vec_;
+    std::vector<int8_t> heap_full_vec_;
     NodeGroupId cc_ng_id_;
 };
 

--- a/tx_service/include/cc/cc_request.h
+++ b/tx_service/include/cc/cc_request.h
@@ -3037,7 +3037,7 @@ public:
         total_key_cnt_vec_[ccs.LocalCoreId()] = total_keys;
         dirty_key_cnt_vec_[ccs.LocalCoreId()] = dirty_keys;
 
-        unfinish_cnt_.fetch_sub(1, std::memory_order_release);
+        unfinish_cnt_.fetch_sub(1, std::memory_order_acq_rel);
 
         // return false since CkptTsCc is not reused and does not need to
         // call CcRequestBase::Free

--- a/tx_service/include/store/data_store_handler.h
+++ b/tx_service/include/store/data_store_handler.h
@@ -116,6 +116,16 @@ public:
         return false;
     }
 
+    virtual uint64_t ApproxStoreKeyCount()
+    {
+        return 0;
+    }
+
+    virtual bool CompactStore()
+    {
+        return false;
+    }
+
     /**
      * @param write_time is used to maintain idempotence. For eventual
      * consistency storage, records with larger write_time wins. Cassandra

--- a/tx_service/src/cc/cc_request.cpp
+++ b/tx_service/src/cc/cc_request.cpp
@@ -76,4 +76,15 @@ void ReplayLogCc::AbortCcRequest(CcErrorCode err_code)
     }
 }
 
+void CkptTsCc::Wait()
+{
+    uint64_t interval_us = 100;
+    constexpr uint64_t max_interval = 100000;
+    while (unfinish_cnt_.load(std::memory_order_acquire) > 0)
+    {
+        bthread_usleep(interval_us);
+        if ((interval_us << 1) < max_interval)
+            interval_us <<= 1;
+    }
+}
 }  // namespace txservice


### PR DESCRIPTION
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Reference the link of issue using `fixes eloqdb/tx_service#issue_id`
- [ ] Reference the link of RFC if exists
- [ ] Pass `./mtr --suite=mono_main,mono_multi,mono_basic`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Retrieve approximate key counts from the data store for operational monitoring.
  * Trigger manual data store compaction to optimize storage and reclaim space.
* **Refactor**
  * Background compaction worker added for asynchronous compaction and improved reliability.
  * Checkpoint completion wait mechanism made more robust for better synchronization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/eloqdata/tx_service/pull/483?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->