### PR TITLE
fix(third_party): build rocksdb-cloud with PORTABLE=1

### DIFF
--- a/scripts/third_party/build-ubuntu2404.sh
+++ b/scripts/third_party/build-ubuntu2404.sh
@@ -190,15 +190,18 @@ cd "${THIRD_PARTY_SRC}/rocksdb-cloud"
 # pass every build var before make as env vars, matching eloqkv's
 # scripts/install_dependency_ubuntu2404.sh. Drop the cached make_config.mk first
 # so platform detection re-runs.
+# PORTABLE=1 matches vanilla rocksdb above: without it rocksdb defaults to
+# -march=native, baking the build host's ISA into the .so. Since this prefix is
+# cached/shipped and run on other (older) CPUs, native builds SIGILL at load.
 rm -f make_config.mk
-run env LIBNAME=librocksdb-cloud-aws USE_RTTI=1 USE_AWS=1 ROCKSDB_DISABLE_TCMALLOC=1 ROCKSDB_DISABLE_JEMALLOC=1 make shared_lib -j"${JOBS}"
+run env LIBNAME=librocksdb-cloud-aws USE_RTTI=1 USE_AWS=1 PORTABLE=1 ROCKSDB_DISABLE_TCMALLOC=1 ROCKSDB_DISABLE_JEMALLOC=1 make shared_lib -j"${JOBS}"
 run make install-shared LIBNAME=librocksdb-cloud-aws PREFIX="${THIRD_PARTY_BUILD}/rocksdb-cloud-aws-output"
 mkdir -p "${THIRD_PARTY_PREFIX}/include/rocksdb_cloud_header" "${THIRD_PARTY_PREFIX}/lib"
 run rsync -a "${THIRD_PARTY_BUILD}/rocksdb-cloud-aws-output/include/" "${THIRD_PARTY_PREFIX}/include/rocksdb_cloud_header/"
 run rsync -a "${THIRD_PARTY_BUILD}/rocksdb-cloud-aws-output/lib/" "${THIRD_PARTY_PREFIX}/lib/"
 run make clean
 rm -f make_config.mk
-run env LIBNAME=librocksdb-cloud-gcp USE_RTTI=1 USE_GCP=1 ROCKSDB_DISABLE_TCMALLOC=1 ROCKSDB_DISABLE_JEMALLOC=1 make shared_lib -j"${JOBS}"
+run env LIBNAME=librocksdb-cloud-gcp USE_RTTI=1 USE_GCP=1 PORTABLE=1 ROCKSDB_DISABLE_TCMALLOC=1 ROCKSDB_DISABLE_JEMALLOC=1 make shared_lib -j"${JOBS}"
 run make install-shared LIBNAME=librocksdb-cloud-gcp PREFIX="${THIRD_PARTY_BUILD}/rocksdb-cloud-gcp-output"
 run rsync -a "${THIRD_PARTY_BUILD}/rocksdb-cloud-gcp-output/lib/" "${THIRD_PARTY_PREFIX}/lib/"
 


### PR DESCRIPTION
rocksdb-cloud defaulted to -march=native, baking the build host's ISA into the shared lib. Once the third-party prefix is cached and reused across CI runners (and shipped to users), older CPUs hit SIGILL at load during rocksdb static init. Match vanilla rocksdb and force PORTABLE=1.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Reference the link of issue using `fixes eloqdb/tx_service#issue_id`
- [ ] Reference the link of RFC if exists
- [ ] Pass `./mtr --suite=mono_main,mono_multi,mono_basic`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cloud build output compatibility by ensuring shared libraries are built in a more portable mode, helping them run on older CPUs.
  * Build steps now consistently apply the same portability setting for both cloud targets, reducing the chance of CPU-specific binaries being produced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->