### PR TITLE
feat: expose RocksDB obsolete file scan period

### DIFF
--- a/store_handler/eloq_data_store_service/RocksDB_Configuration_Flags.md
+++ b/store_handler/eloq_data_store_service/RocksDB_Configuration_Flags.md
@@ -53,6 +53,7 @@ rocksdb_storage_path = /path/to/storage
 | `rocksdb_compaction_style` | No | `"level"` | String (options: "level", "universal", "fifo", "none") | Compaction style |
 | `rocksdb_max_subcompactions` | No | `1` | Integer | Maximum number of subcompactions |
 | `rocksdb_periodic_compaction_seconds` | No | `86400` (24 hours) | Integer | SST files older than this value will be picked up for compaction |
+| `rocksdb_delete_obsolete_files_period_micros` | No | `21600000000` (6 hours) | Integer | Period between full scans for obsolete files, in microseconds |
 
 ### Level-Based Compaction Configuration
 
@@ -166,4 +167,3 @@ Different flags have different format requirements:
 4. Size values must include units (`MB`, `GB`, or `TB`).
 5. A write rate limit of "0MB" means no limit is applied.
 6. The off-peak time is converted from local time to UTC by default.
-

--- a/store_handler/eloq_data_store_service/rocksdb_cloud_data_store.cpp
+++ b/store_handler/eloq_data_store_service/rocksdb_cloud_data_store.cpp
@@ -577,6 +577,8 @@ bool RocksDBCloudDataStore::OpenCloudDB(
     // through the TTLCompactionFilter which is configurated for column family
     options.periodic_compaction_seconds = periodic_compaction_seconds_;
     options.daily_offpeak_time_utc = dialy_offpeak_time_utc_;
+    options.delete_obsolete_files_period_micros =
+        delete_obsolete_files_period_micros_;
 
     if (target_file_size_base_ > 0)
     {

--- a/store_handler/eloq_data_store_service/rocksdb_config.cpp
+++ b/store_handler/eloq_data_store_service/rocksdb_config.cpp
@@ -104,6 +104,9 @@ DEFINE_uint32(
     rocksdb_periodic_compaction_seconds,
     24 * 60 * 60, /*sst files older than 1 day will be pick up for compaction*/
     "RocksDB periodic compaction seconds");
+DEFINE_uint64(rocksdb_delete_obsolete_files_period_micros,
+              6ULL * 60 * 60 * 1000000,
+              "RocksDB obsolete file full scan period in microseconds");
 
 static std::tm parseTime(const std::string &timeStr)
 {
@@ -494,6 +497,14 @@ RocksDBConfig::RocksDBConfig(const INIReader &config,
             : config.GetInteger("store",
                                 "rocksdb_periodic_compaction_seconds",
                                 FLAGS_rocksdb_periodic_compaction_seconds);
+    delete_obsolete_files_period_micros_ =
+        !CheckCommandLineFlagIsDefault(
+            "rocksdb_delete_obsolete_files_period_micros")
+            ? FLAGS_rocksdb_delete_obsolete_files_period_micros
+            : config.GetInteger(
+                  "store",
+                  "rocksdb_delete_obsolete_files_period_micros",
+                  FLAGS_rocksdb_delete_obsolete_files_period_micros);
     dialy_offpeak_time_utc_ =
         !CheckCommandLineFlagIsDefault("rocksdb_dialy_offpeak_time_utc")
             ? FLAGS_rocksdb_dialy_offpeak_time_utc

--- a/store_handler/eloq_data_store_service/rocksdb_config.h
+++ b/store_handler/eloq_data_store_service/rocksdb_config.h
@@ -21,6 +21,7 @@
  */
 #pragma once
 
+#include <cstdint>
 #include <string>
 
 #include "INIReader.h"
@@ -65,6 +66,7 @@ struct RocksDBConfig
     size_t query_worker_num_;
     size_t batch_write_size_;
     size_t periodic_compaction_seconds_;
+    uint64_t delete_obsolete_files_period_micros_;
     std::string dialy_offpeak_time_utc_;
 };
 

--- a/store_handler/eloq_data_store_service/rocksdb_data_store.cpp
+++ b/store_handler/eloq_data_store_service/rocksdb_data_store.cpp
@@ -177,6 +177,8 @@ bool RocksDBDataStore::StartDB(int64_t term)
     // through the TTLCompactionFilter which is configurated for column family
     options.periodic_compaction_seconds = periodic_compaction_seconds_;
     options.daily_offpeak_time_utc = dialy_offpeak_time_utc_;
+    options.delete_obsolete_files_period_micros =
+        delete_obsolete_files_period_micros_;
 
     if (target_file_size_base_ > 0)
     {

--- a/store_handler/eloq_data_store_service/rocksdb_data_store_common.h
+++ b/store_handler/eloq_data_store_service/rocksdb_data_store_common.h
@@ -146,6 +146,8 @@ public:
           write_rate_limit_(config.write_rate_limit_bytes_),
           batch_write_size_(config.batch_write_size_),
           periodic_compaction_seconds_(config.periodic_compaction_seconds_),
+          delete_obsolete_files_period_micros_(
+              config.delete_obsolete_files_period_micros_),
           dialy_offpeak_time_utc_(config.dialy_offpeak_time_utc_),
           db_path_(storage_path_ + "/db/"),
           ckpt_path_(storage_path_ + "/rocksdb_snapshot/"),
@@ -326,6 +328,7 @@ protected:
     const size_t write_rate_limit_;
     const size_t batch_write_size_;
     const size_t periodic_compaction_seconds_;
+    const uint64_t delete_obsolete_files_period_micros_;
     const std::string dialy_offpeak_time_utc_;
     const std::string db_path_;
     const std::string ckpt_path_;

--- a/store_handler/rocksdb_config.cpp
+++ b/store_handler/rocksdb_config.cpp
@@ -115,6 +115,9 @@ DEFINE_uint32(
     rocksdb_periodic_compaction_seconds,
     24 * 60 * 60, /*sst files older than 1 day will be pick up for compaction*/
     "RocksDB periodic compaction seconds");
+DEFINE_uint64(rocksdb_delete_obsolete_files_period_micros,
+              6ULL * 60 * 60 * 1000000,
+              "RocksDB obsolete file full scan period in microseconds");
 
 static std::tm parseTime(const std::string &timeStr)
 {
@@ -487,6 +490,14 @@ RocksDBConfig::RocksDBConfig(const INIReader &config,
             : config.GetInteger("store",
                                 "rocksdb_periodic_compaction_seconds",
                                 FLAGS_rocksdb_periodic_compaction_seconds);
+    delete_obsolete_files_period_micros_ =
+        !CheckCommandLineFlagIsDefault(
+            "rocksdb_delete_obsolete_files_period_micros")
+            ? FLAGS_rocksdb_delete_obsolete_files_period_micros
+            : config.GetInteger(
+                  "store",
+                  "rocksdb_delete_obsolete_files_period_micros",
+                  FLAGS_rocksdb_delete_obsolete_files_period_micros);
     dialy_offpeak_time_utc_ =
         !CheckCommandLineFlagIsDefault("rocksdb_dialy_offpeak_time_utc")
             ? FLAGS_rocksdb_dialy_offpeak_time_utc

--- a/store_handler/rocksdb_config.h
+++ b/store_handler/rocksdb_config.h
@@ -21,6 +21,7 @@
  */
 #pragma once
 
+#include <cstdint>
 #include <string>
 
 #include "INIReader.h"
@@ -69,6 +70,7 @@ struct RocksDBConfig
     size_t query_worker_num_;
     size_t batch_write_size_;
     size_t periodic_compaction_seconds_;
+    uint64_t delete_obsolete_files_period_micros_;
     std::string dialy_offpeak_time_utc_;
     size_t snapshot_sync_worker_num_;
 };

--- a/store_handler/rocksdb_handler.cpp
+++ b/store_handler/rocksdb_handler.cpp
@@ -213,6 +213,8 @@ RocksDBHandler::RocksDBHandler(const EloqShare::RocksDBConfig &config,
       write_rate_limit_(config.write_rate_limit_bytes_),
       batch_write_size_(config.batch_write_size_),
       periodic_compaction_seconds_(config.periodic_compaction_seconds_),
+      delete_obsolete_files_period_micros_(
+          config.delete_obsolete_files_period_micros_),
       dialy_offpeak_time_utc_(config.dialy_offpeak_time_utc_),
       db_path_(storage_path_ + "/db/"),
       ckpt_path_(storage_path_ + "/rocksdb_snapshot/"),
@@ -2939,6 +2941,8 @@ bool RocksDBCloudHandlerImpl::OpenCloudDB(
     // through the TTLCompactionFilter which is configurated for column family
     options.periodic_compaction_seconds = periodic_compaction_seconds_;
     options.daily_offpeak_time_utc = dialy_offpeak_time_utc_;
+    options.delete_obsolete_files_period_micros =
+        delete_obsolete_files_period_micros_;
 
     // The max_open_files default value is -1, it cause DB open all files on
     // DB::Open() This behavior causes 2 effects,
@@ -3453,6 +3457,8 @@ bool RocksDBHandlerImpl::StartDB(bool is_ng_leader, uint32_t *next_leader_node)
     // through the TTLCompactionFilter which is configurated for column family
     options.periodic_compaction_seconds = periodic_compaction_seconds_;
     options.daily_offpeak_time_utc = dialy_offpeak_time_utc_;
+    options.delete_obsolete_files_period_micros =
+        delete_obsolete_files_period_micros_;
 
     std::vector<rocksdb::ColumnFamilyDescriptor> cfds;
 

--- a/store_handler/rocksdb_handler.h
+++ b/store_handler/rocksdb_handler.h
@@ -614,6 +614,7 @@ protected:
     const size_t write_rate_limit_;
     const size_t batch_write_size_;
     size_t periodic_compaction_seconds_;
+    uint64_t delete_obsolete_files_period_micros_;
     std::string dialy_offpeak_time_utc_;
     const std::string db_path_;
     const std::string ckpt_path_;


### PR DESCRIPTION
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Reference the link of issue using `fixes eloqdb/tx_service#issue_id`
- [ ] Reference the link of RFC if exists
- [ ] Pass `./mtr --suite=mono_main,mono_multi,mono_basic`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new RocksDB configuration option to control how often obsolete files are scanned and removed.
  * The setting can now be configured via command line or INI config and applies to both cloud and local database startup paths.
* **Documentation**
  * Updated configuration docs with the new option, including its default value and microsecond units.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->