### PR TITLE
feat: expose per-processor external active-tx count

### DIFF
--- a/tx_service/include/tx_service.h
+++ b/tx_service/include/tx_service.h
@@ -861,6 +861,21 @@ public:
 #endif
     }
 
+    /**
+     * @brief Number of live external transactions on this processor —
+     * transactions handed out to API layers (e.g. via TxService::NewTx) that
+     * have not yet finished. A relaxed read: momentarily approximate under
+     * concurrency, exact when the processor is quiesced.
+     */
+    size_t ExternActiveTxCount() const
+    {
+#ifdef EXT_TX_PROC_ENABLED
+        return ext_active_tx_cnt_.load(std::memory_order_relaxed);
+#else
+        return 0;
+#endif
+    }
+
     std::shared_ptr<TxProcCoordinator> GetTxProcCoordinator() const
     {
         return coordi_;
@@ -1376,6 +1391,22 @@ public:
                            pool_.end(),
                            [](const std::unique_ptr<TxProcessor> &tp)
                            { return tp->AllTxFinished(); });
+    }
+
+    /**
+     * @brief Total live external transactions across all tx processors. Sums
+     * each processor's relaxed counter; exact when the service is quiesced.
+     * Exposed so API layers can surface a leak-detection gauge (e.g. the
+     * EloqKV INFO field active_extern_txms).
+     */
+    size_t ExternActiveTxCount() const
+    {
+        size_t cnt = 0;
+        for (const auto &tp : pool_)
+        {
+            cnt += tp->ExternActiveTxCount();
+        }
+        return cnt;
     }
 
 #ifdef EXT_TX_PROC_ENABLED


### PR DESCRIPTION
## Summary

Adds two read-only accessors so API layers can surface a live gauge of external transactions:

- `TxProcessor::ExternActiveTxCount()` — relaxed load of the existing per-processor `ext_active_tx_cnt_` (0 when built without `EXT_TX_PROC_ENABLED`).
- `TxService::ExternActiveTxCount()` — sum across the processor pool, mirroring the adjacent `AllTxFinished()`.

Relaxed reads make the sum momentarily approximate under concurrency and exact when the service is quiesced — which is the contract the consumer needs.

## Motivation

eloqdata/eloqkv#528: the empty-EXEC watch-txm leak fixed in eloqdata/eloqkv#506 could not be guarded by an automated regression because nothing observable exposed live txm counts (the leak had to be demonstrated via ~14 KB/cycle RSS growth). EloqKV pairs this with an `INFO # Stats` field `active_extern_txms` plus a TCL regression (quiesce to 0 → BEGIN/ROLLBACK positive control → 20 empty WATCH/EXEC cycles → back to 0).

Header-only, no behavior change; verified in the EloqKV build: the gauge reads 0 idle, 1 during an open BEGIN session, 0 after rollback/disconnect, and the paired regression test passes on Release and Debug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added access to external transaction activity counts at both processor and service levels.
  * Service-wide counts now provide an aggregate view across all transaction processors.
  * Returns zero when external transaction processing is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->