### PR TITLE
Fix DSS drain gates

### DIFF
--- a/store_handler/eloq_data_store_service/data_store_service.cpp
+++ b/store_handler/eloq_data_store_service/data_store_service.cpp
@@ -85,6 +85,11 @@ thread_local ObjectPool<CreateSnapshotForBackupLocalRequest>
 thread_local ObjectPool<SyncFileCacheLocalRequest>
     local_sync_file_cache_req_pool_;
 
+thread_local const DataStoreService *tls_read_submit_slot_owner = nullptr;
+thread_local uint32_t tls_read_submit_slot_idx = UINT32_MAX;
+thread_local std::array<uint32_t, DataStoreService::kMaxShardCount>
+    tls_read_submit_depths{};
+
 TTLWrapperCache::TTLWrapperCache()
 {
     ttl_check_running_ = true;
@@ -270,6 +275,91 @@ DataStoreService::~DataStoreService()
     for (auto &it : data_shards_)
     {
         it.ShutDown();
+    }
+}
+
+DataStoreService::ReadSubmitGuard::ReadSubmitGuard(DataStoreService *service,
+                                                   uint32_t shard_id,
+                                                   uint32_t slot_idx)
+    : service_(service), shard_id_(shard_id), slot_idx_(slot_idx)
+{
+}
+
+DataStoreService::ReadSubmitGuard::ReadSubmitGuard(
+    ReadSubmitGuard &&other) noexcept
+    : service_(other.service_),
+      shard_id_(other.shard_id_),
+      slot_idx_(other.slot_idx_)
+{
+    other.service_ = nullptr;
+    other.shard_id_ = UINT32_MAX;
+    other.slot_idx_ = UINT32_MAX;
+}
+
+DataStoreService::ReadSubmitGuard::~ReadSubmitGuard()
+{
+    if (service_ != nullptr)
+    {
+        service_->LeaveReadSubmitWindow(shard_id_, slot_idx_);
+    }
+}
+
+uint32_t DataStoreService::GetReadSubmitSlotIndex()
+{
+    if (__builtin_expect(tls_read_submit_slot_owner == this &&
+                             tls_read_submit_slot_idx != UINT32_MAX,
+                         1))
+    {
+        return tls_read_submit_slot_idx;
+    }
+
+    uint32_t slot_idx =
+        next_read_submit_slot_idx_.fetch_add(1, std::memory_order_seq_cst);
+    CHECK_LT(slot_idx, kReadSubmitSlotCount)
+        << "Too many read submit threads for DataStoreService";
+
+    tls_read_submit_slot_owner = this;
+    tls_read_submit_slot_idx = slot_idx;
+    tls_read_submit_depths.fill(0);
+    return slot_idx;
+}
+
+DataStoreService::ReadSubmitGuard DataStoreService::EnterReadSubmitWindow(
+    uint32_t shard_id)
+{
+    uint32_t slot_idx = GetReadSubmitSlotIndex();
+    uint32_t depth = ++tls_read_submit_depths.at(shard_id);
+    data_shards_.at(shard_id).read_submit_slots_.at(slot_idx).depth.store(
+        depth, std::memory_order_seq_cst);
+    return ReadSubmitGuard(this, shard_id, slot_idx);
+}
+
+void DataStoreService::LeaveReadSubmitWindow(uint32_t shard_id,
+                                             uint32_t slot_idx)
+{
+    uint32_t &local_depth = tls_read_submit_depths.at(shard_id);
+    CHECK_GT(local_depth, 0);
+    uint32_t depth = --local_depth;
+    data_shards_.at(shard_id).read_submit_slots_.at(slot_idx).depth.store(
+        depth, std::memory_order_seq_cst);
+}
+
+void DataStoreService::WaitReadSubmitWindowsDrained(
+    const DataShard &ds_ref) const
+{
+    bool drained = false;
+    while (!drained)
+    {
+        drained = true;
+        for (const auto &slot : ds_ref.read_submit_slots_)
+        {
+            if (slot.depth.load(std::memory_order_seq_cst) != 0)
+            {
+                drained = false;
+                bthread_usleep(1000);
+                break;
+            }
+        }
     }
 }
 
@@ -477,7 +567,8 @@ void DataStoreService::Read(::google::protobuf::RpcController *controller,
     }
 
     DataShard &ds_ref = data_shards_.at(shard_id);
-    auto shard_status = ds_ref.shard_status_.load(std::memory_order_acquire);
+    auto read_submit_guard = EnterReadSubmitWindow(shard_id);
+    auto shard_status = ds_ref.shard_status_.load(std::memory_order_seq_cst);
     if (shard_status != DSShardStatus::ReadOnly &&
         shard_status != DSShardStatus::ReadWrite)
     {
@@ -514,7 +605,8 @@ void DataStoreService::Read(const std::string_view table_name,
     }
 
     DataShard &ds_ref = data_shards_.at(shard_id);
-    auto shard_status = ds_ref.shard_status_.load(std::memory_order_acquire);
+    auto read_submit_guard = EnterReadSubmitWindow(shard_id);
+    auto shard_status = ds_ref.shard_status_.load(std::memory_order_seq_cst);
     if (shard_status != DSShardStatus::ReadOnly &&
         shard_status != DSShardStatus::ReadWrite)
     {
@@ -559,7 +651,7 @@ void DataStoreService::FlushData(
     IncreaseWriteReqCount(shard_id);
     DataShard &ds_ref = data_shards_.at(shard_id);
 
-    auto shard_status = ds_ref.shard_status_.load(std::memory_order_acquire);
+    auto shard_status = ds_ref.shard_status_.load(std::memory_order_seq_cst);
     if (shard_status != DSShardStatus::ReadWrite)
     {
         DecreaseWriteReqCount(shard_id);
@@ -713,7 +805,7 @@ void DataStoreService::FlushData(const std::vector<std::string> &kv_table_names,
     IncreaseWriteReqCount(shard_id);
     DataShard &ds_ref = data_shards_.at(shard_id);
 
-    auto shard_status = ds_ref.shard_status_.load(std::memory_order_acquire);
+    auto shard_status = ds_ref.shard_status_.load(std::memory_order_seq_cst);
     if (shard_status != DSShardStatus::ReadWrite)
     {
         DecreaseWriteReqCount(shard_id);
@@ -759,7 +851,7 @@ void DataStoreService::DeleteRange(
     IncreaseWriteReqCount(shard_id);
 
     DataShard &ds_ref = data_shards_.at(shard_id);
-    auto shard_status = ds_ref.shard_status_.load(std::memory_order_acquire);
+    auto shard_status = ds_ref.shard_status_.load(std::memory_order_seq_cst);
     if (shard_status != DSShardStatus::ReadWrite)
     {
         DecreaseWriteReqCount(shard_id);
@@ -809,7 +901,7 @@ void DataStoreService::DeleteRange(const std::string_view table_name,
     IncreaseWriteReqCount(shard_id);
 
     DataShard &ds_ref = data_shards_.at(shard_id);
-    auto shard_status = ds_ref.shard_status_.load(std::memory_order_acquire);
+    auto shard_status = ds_ref.shard_status_.load(std::memory_order_seq_cst);
     if (shard_status != DSShardStatus::ReadWrite)
     {
         DecreaseWriteReqCount(shard_id);
@@ -863,7 +955,7 @@ void DataStoreService::CreateTable(
     IncreaseWriteReqCount(shard_id);
 
     DataShard &ds_ref = data_shards_.at(shard_id);
-    auto shard_status = ds_ref.shard_status_.load(std::memory_order_acquire);
+    auto shard_status = ds_ref.shard_status_.load(std::memory_order_seq_cst);
     if (shard_status != DSShardStatus::ReadWrite)
     {
         DecreaseWriteReqCount(shard_id);
@@ -907,7 +999,7 @@ void DataStoreService::CreateTable(const std::string_view table_name,
     IncreaseWriteReqCount(shard_id);
 
     DataShard &ds_ref = data_shards_.at(shard_id);
-    auto shard_status = ds_ref.shard_status_.load(std::memory_order_acquire);
+    auto shard_status = ds_ref.shard_status_.load(std::memory_order_seq_cst);
     if (shard_status != DSShardStatus::ReadWrite)
     {
         DecreaseWriteReqCount(shard_id);
@@ -953,7 +1045,7 @@ void DataStoreService::DropTable(
     IncreaseWriteReqCount(shard_id);
 
     DataShard &ds_ref = data_shards_.at(shard_id);
-    auto shard_status = ds_ref.shard_status_.load(std::memory_order_acquire);
+    auto shard_status = ds_ref.shard_status_.load(std::memory_order_seq_cst);
     if (shard_status != DSShardStatus::ReadWrite)
     {
         DecreaseWriteReqCount(shard_id);
@@ -997,7 +1089,7 @@ void DataStoreService::DropTable(const std::string_view table_name,
     IncreaseWriteReqCount(shard_id);
 
     DataShard &ds_ref = data_shards_.at(shard_id);
-    auto shard_status = ds_ref.shard_status_.load(std::memory_order_acquire);
+    auto shard_status = ds_ref.shard_status_.load(std::memory_order_seq_cst);
     if (shard_status != DSShardStatus::ReadWrite)
     {
         DecreaseWriteReqCount(shard_id);
@@ -1044,7 +1136,7 @@ void DataStoreService::BatchWriteRecords(
     IncreaseWriteReqCount(shard_id);
 
     DataShard &ds_ref = data_shards_.at(shard_id);
-    auto shard_status = ds_ref.shard_status_.load(std::memory_order_acquire);
+    auto shard_status = ds_ref.shard_status_.load(std::memory_order_seq_cst);
     if (shard_status != DSShardStatus::ReadWrite)
     {
         DecreaseWriteReqCount(shard_id);
@@ -1100,7 +1192,8 @@ void DataStoreService::ScanNext(
     }
 
     DataShard &ds_ref = data_shards_.at(shard_id);
-    auto shard_status = ds_ref.shard_status_.load(std::memory_order_acquire);
+    auto scan_submit_guard = EnterReadSubmitWindow(shard_id);
+    auto shard_status = ds_ref.shard_status_.load(std::memory_order_seq_cst);
     if (shard_status != DSShardStatus::ReadWrite &&
         shard_status != DSShardStatus::ReadOnly)
     {
@@ -1148,7 +1241,8 @@ void DataStoreService::ScanNext(::google::protobuf::RpcController *controller,
     }
 
     DataShard &ds_ref = data_shards_.at(shard_id);
-    auto shard_status = ds_ref.shard_status_.load(std::memory_order_acquire);
+    auto scan_submit_guard = EnterReadSubmitWindow(shard_id);
+    auto shard_status = ds_ref.shard_status_.load(std::memory_order_seq_cst);
     if (shard_status != DSShardStatus::ReadWrite &&
         shard_status != DSShardStatus::ReadOnly)
     {
@@ -1182,7 +1276,8 @@ void DataStoreService::ScanClose(::google::protobuf::RpcController *controller,
     }
 
     DataShard &ds_ref = data_shards_.at(shard_id);
-    auto shard_status = ds_ref.shard_status_.load(std::memory_order_acquire);
+    auto scan_submit_guard = EnterReadSubmitWindow(shard_id);
+    auto shard_status = ds_ref.shard_status_.load(std::memory_order_seq_cst);
     if (shard_status != DSShardStatus::ReadWrite &&
         shard_status != DSShardStatus::ReadOnly)
     {
@@ -1217,7 +1312,8 @@ void DataStoreService::ScanClose(const std::string_view table_name,
     }
 
     DataShard &ds_ref = data_shards_.at(shard_id);
-    auto shard_status = ds_ref.shard_status_.load(std::memory_order_acquire);
+    auto scan_submit_guard = EnterReadSubmitWindow(shard_id);
+    auto shard_status = ds_ref.shard_status_.load(std::memory_order_seq_cst);
     if (shard_status != DSShardStatus::ReadWrite &&
         shard_status != DSShardStatus::ReadOnly)
     {
@@ -1338,7 +1434,7 @@ void DataStoreService::BatchWriteRecords(
     IncreaseWriteReqCount(shard_id);
 
     DataShard &ds_ref = data_shards_.at(shard_id);
-    auto shard_status = ds_ref.shard_status_.load(std::memory_order_acquire);
+    auto shard_status = ds_ref.shard_status_.load(std::memory_order_seq_cst);
     if (shard_status != DSShardStatus::ReadWrite)
     {
         DecreaseWriteReqCount(shard_id);
@@ -1399,7 +1495,7 @@ void DataStoreService::CreateSnapshotForBackup(
     IncreaseWriteReqCount(shard_id);
 
     DataShard &ds_ref = data_shards_.at(shard_id);
-    auto shard_status = ds_ref.shard_status_.load(std::memory_order_acquire);
+    auto shard_status = ds_ref.shard_status_.load(std::memory_order_seq_cst);
     if (shard_status != DSShardStatus::ReadWrite)
     {
         DecreaseWriteReqCount(shard_id);
@@ -1445,7 +1541,7 @@ void DataStoreService::CreateSnapshotForBackup(
     IncreaseWriteReqCount(shard_id);
 
     DataShard &ds_ref = data_shards_.at(shard_id);
-    auto shard_status = ds_ref.shard_status_.load(std::memory_order_acquire);
+    auto shard_status = ds_ref.shard_status_.load(std::memory_order_seq_cst);
     if (shard_status != DSShardStatus::ReadWrite)
     {
         DecreaseWriteReqCount(shard_id);
@@ -3089,7 +3185,7 @@ bool DataStoreService::SwitchReadWriteToReadOnly(uint32_t shard_id)
     auto &ds_ref = data_shards_.at(shard_id);
     DSShardStatus expected = DSShardStatus::ReadWrite;
     if (!ds_ref.shard_status_.compare_exchange_strong(
-            expected, DSShardStatus::ReadOnly) &&
+            expected, DSShardStatus::ReadOnly, std::memory_order_seq_cst) &&
         expected != DSShardStatus::ReadOnly)
     {
         DLOG(ERROR) << "SwitchReadWriteToReadOnly failed, shard status is not "
@@ -3098,11 +3194,11 @@ bool DataStoreService::SwitchReadWriteToReadOnly(uint32_t shard_id)
     }
 
     // wait for all write requests to finish
-    while (ds_ref.ongoing_write_requests_.load(std::memory_order_acquire) > 0)
+    while (ds_ref.ongoing_write_requests_.load(std::memory_order_seq_cst) > 0)
     {
         bthread_usleep(1000);
     }
-    if (ds_ref.shard_status_.load(std::memory_order_acquire) ==
+    if (ds_ref.shard_status_.load(std::memory_order_seq_cst) ==
         DSShardStatus::ReadOnly)
     {
         cluster_manager_.SwitchShardToReadOnly(shard_id, expected);
@@ -3126,7 +3222,7 @@ bool DataStoreService::SwitchReadOnlyToClosed(uint32_t shard_id)
     auto &ds_ref = data_shards_.at(shard_id);
     DSShardStatus expected = DSShardStatus::ReadOnly;
     if (!ds_ref.shard_status_.compare_exchange_strong(
-            expected, DSShardStatus::Starting) &&
+            expected, DSShardStatus::Starting, std::memory_order_seq_cst) &&
         expected != DSShardStatus::Closed)
     {
         DLOG(ERROR) << "SwitchReadOnlyToClosed failed, shard status is not "
@@ -3138,10 +3234,13 @@ bool DataStoreService::SwitchReadOnlyToClosed(uint32_t shard_id)
     {
         DLOG(INFO) << "SwitchReadOnlyToClosed enter shutdown, shard "
                    << shard_id;
+        WaitReadSubmitWindowsDrained(ds_ref);
         ds_ref.data_store_->Shutdown();
         DSShardStatus expected_after_shutdown = DSShardStatus::Starting;
         const bool switched = ds_ref.shard_status_.compare_exchange_strong(
-            expected_after_shutdown, DSShardStatus::Closed);
+            expected_after_shutdown,
+            DSShardStatus::Closed,
+            std::memory_order_seq_cst);
         CHECK(switched);
         cluster_manager_.SwitchShardToClosed(shard_id, DSShardStatus::ReadOnly);
     }

--- a/store_handler/eloq_data_store_service/data_store_service.h
+++ b/store_handler/eloq_data_store_service/data_store_service.h
@@ -25,6 +25,7 @@
 #include <bthread/condition_variable.h>
 #include <bthread/mutex.h>
 
+#include <array>
 #include <atomic>
 #include <chrono>
 #include <condition_variable>
@@ -194,6 +195,9 @@ private:
 class DataStoreService : EloqDS::remote::DataStoreRpcService
 {
 public:
+    static constexpr uint32_t kMaxShardCount = 1000;
+    static constexpr uint32_t kReadSubmitSlotCount = 1000;
+
     DataStoreService(const DataStoreServiceClusterManager &config,
                      const std::string &config_file_path,
                      const std::string &migration_log_path,
@@ -648,13 +652,13 @@ public:
     void IncreaseWriteReqCount(uint32_t shard_id)
     {
         data_shards_.at(shard_id).ongoing_write_requests_.fetch_add(
-            1, std::memory_order_release);
+            1, std::memory_order_seq_cst);
     }
 
     void DecreaseWriteReqCount(uint32_t shard_id)
     {
         data_shards_.at(shard_id).ongoing_write_requests_.fetch_sub(
-            1, std::memory_order_release);
+            1, std::memory_order_seq_cst);
     }
 
     bool IsOwnerOfShard(uint32_t shard_id) const
@@ -709,6 +713,32 @@ public:
     }
 
 private:
+    struct DataShard;
+
+    struct alignas(64) ReadSubmitSlot
+    {
+        std::atomic<uint32_t> depth{0};
+    };
+
+    class ReadSubmitGuard
+    {
+    public:
+        ReadSubmitGuard() = default;
+        ReadSubmitGuard(DataStoreService *service,
+                        uint32_t shard_id,
+                        uint32_t slot_idx);
+        ReadSubmitGuard(const ReadSubmitGuard &) = delete;
+        ReadSubmitGuard &operator=(const ReadSubmitGuard &) = delete;
+        ReadSubmitGuard(ReadSubmitGuard &&other) noexcept;
+        ReadSubmitGuard &operator=(ReadSubmitGuard &&other) = delete;
+        ~ReadSubmitGuard();
+
+    private:
+        DataStoreService *service_{nullptr};
+        uint32_t shard_id_{UINT32_MAX};
+        uint32_t slot_idx_{UINT32_MAX};
+    };
+
     DataStore *GetDataStore(uint32_t shard_id)
     {
         if (data_shards_.at(shard_id).shard_id_ == shard_id)
@@ -729,6 +759,10 @@ private:
     bool SwitchReadWriteToReadOnly(uint32_t shard_id);
     bool SwitchReadOnlyToClosed(uint32_t shard_id);
     bool SwitchReadOnlyToReadWrite(uint32_t shard_id);
+    uint32_t GetReadSubmitSlotIndex();
+    ReadSubmitGuard EnterReadSubmitWindow(uint32_t shard_id);
+    void LeaveReadSubmitWindow(uint32_t shard_id, uint32_t slot_idx);
+    void WaitReadSubmitWindowsDrained(const DataShard &ds_ref) const;
     bool WriteMigrationLog(uint32_t shard_id,
                            const std::string &event_id,
                            const std::string &target_node_ip,
@@ -785,13 +819,15 @@ private:
         std::atomic<uint64_t> latest_snapshot_ts_{0};
         std::atomic<uint64_t> latest_delete_archive_ts_{0};
         std::unique_ptr<TTLWrapperCache> scan_iter_cache_{nullptr};
+        std::array<ReadSubmitSlot, kReadSubmitSlotCount> read_submit_slots_;
 
         // Whether the file cache sync is running. Used to avoid concurrent
         // local ssd file operations between db and file sync worker.
         std::atomic<bool> is_file_sync_running_{false};
     };
 
-    std::array<DataShard, 1000> data_shards_;
+    std::array<DataShard, kMaxShardCount> data_shards_;
+    std::atomic<uint32_t> next_read_submit_slot_idx_{0};
 
     std::unique_ptr<DataStoreFactory> data_store_factory_;
 


### PR DESCRIPTION
## Summary

This PR closes two DataStoreService shutdown/drain races:

- Prevents a write request from being accepted concurrently with `ReadWrite -> ReadOnly` while the drainer observes zero in-flight writes.
- Prevents new read/scan submissions from entering the backend after `ReadOnly -> Closed` begins draining, which is required for EloqStore because `Stop()` must not race with a later `ExecAsyn()` submission.

It also advances the nested `eloqstore` submodule to the latest `main` commit:

- `acd3cb3 fix: complete requests racing Stop() instead of crashing or hanging (#483)`
- includes the recent fixes from #480, #476, and #469.

## Details

### Write drain gate

The write path already increments `ongoing_write_requests_` before checking shard status. However, the previous ordering used release/acquire operations, which does not impose one global order across the writer's count increment/status load and the drainer's status CAS/count load.

This PR changes the write gate operations to `seq_cst`:

- write request count increment/decrement
- post-increment shard status loads on write paths
- `ReadWrite -> ReadOnly` CAS
- write-drain count load

With one sequentially consistent order, the unsafe outcome where a writer still observes `ReadWrite` while the drainer already observes count `0` is prevented.

### Read/scan submit drain gate

Read and scan paths now enter a per-thread submit window before loading shard status. `ReadOnly -> Closed` first switches the shard status to `Starting`, then waits for all submit windows to drain before calling backend `Shutdown()`.

This blocks the problematic interleaving:

1. a read/scan request is in DataStoreService and about to submit to the backend;
2. close switches the shard to closing and drains;
3. backend shutdown/stop runs;
4. the read/scan request submits after shutdown has begun.

The submit window is intentionally scoped only around the status check and backend submission. It is not a full async request lifetime counter.

That is deliberate for EloqStore: the bug is submission-after-stop, not waiting for every accepted read callback before close. Extending the counter to `SetFinish()` would add a cross-thread atomic decrement to the hot read path.

For RocksDB/RocksDBCloud, accepted reads/scans are already safe because their async behavior is implemented by DataStoreService's `query_worker_pool_`. `Shutdown()` joins the worker pool, and workers drain queued work before exiting, so the DB is closed/deleted only after accepted worker tasks complete.

## Validation

- `cmake --build bld-eloqstore-local --target eloqkv -j2`
- `git diff --check -- store_handler/eloq_data_store_service/data_store_service.cpp store_handler/eloq_data_store_service/data_store_service.h`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of read and scan operations during datastore shutdown by tracking and draining in-flight read activity before shutdown completes.
  * Prevented shutdown from interrupting in-progress read requests, scans, and scan-close flows.
  * Strengthened synchronization around shard status handling to reduce race conditions under concurrent load.
* **Chores**
  * Updated the checked-in datastore service submodule reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->