### PR TITLE
fix: make enable_metrics parameter work through cli

### DIFF
--- a/core/src/metrics_init.cpp
+++ b/core/src/metrics_init.cpp
@@ -24,6 +24,7 @@ bool DataSubstrate::InitializeMetrics(const INIReader &config_reader)
 {
     /* Parse metrics config */
     metrics::enable_metrics =
+        FLAGS_enable_metrics ||
         config_reader.GetBoolean("metrics", "enable_metrics", false);
     DLOG(INFO) << "enable_metrics: "
                << (metrics::enable_metrics ? "ON" : "OFF");


### PR DESCRIPTION
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Reference the link of issue using `fixes eloqdb/tx_service#issue_id`
- [ ] Reference the link of RFC if exists
- [ ] Pass `./mtr --suite=mono_main,mono_multi,mono_basic`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Metrics can now be enabled via command-line flag or INI configuration file settings, providing flexible configuration options for users managing metrics enablement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->