### PR TITLE
fix(log-service): put rocksdb-cloud headers ahead of vanilla rocksdb

### DIFF
--- a/eloq_log_service/CMakeLists.txt
+++ b/eloq_log_service/CMakeLists.txt
@@ -244,6 +244,11 @@ if (WITH_LOG_STATE MATCHES "ROCKSDB|ROCKSDB_CLOUD_S3|ROCKSDB_CLOUD_GCS")
     	  message(FATAL_ERROR "Fail to find RocksDB Cloud include path")
       endif ()
       message(STATUS "ROCKSDB_CLOUD_INCLUDE_PATH: ${ROCKSDB_CLOUD_INCLUDE_PATH}")
+      # rocksdb-cloud and vanilla rocksdb both ship rocksdb/db.h under different
+      # prefixes, and the shared prefix (brpc/... headers) is on -I ahead of the
+      # cloud one. Force the cloud dir to the front so rocksdb/db.h resolves to
+      # it (has DBCloud::GetNextFileNumber), not the vanilla copy.
+      include_directories(BEFORE ${ROCKSDB_CLOUD_INCLUDE_PATH})
       set(ROCKSDB_INCLUDE_PATH ${ROCKSDB_INCLUDE_PATH} ${ROCKSDB_CLOUD_INCLUDE_PATH})
 
       if (NOT ROCKSDB_CLOUD_LIB)


### PR DESCRIPTION
The standalone eloq_log_service build reaches the shared third-party include prefix via a plain include_directories(${BRPC_INCLUDE_PATH}) (a -I), and that prefix also ships a vanilla rocksdb/db.h alongside rocksdb-cloud's copy under rocksdb_cloud_header/. For cloud log states, rocksdb/db.h therefore resolved to the vanilla header (no DBCloud::GetNextFileNumber) and log_instance.cpp failed to compile. Add the cloud include dir with include_directories(BEFORE ...) so it wins. (The in-tree eloqkv build is unaffected: it pulls the prefix in as a SYSTEM include via imported targets, which -I already outranks.)

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Reference the link of issue using `fixes eloqdb/tx_service#issue_id`
- [ ] Reference the link of RFC if exists
- [ ] Pass `./mtr --suite=mono_main,mono_multi,mono_basic`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved build configuration so the correct RocksDB Cloud headers are picked up first, preventing header conflicts during compilation.
  * This helps ensure Cloud-specific features are available consistently when building the service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->