### PR TITLE
feat: adapt to eloqstore reopen feature

### DIFF
--- a/store_handler/eloq_data_store_service/eloq_store_config.cpp
+++ b/store_handler/eloq_data_store_service/eloq_store_config.cpp
@@ -128,6 +128,9 @@ DEFINE_bool(eloq_store_prewarm_cloud_cache,
 DEFINE_uint32(eloq_store_prewarm_task_count,
               3,
               "EloqStore prewarm task count per shard.");
+DEFINE_uint32(eloq_store_auto_reopen_pending_time_sec,
+              10,
+              "EloqStore auto-reopen pending time in seconds.");
 DEFINE_bool(eloq_store_reuse_local_files,
             true,
             "EloqStore reuse local files in cloud mode");
@@ -743,6 +746,16 @@ EloqStoreConfig::EloqStoreConfig(const INIReader &config_reader,
             : config_reader.GetInteger("store",
                                        "eloq_store_prewarm_task_count",
                                        FLAGS_eloq_store_prewarm_task_count);
+    eloqstore_configs_.auto_reopen_pending_time_us =
+        static_cast<uint64_t>(
+            !CheckCommandLineFlagIsDefault(
+                "eloq_store_auto_reopen_pending_time_sec")
+                ? FLAGS_eloq_store_auto_reopen_pending_time_sec
+                : config_reader.GetInteger(
+                      "store",
+                      "auto_reopen_pending_time_sec",
+                      FLAGS_eloq_store_auto_reopen_pending_time_sec)) *
+        1'000'000;
     eloqstore_configs_.allow_reuse_local_caches =
         !CheckCommandLineFlagIsDefault("eloq_store_reuse_local_files")
             ? FLAGS_eloq_store_reuse_local_files


### PR DESCRIPTION
- Bump eloqstore submodule to latest main (delayed reopen queue, auto-reopen pending time, metrics label fix)
- Expose eloq_store_auto_reopen_pending_time_sec so the delayed auto-reopen wait is tunable; no tx-side reopen plumbing included

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Reference the link of issue using `fixes eloqdb/tx_service#issue_id`
- [ ] Reference the link of RFC if exists
- [ ] Pass `./mtr --suite=mono_main,mono_multi,mono_basic`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new configuration option to control how long pending reopen actions wait before auto-reopening, with the value set in seconds.

* **Chores**
  * Updated the bundled storage component to a newer revision.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->