### PR TITLE
fix: avoid bthread mutex deadlock between tx processors and bthread waiters

### DIFF
--- a/tx_service/include/cc/cc_req_misc.h
+++ b/tx_service/include/cc/cc_req_misc.h
@@ -339,23 +339,19 @@ public:
 
     bool Execute(CcShard &ccs) override;
 
-    void Wait()
-    {
-        std::unique_lock lk(mux_);
-        while (finish_cnt_ != core_cnt_)
-        {
-            wait_cv_.wait(lk);
-        }
-    }
+    // ClearCcNodeGroup is issued and Waited on RPC handler bthread, while
+    // Execute() runs on tx processors (the brpc worker main stack), so the
+    // two sides must not share a bthread::Mutex. Wait() polls an atomic
+    // flag instead.
+    void Wait();
 
 private:
     const uint32_t cc_ng_id_;
     const uint16_t core_cnt_;
-    uint16_t finish_cnt_{0};
-    // ClearCcNodeGroup is issued and Waited on RPC handler bthread, use bthread
-    // mutex and condition variable.
-    bthread::Mutex mux_;
-    bthread::ConditionVariable wait_cv_;
+    std::atomic<uint16_t> finish_cnt_{0};
+    // Set by the last core after it has dropped the node group's table
+    // statistics, catalogs, ranges and bucket info.
+    std::atomic<bool> done_{false};
 };
 
 struct FillStoreSliceCc;
@@ -871,11 +867,10 @@ public:
     void Reset(std::function<bool(CcShard &ccs)> task = {},
                uint16_t core_cnt = 1)
     {
-        std::lock_guard<bthread::Mutex> lk(mux_);
         RunOnTxProcessorCc::Reset(std::move(task));
 
-        unfinished_cnt_ = core_cnt;
-        error_code_ = CcErrorCode::NO_ERROR;
+        error_code_.store(CcErrorCode::NO_ERROR, std::memory_order_relaxed);
+        unfinished_cnt_.store(core_cnt, std::memory_order_release);
     }
 
     void SetCoroCallbacks(const std::function<void()> *yield_fn,
@@ -885,14 +880,11 @@ public:
         resume_fn_ = resume_fn;
     }
 
-    void Wait()
-    {
-        std::unique_lock<bthread::Mutex> lk(mux_);
-        while (unfinished_cnt_)
-        {
-            cv_.wait(lk);
-        }
-    }
+    // The owner of a WaitableCc may be a bthread while Execute() runs on tx
+    // processors (the brpc worker main stack). The two sides must not share
+    // a bthread::Mutex, so Wait() polls atomics. mux_ is only used for the
+    // yield/resume handshake whose waiter is a dedicated worker thread.
+    void Wait();
 
     void Wait(const std::function<void()> *yield_fn,
               const std::function<void()> *resume_fn)
@@ -903,7 +895,7 @@ public:
             return;
         }
         std::unique_lock<bthread::Mutex> lk(mux_);
-        while (unfinished_cnt_)
+        while (unfinished_cnt_.load(std::memory_order_acquire) > 0)
         {
             waiting_.store(true, std::memory_order_release);
             lk.unlock();
@@ -915,70 +907,60 @@ public:
 
     bool IsFinished() const
     {
-        std::lock_guard<bthread::Mutex> lk(mux_);
-        return unfinished_cnt_ == 0;
+        return unfinished_cnt_.load(std::memory_order_acquire) == 0;
     }
 
     bool IsError() const
     {
-        std::lock_guard<bthread::Mutex> lk(mux_);
-        return error_code_ != CcErrorCode::NO_ERROR;
+        return error_code_.load(std::memory_order_acquire) !=
+               CcErrorCode::NO_ERROR;
     }
 
     CcErrorCode ErrorCode() const
     {
-        std::lock_guard<bthread::Mutex> lk(mux_);
-        return error_code_;
+        return error_code_.load(std::memory_order_acquire);
     }
 
     void AbortCcRequest(CcErrorCode error_code) override
     {
-        std::unique_lock<bthread::Mutex> lk(mux_);
-        unfinished_cnt_--;
-        error_code_ = error_code;
-        if (unfinished_cnt_ == 0)
-        {
-            if (resume_fn_ != nullptr &&
-                waiting_.load(std::memory_order_acquire))
-            {
-                waiting_.store(false, std::memory_order_release);
-                auto *fn = resume_fn_;
-                lk.unlock();
-                (*fn)();
-            }
-            else if (resume_fn_ == nullptr)
-            {
-                cv_.notify_one();
-            }
-        }
+        error_code_.store(error_code, std::memory_order_release);
+        FinishOne();
     }
 
     bool Execute(CcShard &ccs) override
     {
         if (RunOnTxProcessorCc::Execute(ccs))
         {
-            std::unique_lock<bthread::Mutex> lk(mux_);
-            error_code_ = CcErrorCode::NO_ERROR;
-            if (--unfinished_cnt_ == 0)
+            error_code_.store(CcErrorCode::NO_ERROR,
+                              std::memory_order_release);
+            FinishOne();
+        }
+        return false;
+    }
+
+private:
+    void FinishOne()
+    {
+        if (unfinished_cnt_.fetch_sub(1, std::memory_order_acq_rel) == 1)
+        {
+            if (resume_fn_ != nullptr)
             {
-                if (resume_fn_ != nullptr &&
-                    waiting_.load(std::memory_order_acquire))
+                // The coroutine waiter checks unfinished_cnt_ and sets
+                // waiting_ under mux_, so the last finisher either observes
+                // waiting_ here, or the waiter re-checks the count and never
+                // yields.
+                std::unique_lock<bthread::Mutex> lk(mux_);
+                if (waiting_.load(std::memory_order_acquire))
                 {
                     waiting_.store(false, std::memory_order_release);
                     auto *fn = resume_fn_;
                     lk.unlock();
                     (*fn)();
                 }
-                else if (resume_fn_ == nullptr)
-                {
-                    cv_.notify_one();
-                }
             }
         }
-        return false;
     }
 
-private:
     void *operator new(size_t) noexcept
     {
         return nullptr;
@@ -989,11 +971,12 @@ private:
     }
 
 private:
+    // Only guards the coroutine yield/resume handshake. Never taken by
+    // bthread owners.
     mutable bthread::Mutex mux_;
-    bthread::ConditionVariable cv_;
 
-    uint32_t unfinished_cnt_{0};
-    CcErrorCode error_code_;
+    std::atomic<uint32_t> unfinished_cnt_{0};
+    std::atomic<CcErrorCode> error_code_;
 
     // Coroutine yield/resume support
     const std::function<void()> *yield_fn_{nullptr};

--- a/tx_service/include/cc/cc_req_misc.h
+++ b/tx_service/include/cc/cc_req_misc.h
@@ -923,7 +923,13 @@ public:
 
     void AbortCcRequest(CcErrorCode error_code) override
     {
-        error_code_.store(error_code, std::memory_order_release);
+        // Latch the first error; a later success on another core must not
+        // erase it.
+        CcErrorCode expected = CcErrorCode::NO_ERROR;
+        error_code_.compare_exchange_strong(expected,
+                                            error_code,
+                                            std::memory_order_acq_rel,
+                                            std::memory_order_relaxed);
         FinishOne();
     }
 
@@ -931,8 +937,6 @@ public:
     {
         if (RunOnTxProcessorCc::Execute(ccs))
         {
-            error_code_.store(CcErrorCode::NO_ERROR,
-                              std::memory_order_release);
             FinishOne();
         }
         return false;

--- a/tx_service/include/cc/cc_request.h
+++ b/tx_service/include/cc/cc_request.h
@@ -3159,11 +3159,7 @@ struct ActiveTxMaxTsCc : public CcRequestBase
 {
 public:
     ActiveTxMaxTsCc(size_t shard_cnt, NodeGroupId ng_id)
-        : active_tx_max_ts_(0),
-          mux_(),
-          cv_(),
-          unfinish_cnt_(shard_cnt),
-          cc_ng_id_(ng_id)
+        : active_tx_max_ts_(0), unfinish_cnt_(shard_cnt), cc_ng_id_(ng_id)
     {
     }
 
@@ -3181,25 +3177,14 @@ public:
                    old_val, shard_active_tx_max_ts, std::memory_order_acq_rel))
             ;
 
-        std::unique_lock lk(mux_);
-        if (--unfinish_cnt_ == 0)
-        {
-            cv_.notify_one();
-        }
+        unfinish_cnt_.fetch_sub(1, std::memory_order_acq_rel);
 
         // return false since ActiveTxMaxTsCc is not reused and does not need
         // to call CcRequestBase::Free
         return false;
     }
 
-    void Wait()
-    {
-        std::unique_lock lk(mux_);
-        while (unfinish_cnt_ > 0)
-        {
-            cv_.wait(lk);
-        }
-    }
+    void Wait();
 
     uint64_t GetActiveTxMaxTs() const
     {
@@ -3208,9 +3193,7 @@ public:
 
 private:
     std::atomic<uint64_t> active_tx_max_ts_;
-    bthread::Mutex mux_;
-    bthread::ConditionVariable cv_;
-    size_t unfinish_cnt_;
+    std::atomic<size_t> unfinish_cnt_;
     NodeGroupId cc_ng_id_;
 };
 
@@ -4603,8 +4586,7 @@ public:
 struct ClearTxCc : public CcRequestBase
 {
 public:
-    ClearTxCc(uint32_t core_cnt)
-        : mux_(), wait_cv_(), finish_cnt_(0), core_cnt_(core_cnt)
+    ClearTxCc(uint32_t core_cnt) : finish_cnt_(0), core_cnt_(core_cnt)
     {
     }
 
@@ -4613,33 +4595,24 @@ public:
     void Set(uint64_t tx_number)
     {
         tx_number_ = tx_number;
-        std::unique_lock<std::mutex> lk(mux_);
-        finish_cnt_ = 0;
+        finish_cnt_.store(0, std::memory_order_relaxed);
     }
 
     bool Execute(CcShard &ccs) override
     {
         ccs.ClearTx(tx_number_);
 
-        std::unique_lock<std::mutex> lk(mux_);
-        ++finish_cnt_;
-        wait_cv_.notify_one();
+        finish_cnt_.fetch_add(1, std::memory_order_acq_rel);
 
         // return false since ClearTxCc is not reused and does not need to call
         // CcRequestBase::Free
         return false;
     }
 
-    void Wait()
-    {
-        std::unique_lock<std::mutex> lk(mux_);
-        wait_cv_.wait(lk, [this]() { return finish_cnt_ == core_cnt_; });
-    }
+    void Wait();
 
 private:
-    std::mutex mux_;
-    std::condition_variable wait_cv_;
-    uint32_t finish_cnt_;
+    std::atomic<uint32_t> finish_cnt_;
     const uint32_t core_cnt_;
 };
 
@@ -7604,15 +7577,13 @@ public:
 
     void Reset(const TableName &table_name,
                txservice::NodeGroupId ng_id,
-               int64_t &ng_term,
+               std::atomic<int64_t> &ng_term,
                int32_t partition_id,
                size_t batch_size,
                size_t start_key_idx,
                const std::vector<std::pair<uint8_t, WriteEntry *>> &entry_vec,
-               bthread::Mutex &req_mux,
-               bthread::ConditionVariable &req_cv,
-               size_t &finished_req_cnt,
-               CcErrorCode &req_result,
+               std::atomic<size_t> &finished_req_cnt,
+               std::atomic<CcErrorCode> &req_result,
                UploadBatchType data_type)
     {
         table_name_ = &table_name;
@@ -7623,8 +7594,6 @@ public:
         batch_size_ = batch_size;
         start_key_idx_ = start_key_idx;
         entry_vector_ = &entry_vec;
-        req_mux_ = &req_mux;
-        req_cv_ = &req_cv;
         finished_req_cnt_ = &finished_req_cnt;
         req_result_ = &req_result;
         unfinished_cnt_.store(1, std::memory_order_relaxed);
@@ -7636,14 +7605,12 @@ public:
 
     void Reset(const TableName &table_name,
                txservice::NodeGroupId ng_id,
-               int64_t &ng_term,
+               std::atomic<int64_t> &ng_term,
                int32_t partition_id,
                size_t core_cnt,
                uint32_t batch_size,
                const WriteEntryTuple &entry_tuple,
-               bthread::Mutex &req_mux,
-               bthread::ConditionVariable &req_cv,
-               size_t &finished_req_cnt,
+               std::atomic<size_t> &finished_req_cnt,
                UploadBatchType data_type)
     {
         table_name_ = &table_name;
@@ -7654,8 +7621,6 @@ public:
         batch_size_ = batch_size;
         start_key_idx_ = 0;
         entry_tuples_ = &entry_tuple;
-        req_mux_ = &req_mux;
-        req_cv_ = &req_cv;
         finished_req_cnt_ = &finished_req_cnt;
         req_result_ = nullptr;
         unfinished_cnt_.store(core_cnt, std::memory_order_relaxed);
@@ -7667,21 +7632,24 @@ public:
 
     bool ValidTermCheck()
     {
-        std::lock_guard<bthread::Mutex> req_lk(*req_mux_);
+        // Lock-free term check. The owner of this request may be a bthread
+        // and this method runs on tx processors (the brpc worker main
+        // stack), so no bthread::Mutex may be shared between the two sides.
         int64_t cc_ng_term = Sharder::Instance().LeaderTerm(node_group_id_);
-        if (*node_group_term_ < 0)
+        int64_t expected_term =
+            node_group_term_->load(std::memory_order_acquire);
+        if (expected_term < 0)
         {
-            *node_group_term_ = cc_ng_term;
+            if (node_group_term_->compare_exchange_strong(
+                    expected_term, cc_ng_term, std::memory_order_acq_rel))
+            {
+                expected_term = cc_ng_term;
+            }
+            // On CAS failure, expected_term holds the term set by another
+            // core.
         }
 
-        if (cc_ng_term < 0 || cc_ng_term != *node_group_term_)
-        {
-            return false;
-        }
-        else
-        {
-            return true;
-        }
+        return cc_ng_term >= 0 && cc_ng_term == expected_term;
     }
 
     bool Execute(CcShard &ccs) override
@@ -7728,14 +7696,14 @@ public:
     {
         if (unfinished_cnt_.fetch_sub(1, std::memory_order_acq_rel) == 1)
         {
-            std::unique_lock<bthread::Mutex> req_lk(*req_mux_);
-            ++(*finished_req_cnt_);
             auto res = err_code_.load(std::memory_order_relaxed);
             if (req_result_ && res != CcErrorCode::NO_ERROR)
             {
-                *req_result_ = res;
+                req_result_->store(res, std::memory_order_relaxed);
             }
-            req_cv_->notify_one();
+            // The owner polls finished_req_cnt_; the release order makes the
+            // result visible before the count is bumped.
+            finished_req_cnt_->fetch_add(1, std::memory_order_acq_rel);
 
             return true;
         }
@@ -7749,13 +7717,12 @@ public:
             no_error, err_code, std::memory_order_acq_rel);
         if (unfinished_cnt_.fetch_sub(1, std::memory_order_acq_rel) == 1)
         {
-            std::unique_lock<bthread::Mutex> req_lk(*req_mux_);
-            ++(*finished_req_cnt_);
             if (req_result_)
             {
-                *req_result_ = err_code_.load(std::memory_order_relaxed);
+                req_result_->store(err_code_.load(std::memory_order_relaxed),
+                                   std::memory_order_relaxed);
             }
-            req_cv_->notify_one();
+            finished_req_cnt_->fetch_add(1, std::memory_order_acq_rel);
 
             return true;
         }
@@ -7775,7 +7742,7 @@ public:
 
     int64_t CcNgTerm() const
     {
-        return *node_group_term_;
+        return node_group_term_->load(std::memory_order_acquire);
     }
 
     uint32_t NodeGroupId() const
@@ -7851,7 +7818,7 @@ public:
 private:
     const TableName *table_name_{nullptr};
     uint32_t node_group_id_{0};
-    int64_t *node_group_term_{nullptr};
+    std::atomic<int64_t> *node_group_term_{nullptr};
     bool is_remote_{false};
     // -1 means broadcast to all shards(used by hash partition)
     int32_t partition_id_{-1};
@@ -7865,10 +7832,8 @@ private:
         const WriteEntryTuple *entry_tuples_;
     };
 
-    bthread::Mutex *req_mux_{nullptr};
-    bthread::ConditionVariable *req_cv_{nullptr};
-    size_t *finished_req_cnt_{nullptr};
-    CcErrorCode *req_result_{nullptr};
+    std::atomic<size_t> *finished_req_cnt_{nullptr};
+    std::atomic<CcErrorCode> *req_result_{nullptr};
     // This two variables may be accessed by multi-cores.
     std::atomic<size_t> unfinished_cnt_{0};
     std::atomic<CcErrorCode> err_code_{CcErrorCode::NO_ERROR};
@@ -8410,8 +8375,9 @@ public:
         Clear();
         table_names_ = table_names;
 
-        total_ref_cnt_ = local_ref_cnt + remote_ref_cnt;
-        remote_ref_cnt_ = remote_ref_cnt;
+        total_ref_cnt_.store(local_ref_cnt + remote_ref_cnt,
+                             std::memory_order_relaxed);
+        remote_ref_cnt_.store(remote_ref_cnt, std::memory_order_relaxed);
         total_obj_sizes_.resize(table_names_->size(), 0);
     }
 
@@ -8433,11 +8399,7 @@ public:
             }
         }
 
-        std::unique_lock lk(mux_);
-        if (--total_ref_cnt_ == 0)
-        {
-            cv_.notify_one();
-        }
+        total_ref_cnt_.fetch_sub(1, std::memory_order_acq_rel);
 
         return false;
     }
@@ -8473,13 +8435,11 @@ public:
                 idx, total_obj_sizes[idx], std::memory_order_relaxed);
         }
 
-        std::unique_lock lk(mux_);
-        --remote_ref_cnt_;
-        --total_ref_cnt_;
-        if (total_ref_cnt_ == 0)
-        {
-            cv_.notify_one();
-        }
+        // Decrement remote_ref_cnt_ first so that Wait() never observes
+        // total_ref_cnt_ <= remote_ref_cnt_ (the give-up-on-remote condition)
+        // while a local core is still pending.
+        remote_ref_cnt_.fetch_sub(1, std::memory_order_relaxed);
+        total_ref_cnt_.fetch_sub(1, std::memory_order_acq_rel);
     }
 
     int32_t GetTerm()
@@ -8496,27 +8456,13 @@ public:
         total_obj_sizes_.clear();
         total_obj_sizes_.shrink_to_fit();
 
-        total_ref_cnt_ = 0;
-        remote_ref_cnt_ = 0;
+        total_ref_cnt_.store(0, std::memory_order_relaxed);
+        remote_ref_cnt_.store(0, std::memory_order_relaxed);
         table_names_ = nullptr;
         vct_ng_id_.clear();
     }
 
-    void Wait()
-    {
-        const uint64_t MAX_WAIT_TS = 2000000;
-        std::unique_lock lk(mux_);
-
-        while (total_ref_cnt_ > 0)
-        {
-            int wait_res = cv_.wait_for(lk, MAX_WAIT_TS);
-            if (wait_res == ETIMEDOUT && total_ref_cnt_ <= remote_ref_cnt_)
-            {
-                LOG(WARNING) << "Waitting timeout for dbsize";
-                break;
-            }
-        }
-    }
+    void Wait();
 
     void TotalObjSizesFetchAdd(size_t idx,
                                int64_t size,
@@ -8538,15 +8484,12 @@ public:
         return total_obj_sizes_.size();
     }
 
-    bthread::Mutex mux_;
-    bthread::ConditionVariable cv_;
-
 private:
     std::vector<int64_t /*atomic*/> total_obj_sizes_;
 
 protected:
-    size_t total_ref_cnt_{0};
-    size_t remote_ref_cnt_{0};
+    std::atomic<size_t> total_ref_cnt_{0};
+    std::atomic<size_t> remote_ref_cnt_{0};
     int32_t term_{0};
     std::vector<uint32_t> vct_ng_id_;
     std::vector<TableName> *table_names_{nullptr};
@@ -8582,28 +8525,15 @@ struct EscalateStandbyCcmCc : CcRequestBase
     {
         return primary_ckpt_ts_;
     }
-    void Wait()
-    {
-        std::unique_lock<bthread::Mutex> lk(req_mux_);
-        while (unfinished_cnt_ != 0)
-        {
-            req_cv_.wait(lk);
-        }
-    }
+    void Wait();
     void SetFinish()
     {
-        std::unique_lock<bthread::Mutex> lk(req_mux_);
-        if (--unfinished_cnt_ == 0)
-        {
-            req_cv_.notify_one();
-        }
+        unfinished_cnt_.fetch_sub(1, std::memory_order_acq_rel);
     }
 
 private:
     uint64_t primary_ckpt_ts_;
-    bthread::Mutex req_mux_{};
-    bthread::ConditionVariable req_cv_{};
-    uint16_t unfinished_cnt_{0};
+    std::atomic<uint16_t> unfinished_cnt_{0};
 };
 
 struct ScanSliceDeltaSizeCcForRangePartition : public CcRequestBase

--- a/tx_service/include/cc/cc_request.h
+++ b/tx_service/include/cc/cc_request.h
@@ -8378,7 +8378,10 @@ public:
         total_ref_cnt_.store(local_ref_cnt + remote_ref_cnt,
                              std::memory_order_relaxed);
         remote_ref_cnt_.store(remote_ref_cnt, std::memory_order_relaxed);
-        total_obj_sizes_.resize(table_names_->size(), 0);
+        // Value-initialized, i.e. all zeros. std::atomic is not movable, so
+        // the vector is replaced instead of resized.
+        total_obj_sizes_ =
+            std::vector<std::atomic<int64_t>>(table_names_->size());
     }
 
     bool Execute(CcShard &ccs) override
@@ -8424,7 +8427,7 @@ public:
     void AddRemoteObjSize(int32_t term,
                           const std::vector<int64_t> &total_obj_sizes)
     {
-        if (term != term_)
+        if (term != term_.load(std::memory_order_acquire))
         {
             return;
         }
@@ -8444,17 +8447,16 @@ public:
 
     int32_t GetTerm()
     {
-        return term_;
+        return term_.load(std::memory_order_acquire);
     }
     void IncTerm()
     {
-        term_++;
+        term_.fetch_add(1, std::memory_order_acq_rel);
     }
 
     void Clear()
     {
-        total_obj_sizes_.clear();
-        total_obj_sizes_.shrink_to_fit();
+        total_obj_sizes_ = std::vector<std::atomic<int64_t>>();
 
         total_ref_cnt_.store(0, std::memory_order_relaxed);
         remote_ref_cnt_.store(0, std::memory_order_relaxed);
@@ -8468,15 +8470,12 @@ public:
                                int64_t size,
                                std::memory_order order)
     {
-        reinterpret_cast<std::atomic_int64_t &>(total_obj_sizes_[idx])
-            .fetch_add(size, order);
+        total_obj_sizes_[idx].fetch_add(size, order);
     }
 
     int64_t TotalObjSizesLoad(size_t idx, std::memory_order order) const
     {
-        return reinterpret_cast<const std::atomic_int64_t &>(
-                   total_obj_sizes_[idx])
-            .load(order);
+        return total_obj_sizes_[idx].load(order);
     }
 
     size_t TotalObjSizesCount() const
@@ -8485,12 +8484,12 @@ public:
     }
 
 private:
-    std::vector<int64_t /*atomic*/> total_obj_sizes_;
+    std::vector<std::atomic<int64_t>> total_obj_sizes_;
 
 protected:
     std::atomic<size_t> total_ref_cnt_{0};
     std::atomic<size_t> remote_ref_cnt_{0};
-    int32_t term_{0};
+    std::atomic<int32_t> term_{0};
     std::vector<uint32_t> vct_ng_id_;
     std::vector<TableName> *table_names_{nullptr};
 };

--- a/tx_service/include/sk_generator.h
+++ b/tx_service/include/sk_generator.h
@@ -107,15 +107,13 @@ private:
     void SendIndexes(
         const TableName &table_name,
         NodeGroupId dest_ng_id,
-        int64_t &ng_term,
+        std::atomic<int64_t> &ng_term,
         int32_t partition_id,
         const std::vector<std::pair<uint8_t, WriteEntry *>> &write_entry_vec,
         size_t batch_size,
         size_t start_key_idx,
-        bthread::Mutex &req_mux,
-        bthread::ConditionVariable &req_cv,
-        size_t &finished_req_cnt,
-        CcErrorCode &res_code);
+        std::atomic<size_t> &finished_req_cnt,
+        std::atomic<CcErrorCode> &res_code);
     // Acquire and release range read lock.
     CcErrorCode AcquireRangeReadLocks(
         TransactionExecution *acq_lock_txm,

--- a/tx_service/src/cc/cc_req_misc.cpp
+++ b/tx_service/src/cc/cc_req_misc.cpp
@@ -517,8 +517,9 @@ void ClearCcNodeGroup::Wait()
     while (!done_.load(std::memory_order_acquire))
     {
         bthread_usleep(interval_us);
-        if ((interval_us << 1) < max_interval)
-            interval_us <<= 1;
+        interval_us <<= 1;
+        if (interval_us > max_interval)
+            interval_us = max_interval;
     }
 }
 
@@ -1141,8 +1142,9 @@ void WaitableCc::Wait()
     while (unfinished_cnt_.load(std::memory_order_acquire) > 0)
     {
         bthread_usleep(interval_us);
-        if ((interval_us << 1) < max_interval)
-            interval_us <<= 1;
+        interval_us <<= 1;
+        if (interval_us > max_interval)
+            interval_us = max_interval;
     }
 }
 

--- a/tx_service/src/cc/cc_req_misc.cpp
+++ b/tx_service/src/cc/cc_req_misc.cpp
@@ -21,6 +21,8 @@
  */
 #include "cc/cc_req_misc.h"
 
+#include <bthread/bthread.h>
+
 #include <algorithm>
 #include <atomic>
 #include <cstddef>
@@ -490,9 +492,8 @@ bool ClearCcNodeGroup::Execute(CcShard &ccs)
         ccs.ClearActiveBlockingTxs();
     }
 
-    std::unique_lock lk(mux_);
-    ++finish_cnt_;
-    if (finish_cnt_ == core_cnt_)
+    uint16_t finished = finish_cnt_.fetch_add(1, std::memory_order_acq_rel);
+    if (finished + 1 == core_cnt_)
     {
         ccs.local_shards_.DropTableStatistics(cc_ng_id_);
         ccs.local_shards_.DropCatalogs(cc_ng_id_);
@@ -500,13 +501,25 @@ bool ClearCcNodeGroup::Execute(CcShard &ccs)
         ccs.local_shards_.DropBucketInfo(cc_ng_id_);
         LOG(INFO) << "ccshard: " << ccs.core_id_
                   << "; clear ccmaps and catalogs of node group: " << cc_ng_id_;
-        wait_cv_.notify_one();
+        done_.store(true, std::memory_order_release);
     }
 
     // The owner of this request is the raft thread that downgrades the cc
     // ng leader to a non-leader node. The request is not in a resource pool
     // and re-used. So, always returns false.
     return false;
+}
+
+void ClearCcNodeGroup::Wait()
+{
+    uint64_t interval_us = 100;
+    constexpr uint64_t max_interval = 100000;
+    while (!done_.load(std::memory_order_acquire))
+    {
+        bthread_usleep(interval_us);
+        if ((interval_us << 1) < max_interval)
+            interval_us <<= 1;
+    }
 }
 
 void InitKeyCacheCc::SetFinish(bool succ)
@@ -1119,6 +1132,18 @@ bool RunOnTxProcessorCc::Execute(CcShard &ccs)
         }
     }
     return true;
+}
+
+void WaitableCc::Wait()
+{
+    uint64_t interval_us = 100;
+    constexpr uint64_t max_interval = 100000;
+    while (unfinished_cnt_.load(std::memory_order_acquire) > 0)
+    {
+        bthread_usleep(interval_us);
+        if ((interval_us << 1) < max_interval)
+            interval_us <<= 1;
+    }
 }
 
 bool UpdateCceCkptTsCc::Execute(CcShard &ccs)

--- a/tx_service/src/cc/cc_request.cpp
+++ b/tx_service/src/cc/cc_request.cpp
@@ -83,8 +83,9 @@ void CkptTsCc::Wait()
     while (unfinish_cnt_.load(std::memory_order_acquire) > 0)
     {
         bthread_usleep(interval_us);
-        if ((interval_us << 1) < max_interval)
-            interval_us <<= 1;
+        interval_us <<= 1;
+        if (interval_us > max_interval)
+            interval_us = max_interval;
     }
 }
 
@@ -95,8 +96,9 @@ void ClearTxCc::Wait()
     while (finish_cnt_.load(std::memory_order_acquire) < core_cnt_)
     {
         bthread_usleep(interval_us);
-        if ((interval_us << 1) < max_interval)
-            interval_us <<= 1;
+        interval_us <<= 1;
+        if (interval_us > max_interval)
+            interval_us = max_interval;
     }
 }
 
@@ -107,8 +109,9 @@ void ActiveTxMaxTsCc::Wait()
     while (unfinish_cnt_.load(std::memory_order_acquire) > 0)
     {
         bthread_usleep(interval_us);
-        if ((interval_us << 1) < max_interval)
-            interval_us <<= 1;
+        interval_us <<= 1;
+        if (interval_us > max_interval)
+            interval_us = max_interval;
     }
 }
 
@@ -119,8 +122,9 @@ void EscalateStandbyCcmCc::Wait()
     while (unfinished_cnt_.load(std::memory_order_acquire) > 0)
     {
         bthread_usleep(interval_us);
-        if ((interval_us << 1) < max_interval)
-            interval_us <<= 1;
+        interval_us <<= 1;
+        if (interval_us > max_interval)
+            interval_us = max_interval;
     }
 }
 
@@ -140,13 +144,14 @@ void DbSizeCc::Wait()
             total_ref_cnt_.load(std::memory_order_acquire) <=
                 remote_ref_cnt_.load(std::memory_order_acquire))
         {
-            LOG(WARNING) << "Waitting timeout for dbsize";
+            LOG(WARNING) << "Waiting timeout for dbsize";
             break;
         }
         bthread_usleep(interval_us);
         waited_us += interval_us;
-        if ((interval_us << 1) < max_interval)
-            interval_us <<= 1;
+        interval_us <<= 1;
+        if (interval_us > max_interval)
+            interval_us = max_interval;
     }
 }
 }  // namespace txservice

--- a/tx_service/src/cc/cc_request.cpp
+++ b/tx_service/src/cc/cc_request.cpp
@@ -87,4 +87,66 @@ void CkptTsCc::Wait()
             interval_us <<= 1;
     }
 }
+
+void ClearTxCc::Wait()
+{
+    uint64_t interval_us = 100;
+    constexpr uint64_t max_interval = 100000;
+    while (finish_cnt_.load(std::memory_order_acquire) < core_cnt_)
+    {
+        bthread_usleep(interval_us);
+        if ((interval_us << 1) < max_interval)
+            interval_us <<= 1;
+    }
+}
+
+void ActiveTxMaxTsCc::Wait()
+{
+    uint64_t interval_us = 100;
+    constexpr uint64_t max_interval = 100000;
+    while (unfinish_cnt_.load(std::memory_order_acquire) > 0)
+    {
+        bthread_usleep(interval_us);
+        if ((interval_us << 1) < max_interval)
+            interval_us <<= 1;
+    }
+}
+
+void EscalateStandbyCcmCc::Wait()
+{
+    uint64_t interval_us = 100;
+    constexpr uint64_t max_interval = 100000;
+    while (unfinished_cnt_.load(std::memory_order_acquire) > 0)
+    {
+        bthread_usleep(interval_us);
+        if ((interval_us << 1) < max_interval)
+            interval_us <<= 1;
+    }
+}
+
+void DbSizeCc::Wait()
+{
+    // Wait for all local cores and remote node groups to report. After
+    // roughly 2 seconds, if only remote responses are missing, give up on
+    // them; a late response of the same term is dropped by the term check
+    // in AddRemoteObjSize().
+    constexpr uint64_t max_wait_us = 2000000;
+    uint64_t waited_us = 0;
+    uint64_t interval_us = 100;
+    constexpr uint64_t max_interval = 100000;
+    while (total_ref_cnt_.load(std::memory_order_acquire) > 0)
+    {
+        if (waited_us >= max_wait_us &&
+            total_ref_cnt_.load(std::memory_order_acquire) <=
+                remote_ref_cnt_.load(std::memory_order_acquire))
+        {
+            LOG(WARNING) << "Waitting timeout for dbsize";
+            break;
+        }
+        bthread_usleep(interval_us);
+        waited_us += interval_us;
+        if ((interval_us << 1) < max_interval)
+            interval_us <<= 1;
+    }
+}
 }  // namespace txservice

--- a/tx_service/src/remote/cc_node_service.cpp
+++ b/tx_service/src/remote/cc_node_service.cpp
@@ -1392,8 +1392,7 @@ void CcNodeService::UploadBatch(
     {
         uint64_t interval_us = 100;
         constexpr uint64_t max_interval = 100000;
-        while (finished_req.load(std::memory_order_acquire) != 1 ||
-               req.InUse())
+        while (finished_req.load(std::memory_order_acquire) != 1 || req.InUse())
         {
             bthread_usleep(interval_us);
             interval_us <<= 1;

--- a/tx_service/src/remote/cc_node_service.cpp
+++ b/tx_service/src/remote/cc_node_service.cpp
@@ -1358,21 +1358,21 @@ void CcNodeService::UploadBatch(
                                        request->rec_status(),
                                        request->range_size_flags());
 
-    size_t finished_req = 0;
-    bthread::Mutex req_mux;
-    bthread::ConditionVariable req_cv;
+    // This RPC handler runs on a bthread while UploadBatchCc executes on tx
+    // processors (the brpc worker main stack). The two sides must not share
+    // a bthread::Mutex, so the handler polls atomics instead.
+    std::atomic<size_t> finished_req{0};
+    std::atomic<int64_t> upload_ng_term{ng_term};
 
     UploadBatchCc req;
     req.Use();
     req.Reset(table_name,
               ng_id,
-              ng_term,
+              upload_ng_term,
               partition_id,
               core_cnt,
               batch_size,
               write_entry_tuple,
-              req_mux,
-              req_cv,
               finished_req,
               data_type);
     if (partition_id >= 0)
@@ -1390,10 +1390,16 @@ void CcNodeService::UploadBatch(
     }
 
     {
-        std::unique_lock<bthread::Mutex> req_lk(req_mux);
-        while (finished_req != 1 || req.InUse())
+        uint64_t interval_us = 100;
+        constexpr uint64_t max_interval = 100000;
+        while (finished_req.load(std::memory_order_acquire) != 1 ||
+               req.InUse())
         {
-            req_cv.wait_for(req_lk, 1000000);
+            bthread_usleep(interval_us);
+            if ((interval_us << 1) < max_interval)
+            {
+                interval_us <<= 1;
+            }
         }
     }
 

--- a/tx_service/src/remote/cc_node_service.cpp
+++ b/tx_service/src/remote/cc_node_service.cpp
@@ -1396,9 +1396,10 @@ void CcNodeService::UploadBatch(
                req.InUse())
         {
             bthread_usleep(interval_us);
-            if ((interval_us << 1) < max_interval)
+            interval_us <<= 1;
+            if (interval_us > max_interval)
             {
-                interval_us <<= 1;
+                interval_us = max_interval;
             }
         }
     }

--- a/tx_service/src/remote/remote_cc_request.cpp
+++ b/tx_service/src/remote/remote_cc_request.cpp
@@ -2317,7 +2317,7 @@ txservice::remote::RemoteDbSizeCc::RemoteDbSizeCc()
 
     post_lambda_ = [this]()
     {
-        assert(total_ref_cnt_ == 0);
+        assert(total_ref_cnt_.load(std::memory_order_relaxed) == 0);
         output_msg_.set_handler_addr(input_msg_->handler_addr());
         output_msg_.set_txm_addr(input_msg_->txm_addr());
 
@@ -2362,8 +2362,8 @@ void txservice::remote::RemoteDbSizeCc::Reset(
 
     DbSizeCc::Reset(&redis_table_names_, core_cnt, 0);
     assert(table_names_ == &redis_table_names_);
-    assert(total_ref_cnt_ == core_cnt);
-    assert(remote_ref_cnt_ == 0);
+    assert(total_ref_cnt_.load(std::memory_order_relaxed) == core_cnt);
+    assert(remote_ref_cnt_.load(std::memory_order_relaxed) == 0);
 
     AddLocalNodeGroupId(cmds_req.node_group_id());
 
@@ -2388,11 +2388,10 @@ bool txservice::remote::RemoteDbSizeCc::Execute(CcShard &ccs)
         }
     }
 
-    std::unique_lock lk(mux_);
-    assert(remote_ref_cnt_ == 0);
-    --total_ref_cnt_;
-    if (total_ref_cnt_ == 0)
+    assert(remote_ref_cnt_.load(std::memory_order_relaxed) == 0);
+    if (total_ref_cnt_.fetch_sub(1, std::memory_order_acq_rel) == 1)
     {
+        // The last core cleans up and sends the response.
         table_names_ = nullptr;
         redis_table_names_.clear();
         redis_table_names_.shrink_to_fit();

--- a/tx_service/src/sk_generator.cpp
+++ b/tx_service/src/sk_generator.cpp
@@ -828,8 +828,7 @@ void UploadIndexContext::SendIndexes(
         remote::UploadBatchRequest *req_ptr =
             upload_batch_closure->UploadBatchRequest();
         req_ptr->set_node_group_id(dest_ng_id);
-        req_ptr->set_node_group_term(
-            ng_term.load(std::memory_order_acquire));
+        req_ptr->set_node_group_term(ng_term.load(std::memory_order_acquire));
         req_ptr->set_table_name_str(table_name.String());
         req_ptr->set_table_type(
             remote::ToRemoteType::ConvertTableType(table_name.Type()));

--- a/tx_service/src/sk_generator.cpp
+++ b/tx_service/src/sk_generator.cpp
@@ -21,6 +21,8 @@
  */
 #include "sk_generator.h"
 
+#include <bthread/bthread.h>
+
 #include <mutex>
 #include <optional>
 
@@ -655,17 +657,25 @@ CcErrorCode UploadIndexContext::UploadIndexInternal(
 {
     size_t entry_vec_size = 0;
     size_t batch_req_cnt = 0;
-    bthread::Mutex req_mux;
-    bthread::ConditionVariable req_cv;
-    size_t finished_upload_count = 0;
-    CcErrorCode upload_res_code = CcErrorCode::NO_ERROR;
+    // The upload requests run on tx processors (the brpc worker main stack)
+    // and the remote-response closures run on bthreads, so the shared
+    // completion state must be lock-free: a bthread::Mutex shared with the
+    // tx processors can deadlock the worker.
+    std::atomic<size_t> finished_upload_count{0};
+    std::atomic<CcErrorCode> upload_res_code{CcErrorCode::NO_ERROR};
     size_t upload_req_count = 0;
+
+    std::vector<std::atomic<int64_t>> ng_terms(leader_terms_.size());
+    for (size_t idx = 0; idx < leader_terms_.size(); ++idx)
+    {
+        ng_terms[idx].store(leader_terms_[idx], std::memory_order_relaxed);
+    }
 
     for (auto &[table_name, ng_entries] : ng_index_set)
     {
         for (auto &[ng_id, range_entries] : ng_entries)
         {
-            int64_t &expected_term = leader_terms_.at(ng_id);
+            std::atomic<int64_t> &expected_term = ng_terms.at(ng_id);
 
             for (auto &[range_id, entry_vec] : range_entries)
             {
@@ -685,8 +695,6 @@ CcErrorCode UploadIndexContext::UploadIndexInternal(
                                 entry_vec,
                                 (end_idx - start_idx),
                                 start_idx,
-                                req_mux,
-                                req_cv,
                                 finished_upload_count,
                                 upload_res_code);
                     ++upload_req_count;
@@ -700,28 +708,37 @@ CcErrorCode UploadIndexContext::UploadIndexInternal(
     }
 
     {
-        std::unique_lock<bthread::Mutex> req_lk(req_mux);
-        while (upload_req_count != finished_upload_count)
+        uint64_t interval_us = 100;
+        constexpr uint64_t max_interval = 100000;
+        while (finished_upload_count.load(std::memory_order_acquire) !=
+               upload_req_count)
         {
-            req_cv.wait(req_lk);
+            bthread_usleep(interval_us);
+            if ((interval_us << 1) < max_interval)
+            {
+                interval_us <<= 1;
+            }
         }
     }
 
-    return upload_res_code;
+    for (size_t idx = 0; idx < leader_terms_.size(); ++idx)
+    {
+        leader_terms_[idx] = ng_terms[idx].load(std::memory_order_relaxed);
+    }
+
+    return upload_res_code.load(std::memory_order_acquire);
 }
 
 void UploadIndexContext::SendIndexes(
     const TableName &table_name,
     NodeGroupId dest_ng_id,
-    int64_t &ng_term,
+    std::atomic<int64_t> &ng_term,
     int32_t partition_id,
     const std::vector<std::pair<uint8_t, WriteEntry *>> &write_entry_vec,
     size_t batch_size,
     size_t start_key_idx,
-    bthread::Mutex &req_mux,
-    bthread::ConditionVariable &req_cv,
-    size_t &finished_req_cnt,
-    CcErrorCode &res_code)
+    std::atomic<size_t> &finished_req_cnt,
+    std::atomic<CcErrorCode> &res_code)
 {
     uint32_t dest_node_id = Sharder::Instance().LeaderNodeId(dest_ng_id);
     LocalCcShards *cc_shards = Sharder::Instance().GetLocalCcShards();
@@ -735,8 +752,6 @@ void UploadIndexContext::SendIndexes(
                        batch_size,
                        start_key_idx,
                        write_entry_vec,
-                       req_mux,
-                       req_cv,
                        finished_req_cnt,
                        res_code,
                        UploadBatchType::SkIndexData);
@@ -756,43 +771,33 @@ void UploadIndexContext::SendIndexes(
             // leader term of input node group.
             LOG(ERROR) << "SendIndexes: Failed to init the channel of ng#"
                        << dest_ng_id;
-            std::unique_lock<bthread::Mutex> req_lk(req_mux);
-            res_code = CcErrorCode::ESTABLISH_NODE_CHANNEL_FAILED;
-            ++finished_req_cnt;
-            req_cv.notify_one();
+            res_code.store(CcErrorCode::ESTABLISH_NODE_CHANNEL_FAILED,
+                           std::memory_order_relaxed);
+            finished_req_cnt.fetch_add(1, std::memory_order_acq_rel);
             return;
         }
 
         remote::CcRpcService_Stub stub(channel.get());
 
         UploadBatchClosure *upload_batch_closure = new UploadBatchClosure(
-            [dest_ng_id,
-             &res_code,
-             &finished_req_cnt,
-             &req_mux,
-             &req_cv,
-             &ng_term](CcErrorCode res, int32_t dest_term)
+            [dest_ng_id, &res_code, &finished_req_cnt, &ng_term](
+                CcErrorCode res, int32_t dest_term)
             {
-                std::unique_lock<bthread::Mutex> req_lk(req_mux);
-                res_code = res;
+                res_code.store(res, std::memory_order_relaxed);
                 if (res == CcErrorCode::NO_ERROR)
                 {
-                    if (ng_term == INIT_TERM)
-                    {
-                        ng_term = dest_term;
-                    }
-                    else if (ng_term != dest_term)
+                    int64_t expected = INIT_TERM;
+                    if (!ng_term.compare_exchange_strong(
+                            expected, dest_term, std::memory_order_acq_rel) &&
+                        expected != dest_term)
                     {
                         LOG(ERROR)
                             << "Response for upload batch failed of ng#"
                             << dest_ng_id
                             << " of term mismatch, with expected term: "
-                            << ng_term << " and actual term: " << dest_term;
-                        res_code = CcErrorCode::REQUESTED_NODE_NOT_LEADER;
-                    }
-                    else
-                    {
-                        assert(ng_term == dest_term);
+                            << expected << " and actual term: " << dest_term;
+                        res_code.store(CcErrorCode::REQUESTED_NODE_NOT_LEADER,
+                                       std::memory_order_relaxed);
                     }
                 }
                 else
@@ -801,8 +806,7 @@ void UploadIndexContext::SendIndexes(
                         << "Response for upload batch failed of ng#"
                         << dest_ng_id << ", with error: " << (uint32_t) res;
                 }
-                ++finished_req_cnt;
-                req_cv.notify_one();
+                finished_req_cnt.fetch_add(1, std::memory_order_acq_rel);
             },
             UploadTimeout,
             true);
@@ -811,7 +815,8 @@ void UploadIndexContext::SendIndexes(
         remote::UploadBatchRequest *req_ptr =
             upload_batch_closure->UploadBatchRequest();
         req_ptr->set_node_group_id(dest_ng_id);
-        req_ptr->set_node_group_term(ng_term);
+        req_ptr->set_node_group_term(
+            ng_term.load(std::memory_order_acquire));
         req_ptr->set_table_name_str(table_name.String());
         req_ptr->set_table_type(
             remote::ToRemoteType::ConvertTableType(table_name.Type()));

--- a/tx_service/src/sk_generator.cpp
+++ b/tx_service/src/sk_generator.cpp
@@ -714,9 +714,10 @@ CcErrorCode UploadIndexContext::UploadIndexInternal(
                upload_req_count)
         {
             bthread_usleep(interval_us);
-            if ((interval_us << 1) < max_interval)
+            interval_us <<= 1;
+            if (interval_us > max_interval)
             {
-                interval_us <<= 1;
+                interval_us = max_interval;
             }
         }
     }
@@ -771,8 +772,13 @@ void UploadIndexContext::SendIndexes(
             // leader term of input node group.
             LOG(ERROR) << "SendIndexes: Failed to init the channel of ng#"
                        << dest_ng_id;
-            res_code.store(CcErrorCode::ESTABLISH_NODE_CHANNEL_FAILED,
-                           std::memory_order_relaxed);
+            // Latch the first error; later successful batches must not
+            // reset it.
+            CcErrorCode expected = CcErrorCode::NO_ERROR;
+            res_code.compare_exchange_strong(
+                expected,
+                CcErrorCode::ESTABLISH_NODE_CHANNEL_FAILED,
+                std::memory_order_acq_rel);
             finished_req_cnt.fetch_add(1, std::memory_order_acq_rel);
             return;
         }
@@ -783,7 +789,8 @@ void UploadIndexContext::SendIndexes(
             [dest_ng_id, &res_code, &finished_req_cnt, &ng_term](
                 CcErrorCode res, int32_t dest_term)
             {
-                res_code.store(res, std::memory_order_relaxed);
+                // Latch the first error; later successful batches must not
+                // reset res_code back to NO_ERROR.
                 if (res == CcErrorCode::NO_ERROR)
                 {
                     int64_t expected = INIT_TERM;
@@ -796,12 +803,18 @@ void UploadIndexContext::SendIndexes(
                             << dest_ng_id
                             << " of term mismatch, with expected term: "
                             << expected << " and actual term: " << dest_term;
-                        res_code.store(CcErrorCode::REQUESTED_NODE_NOT_LEADER,
-                                       std::memory_order_relaxed);
+                        CcErrorCode code = CcErrorCode::NO_ERROR;
+                        res_code.compare_exchange_strong(
+                            code,
+                            CcErrorCode::REQUESTED_NODE_NOT_LEADER,
+                            std::memory_order_acq_rel);
                     }
                 }
                 else
                 {
+                    CcErrorCode code = CcErrorCode::NO_ERROR;
+                    res_code.compare_exchange_strong(
+                        code, res, std::memory_order_acq_rel);
                     LOG(ERROR)
                         << "Response for upload batch failed of ng#"
                         << dest_ng_id << ", with error: " << (uint32_t) res;

--- a/tx_service/tests/CMakeLists.txt
+++ b/tx_service/tests/CMakeLists.txt
@@ -28,6 +28,7 @@ set(CATCH_MAIN_TESTS
     CcEntry-Test
     CcPage-Test
     LargeObjLRU-Test
+    CcRequestWait-Test
 )
 
 # Tests that define their own int main() (they need gflags::ParseCommandLineFlags

--- a/tx_service/tests/CcRequestWait-Test.cpp
+++ b/tx_service/tests/CcRequestWait-Test.cpp
@@ -1,0 +1,207 @@
+/**
+ *    Copyright (C) 2025 EloqData Inc.
+ *
+ *    This program is free software: you can redistribute it and/or  modify
+ *    it under either of the following two licenses:
+ *    1. GNU Affero General Public License, version 3, as published by the Free
+ *    Software Foundation.
+ *    2. GNU General Public License as published by the Free Software
+ *    Foundation; version 2 of the License.
+ *
+ *    This program is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU Affero General Public License or GNU General Public License for more
+ *    details.
+ *
+ *    You should have received a copy of the GNU Affero General Public License
+ *    and GNU General Public License V2 along with this program.  If not, see
+ *    <http://www.gnu.org/licenses/>.
+ *
+ */
+
+// Regression tests for the multi-core completion-counter that backs the
+// "waitable" CC requests (PR #491 / tx_service issue: avoid bthread::Mutex
+// shared between a CC request's Execute() on tx processors and its Wait() on a
+// bthread). The fix replaced the bthread::Mutex + ConditionVariable handshake
+// with a std::atomic completion counter polled by Wait(), and latches the
+// first error reported by AbortCcRequest(). WaitableCc is the generic carrier
+// of that pattern (ClearTxCc / ActiveTxMaxTsCc / EscalateStandbyCcmCc /
+// DbSizeCc / ClearCcNodeGroup share the same atomic-counter + polling Wait()).
+//
+// These tests drive the completion counter directly (no engine needed):
+// AbortCcRequest() is the public entry into FinishOne() (the same decrement
+// Execute() performs on success), and Wait() polls the atomic. They guard
+// against a future regression that (a) loses or races a decrement so Wait()
+// never returns, or (b) lets a later success clobber a previously latched
+// error.
+
+#include <atomic>
+#include <catch2/catch_all.hpp>
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <thread>
+#include <vector>
+
+#include "cc/cc_req_misc.h"  // WaitableCc
+#include "error_messages.h"  // CcErrorCode
+
+using namespace txservice;
+
+namespace
+{
+// A regressed Wait() would hang forever (exactly the deadlock the fix
+// prevents). Rather than wedge the whole test binary, a watchdog thread aborts
+// the process with a clear message if the body does not finish in time. It only
+// reads an atomic flag, so it never touches the test's stack objects.
+class Watchdog
+{
+public:
+    explicit Watchdog(std::chrono::milliseconds budget) : budget_(budget)
+    {
+        thread_ = std::thread(
+            [this]
+            {
+                const auto deadline =
+                    std::chrono::steady_clock::now() + budget_;
+                while (!done_.load(std::memory_order_acquire))
+                {
+                    if (std::chrono::steady_clock::now() > deadline)
+                    {
+                        std::fprintf(stderr,
+                                     "CcRequestWait-Test: WaitableCc::Wait() "
+                                     "did not return within the timeout -- the "
+                                     "completion counter likely regressed.\n");
+                        std::abort();
+                    }
+                    std::this_thread::sleep_for(std::chrono::milliseconds(5));
+                }
+            });
+    }
+
+    ~Watchdog()
+    {
+        done_.store(true, std::memory_order_release);
+        thread_.join();
+    }
+
+private:
+    std::chrono::milliseconds budget_;
+    std::atomic<bool> done_{false};
+    std::thread thread_;
+};
+}  // namespace
+
+TEST_CASE("WaitableCc Wait() returns once every core has finished",
+          "[cc-request-wait]")
+{
+    Watchdog wd(std::chrono::seconds(20));
+
+    for (uint16_t core_cnt : {1, 2, 4, 8})
+    {
+        std::atomic<int> finished{0};
+        WaitableCc cc([](CcShard &) { return true; }, core_cnt);
+
+        // Concurrent finishers: each is the equivalent of one core completing
+        // its Execute() and calling FinishOne(). A tiny stagger makes Wait()
+        // actually poll across the completions instead of seeing them all done.
+        std::vector<std::thread> finishers;
+        finishers.reserve(core_cnt);
+        for (uint16_t i = 0; i < core_cnt; ++i)
+        {
+            finishers.emplace_back(
+                [&cc, &finished, i]
+                {
+                    std::this_thread::sleep_for(std::chrono::milliseconds(i));
+                    finished.fetch_add(1, std::memory_order_relaxed);
+                    cc.AbortCcRequest(CcErrorCode::NO_ERROR);
+                });
+        }
+
+        cc.Wait();  // must return only after all core_cnt finishers ran
+
+        for (auto &t : finishers)
+        {
+            t.join();
+        }
+
+        CHECK(finished.load() == core_cnt);
+        CHECK(cc.IsFinished());
+        CHECK_FALSE(cc.IsError());
+    }
+}
+
+TEST_CASE("WaitableCc latches the first error and ignores later successes",
+          "[cc-request-wait]")
+{
+    Watchdog wd(std::chrono::seconds(20));
+
+    // Three cores: first reports an error, then a success, then a different
+    // error. The first error must win and a later success must not clear it.
+    WaitableCc cc([](CcShard &) { return true; }, /*core_cnt=*/3);
+
+    cc.AbortCcRequest(CcErrorCode::REQUESTED_NODE_NOT_LEADER);  // first error
+    CHECK(cc.IsError());
+    CHECK(cc.ErrorCode() == CcErrorCode::REQUESTED_NODE_NOT_LEADER);
+
+    cc.AbortCcRequest(CcErrorCode::NO_ERROR);  // success must not erase it
+    cc.AbortCcRequest(
+        CcErrorCode::NG_TERM_CHANGED);  // later error must not win
+
+    cc.Wait();
+
+    CHECK(cc.IsFinished());
+    CHECK(cc.IsError());
+    CHECK(cc.ErrorCode() == CcErrorCode::REQUESTED_NODE_NOT_LEADER);
+}
+
+TEST_CASE("WaitableCc Reset re-arms the counter and clears the error",
+          "[cc-request-wait]")
+{
+    Watchdog wd(std::chrono::seconds(20));
+
+    WaitableCc cc([](CcShard &) { return true; }, /*core_cnt=*/2);
+    cc.AbortCcRequest(CcErrorCode::NG_TERM_CHANGED);
+    cc.AbortCcRequest(CcErrorCode::NO_ERROR);
+    cc.Wait();
+    REQUIRE(cc.IsError());
+
+    // Re-arm for a clean 2-core round.
+    cc.Reset([](CcShard &) { return true; }, /*core_cnt=*/2);
+    CHECK_FALSE(cc.IsError());
+    CHECK_FALSE(cc.IsFinished());
+
+    cc.AbortCcRequest(CcErrorCode::NO_ERROR);
+    cc.AbortCcRequest(CcErrorCode::NO_ERROR);
+    cc.Wait();
+    CHECK(cc.IsFinished());
+    CHECK_FALSE(cc.IsError());
+}
+
+TEST_CASE("WaitableCc completion counter survives repeated concurrent rounds",
+          "[cc-request-wait][stress]")
+{
+    Watchdog wd(std::chrono::seconds(60));
+
+    constexpr uint16_t kCoreCnt = 4;
+    constexpr int kRounds = 2000;
+
+    for (int round = 0; round < kRounds; ++round)
+    {
+        WaitableCc cc([](CcShard &) { return true; }, kCoreCnt);
+        std::vector<std::thread> finishers;
+        finishers.reserve(kCoreCnt);
+        for (uint16_t i = 0; i < kCoreCnt; ++i)
+        {
+            finishers.emplace_back(
+                [&cc] { cc.AbortCcRequest(CcErrorCode::NO_ERROR); });
+        }
+        cc.Wait();
+        for (auto &t : finishers)
+        {
+            t.join();
+        }
+        REQUIRE(cc.IsFinished());
+    }
+}


### PR DESCRIPTION
## Problem

Same bug class as the CkptTsCc hang fixed in #483, found in several more CC requests after the issue reappeared in the field.

A `bthread::Mutex`/`ConditionVariable` shared between `CcRequest::Execute()` and a bthread owner can deadlock under our brpc fork:

1. `Execute()` runs on the brpc worker **main stack** (via `ProcessModulesTask()` → `TxProcessor::RunOneRound()`, with a fixed 1:1 worker↔shard binding), so a contended `lock()` there parks the worker as a **pthread waiter** in the mutex's butex queue.
2. The owner bthread waits on the same mutex/cv. `butex_wake` prefers bound-bthread waiters, and bound bthreads can only run on their home worker (`_bound_rq` is never stolen).
3. When an unlock routes the wake to a bthread bound to the blocked worker, the bthread sits in that worker's bound run queue forever while the worker sleeps in `butex_wait`. The mutex may even end up free — nobody can take it. `wait_for` timeouts don't help: in the end state no timer is pending.

The dangerous shape is **concurrent multi-acquisition** (a request broadcast to multiple cores, or one mutex shared by several in-flight requests) combined with a bthread waiter. Single-flight/single-waiter requests are structurally safe.

## Fix

Convert the affected requests to the pattern used by the CkptTsCc fix (#483): shard-side completion is tracked with atomics, the waiter polls with `bthread_usleep` exponential backoff (100us → 100ms), and no bthread::Mutex is shared between tx processors and bthreads.

| Request | Change |
|---|---|
| `ActiveTxMaxTsCc` (used by `ResetStandbySequenceId` RPC) | atomic countdown + polling `Wait()` |
| `WaitableCc` (covers `OnLeaderStart` / `SubscribePrimaryNode` / `UpdateInMemoryClusterConfig` / standby RPC handlers, etc.) | blocking `Wait()` polls; `IsFinished/IsError/ErrorCode` read atomics; `mux_` retained **only** for the coroutine yield/resume handshake whose waiter is a flush-worker `std::thread` |
| `ClearCcNodeGroup` | atomic counter + `done_` flag set after the last core's catalog/range/bucket cleanup |
| `EscalateStandbyCcmCc` | atomic countdown + polling `Wait()` |
| `ClearTxCc` | atomic countdown + polling `Wait()` (was `std::mutex`; safe today since the waiter is the recovery `std::thread`, but a latent landmine for any future bthread caller) |
| `DbSizeCc` / `RemoteDbSizeCc` | atomic ref counts; `Wait()` keeps the give-up-on-remote-after-2s semantics; `remote_ref_cnt_` decremented before `total_ref_cnt_` so the give-up condition never fires while a local core is pending |
| `UploadBatchCc` + `CcNodeService::UploadBatch` + sk_generator upload path | external coordination state (`req_mux/req_cv/finished_req_cnt/req_result/ng_term`) replaced with `std::atomic` references; `ValidTermCheck()` uses CAS; the `UploadBatchClosure` callback (runs on a bthread) updates atomics lock-free |

Left intentionally unchanged (structurally safe): `CheckTxStatusCc`, `WaitNoNakedBucketRefCc`, `UploadRangeSlicesCc`, `UploadBatchSlicesCc` (single-flight + single waiter), `UpdateCceCkptTsCc` and the flush-data coroutine path (waiter is a dedicated `std::thread`).

## Verification

- Full Debug build of eloqkv (with this tx_service) passes: `install/build.sh` exit 0.
- Recommended runtime coverage: standby subscribe/resubscribe, leader failover/step-down, `UploadBatch` during bucket migration, and the Redis `dbsize` command — these are the paths that previously hung.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reworked internal completion/error coordination across transaction-control flows to use atomic, lock-free tracking instead of lock/condition-variable synchronization.
  * Updated wait behavior to use bounded exponential-backoff polling, improving stability and avoiding cross-context wait issues.
  * Added explicit `Wait()` support for clearer completion handling in CC request paths.
* **Tests**
  * Added coverage for wait completion behavior, error latching, and repeated concurrent completion rounds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->