### PR TITLE
Fix standby cache persistence checks during failover

### DIFF
--- a/tx_service/include/cc/object_cc_map.h
+++ b/tx_service/include/cc/object_cc_map.h
@@ -1909,7 +1909,8 @@ public:
         decoded_key.Deserialize(key_str->data(), offset, KeySchema());
         const KeyT *look_key = &decoded_key;
 
-        if (Sharder::Instance().StandbyNodeTerm() >= 0 &&
+        if ((Sharder::Instance().StandbyNodeTerm() >= 0 ||
+             Sharder::Instance().CandidateStandbyNodeTerm() >= 0) &&
             Sharder::Instance().GetDataStoreHandler()->IsSharedStorage() &&
             commit_ts < Sharder::Instance().NativeNodeGroupCkptTs())
         {

--- a/tx_service/src/cc/cc_entry.cpp
+++ b/tx_service/src/cc/cc_entry.cpp
@@ -60,10 +60,16 @@ void VersionedLruEntry<Versioned, RangePartitioned>::SetCommitTsPayloadStatus(
 template <bool Versioned, bool RangePartitioned>
 bool VersionedLruEntry<Versioned, RangePartitioned>::IsPersistent() const
 {
-    if (Sharder::Instance().StandbyNodeTerm() >= 0 &&
+    const int64_t standby_term = Sharder::Instance().StandbyNodeTerm();
+    const int64_t candidate_standby_term =
+        Sharder::Instance().CandidateStandbyNodeTerm();
+    if ((standby_term >= 0 || candidate_standby_term >= 0) &&
         Sharder::Instance().GetDataStoreHandler()->IsSharedStorage())
     {
-        // If this is a follower with shared kv, check the ng leader's ckpt_ts.
+        // For shared-storage standby cache, entries are persistent once the
+        // primary's checkpoint ts has advanced past the entry's commit ts. This
+        // must apply during candidate-standby as well, otherwise entries loaded
+        // while following cannot be reclaimed before snapshot sync finishes.
         return CommitTs() <= Sharder::Instance().NativeNodeGroupCkptTs();
     }
 


### PR DESCRIPTION
## Summary
- treat candidate-standby as shared-storage standby when deciding whether a cce is already persistent
- apply the same condition when discarding already-checkpointed forward messages
- unblock cce cleanup after rolling update / failover so new reads do not stay stuck in the shard memory wait list

## Problem
During rolling update with RocksDBCloud shared storage, Redis cluster failover can complete normally while the new master still inherits standby cache entries that never become reclaimable. In this state:
- `cluster nodes` looks normal
- `CcShard::EnqueueWaitListIfMemoryFull()` keeps enqueueing requests
- `ShardCleanCc::Execute()` and `CcShard::Clean()` run, but `free_cnt` stays `0`
- new `get` requests cannot allocate cce and remain blocked in `cc_wait_list_for_memory_`

The root cause is that shared-storage persistence checks only recognized `StandbyNodeTerm()`, but failover traffic can populate cc map while the node is still in `CandidateStandbyNodeTerm()`. Those entries were treated as non-persistent and therefore never became freeable.

## Validation
- reproduced the bad state from gdb during rolling update / failover
- observed wait list growth while clean was running and `free_cnt` stayed `0`
- code inspection shows the persistence and forward-discard checks were inconsistent with candidate-standby state

## Notes
I did not run a full build or regression suite in this environment.
