### PR TITLE
fix: guard data store handler access in skip_kv mode

### DIFF
--- a/tx_service/include/cc/object_cc_map.h
+++ b/tx_service/include/cc/object_cc_map.h
@@ -1909,7 +1909,10 @@ public:
         decoded_key.Deserialize(key_str->data(), offset, KeySchema());
         const KeyT *look_key = &decoded_key;
 
-        if (Sharder::Instance().StandbyNodeTerm() >= 0 &&
+        // In skip_kv mode there is no data store handler and nothing is
+        // checkpointed to shared storage, so the forward message must be
+        // applied.
+        if (!txservice_skip_kv && Sharder::Instance().StandbyNodeTerm() >= 0 &&
             Sharder::Instance().GetDataStoreHandler()->IsSharedStorage() &&
             commit_ts < Sharder::Instance().NativeNodeGroupCkptTs())
         {

--- a/tx_service/src/cc/cc_entry.cpp
+++ b/tx_service/src/cc/cc_entry.cpp
@@ -60,7 +60,7 @@ void VersionedLruEntry<Versioned, RangePartitioned>::SetCommitTsPayloadStatus(
 template <bool Versioned, bool RangePartitioned>
 bool VersionedLruEntry<Versioned, RangePartitioned>::IsPersistent() const
 {
-    if (Sharder::Instance().StandbyNodeTerm() >= 0 &&
+    if (!txservice_skip_kv && Sharder::Instance().StandbyNodeTerm() >= 0 &&
         Sharder::Instance().GetDataStoreHandler()->IsSharedStorage())
     {
         // If this is a follower with shared kv, check the ng leader's ckpt_ts.

--- a/tx_service/src/remote/cc_node_service.cpp
+++ b/tx_service/src/remote/cc_node_service.cpp
@@ -1914,7 +1914,8 @@ void CcNodeService::UpdateStandbyCkptTs(
                << request->primary_succ_ckpt_ts()
                << ", has_data_store_write: " << (int) has_data_store_write;
 #else
-    if (Sharder::Instance().GetDataStoreHandler()->IsSharedStorage())
+    if (!txservice::txservice_skip_kv &&
+        Sharder::Instance().GetDataStoreHandler()->IsSharedStorage())
     {
         auto store_hd = Sharder::Instance().GetLocalCcShards()->store_hd_;
         const bool has_data_store_write = request->has_data_store_write();

--- a/tx_service/src/tx_operation.cpp
+++ b/tx_service/src/tx_operation.cpp
@@ -3524,6 +3524,12 @@ FlushUpdateTableOp::FlushUpdateTableOp(TransactionExecution *txm)
     update_kv_table_op_.op_func_ = [txm](AsyncOp<Void> &async_op)
     {
         CcHandlerResult<Void> &hd_res = async_op.hd_result_;
+        if (txservice_skip_kv)
+        {
+            // No kv store is attached. Skip updating the kv table.
+            hd_res.SetFinished();
+            return;
+        }
         hd_res.SetRefCnt(txm->rw_set_.CatalogWriteSetSize());
         for (const auto &[write_key, write_entry] :
              txm->rw_set_.CatalogWriteSet())


### PR DESCRIPTION
## Problem

A cluster deployed without a kv store (`enable_data_store=false`, i.e. `txservice_skip_kv`) crashes shortly after startup: as soon as the primary starts forwarding writes, the standby node segfaults.

Reported on an eloqctl v1.3.2 EloqKV deployment (`enable_wal: false`, no store service). Core dump:

```
#0  txservice::ObjectCcMap<EloqKV::EloqKey, EloqKV::RedisEloqObject>::Execute
    at tx_service/include/cc/object_cc_map.h:1913
#1  txservice::CcShard::ProcessRequests
```

Line 1913 (v1.3.2) is `Sharder::Instance().GetDataStoreHandler()->IsSharedStorage()` in `Execute(KeyObjectStandbyForwardCc&)`. With the data store disabled, `GetDataStoreHandler()` returns `nullptr` (tx_service is initialized with a null store handler), so the virtual call faults.

## Fix

Audited every `GetDataStoreHandler()` / `store_hd_` dereference and added `txservice_skip_kv` guards to the four call sites that are reachable without a kv store (matching the idiom already used in `cc_node.cpp`, `tx_execution.cpp`, etc.):

- `ObjectCcMap::Execute(KeyObjectStandbyForwardCc&)` — the reported crash. In skip_kv mode nothing is checkpointed to shared storage, so the forward message must simply be applied.
- `VersionedLruEntry::IsPersistent()` — same unguarded pattern, reachable on standby nodes; falls through to the flushed-bit logic (skip_kv already marks entries flushed in `SetCommitTsPayloadStatus`).
- `CcNodeService::UpdateStandbyCkptTs()` — the non-EloqStore `#else` branch lacked the null handling the EloqStore branch already has.
- `FlushUpdateTableOp::update_kv_table_op_` — committing a transaction with catalog writes unconditionally issued `DataStoreUpsertTable`; now short-circuits like `DsUpsertTableOp::Process` already does.

All other call sites are either already guarded (skip_kv check or null check) or unreachable in skip_kv mode (checkpointer early-returns on null `store_hd_`; log replay requires WAL which requires the data store).

Also bumps the eloqstore submodule to latest main (`123e262`).

## Verification

- `txservice` target builds clean with `WITH_DATA_STORE=ELOQDSS_ELOQSTORE` and `ELOQDSS_ROCKSDB_CLOUD_S3` (the latter covers the non-EloqStore `#else` branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)