### PR TITLE
fix: WaitableCc completion lifetime race

### DIFF
--- a/store_handler/rocksdb_handler.cpp
+++ b/store_handler/rocksdb_handler.cpp
@@ -2257,7 +2257,7 @@ void RocksDBHandler::ParallelIterateTable(
                         // is marked as errored.
                         if (init_res.error != txservice::CcErrorCode::NO_ERROR)
                         {
-                            requester->AbortCcRequest(init_res.error);
+                            requester->SetErrorCode(init_res.error);
                             return true;
                         }
                         return false;

--- a/tx_service/include/cc/cc_req_misc.h
+++ b/tx_service/include/cc/cc_req_misc.h
@@ -21,6 +21,7 @@
  */
 #pragma once
 
+#include <bthread/bthread.h>
 #include <bthread/condition_variable.h>
 #include <bthread/mutex.h>
 
@@ -869,8 +870,9 @@ public:
     {
         RunOnTxProcessorCc::Reset(std::move(task));
 
+        assert(active_finishers_.load(std::memory_order_seq_cst) == 0);
         error_code_.store(CcErrorCode::NO_ERROR, std::memory_order_relaxed);
-        unfinished_cnt_.store(core_cnt, std::memory_order_release);
+        unfinished_cnt_.store(core_cnt, std::memory_order_seq_cst);
     }
 
     void SetCoroCallbacks(const std::function<void()> *yield_fn,
@@ -895,8 +897,15 @@ public:
             return;
         }
         std::unique_lock<bthread::Mutex> lk(mux_);
-        while (unfinished_cnt_.load(std::memory_order_acquire) > 0)
+        while (!IsFinished())
         {
+            if (unfinished_cnt_.load(std::memory_order_seq_cst) == 0)
+            {
+                lk.unlock();
+                bthread_usleep(100);
+                lk.lock();
+                continue;
+            }
             waiting_.store(true, std::memory_order_release);
             lk.unlock();
             (*yield_fn)();
@@ -907,7 +916,8 @@ public:
 
     bool IsFinished() const
     {
-        return unfinished_cnt_.load(std::memory_order_acquire) == 0;
+        return unfinished_cnt_.load(std::memory_order_seq_cst) == 0 &&
+               active_finishers_.load(std::memory_order_seq_cst) == 0;
     }
 
     bool IsError() const
@@ -921,7 +931,10 @@ public:
         return error_code_.load(std::memory_order_acquire);
     }
 
-    void AbortCcRequest(CcErrorCode error_code) override
+    // Record an error without completing this request. Use this from a task
+    // body that will return true and let Execute() perform the single
+    // FinishOne() call for that shard.
+    void SetErrorCode(CcErrorCode error_code)
     {
         // Latch the first error; a later success on another core must not
         // erase it.
@@ -930,6 +943,11 @@ public:
                                             error_code,
                                             std::memory_order_acq_rel,
                                             std::memory_order_relaxed);
+    }
+
+    void AbortCcRequest(CcErrorCode error_code) override
+    {
+        SetErrorCode(error_code);
         FinishOne();
     }
 
@@ -945,7 +963,30 @@ public:
 private:
     void FinishOne()
     {
-        if (unfinished_cnt_.fetch_sub(1, std::memory_order_acq_rel) == 1)
+        active_finishers_.fetch_add(1, std::memory_order_seq_cst);
+
+        uint32_t unfinished = unfinished_cnt_.load(std::memory_order_seq_cst);
+        while (unfinished > 0)
+        {
+            if (unfinished_cnt_.compare_exchange_weak(
+                    unfinished,
+                    unfinished - 1,
+                    std::memory_order_seq_cst,
+                    std::memory_order_seq_cst))
+            {
+                break;
+            }
+        }
+
+        if (unfinished == 0)
+        {
+            LOG(ERROR) << "WaitableCc::FinishOne called after completion";
+            assert(false);
+            active_finishers_.fetch_sub(1, std::memory_order_seq_cst);
+            return;
+        }
+
+        if (unfinished == 1)
         {
             if (resume_fn_ != nullptr)
             {
@@ -963,6 +1004,8 @@ private:
                 }
             }
         }
+
+        active_finishers_.fetch_sub(1, std::memory_order_seq_cst);
     }
 
     void *operator new(size_t) noexcept
@@ -986,6 +1029,12 @@ private:
     const std::function<void()> *yield_fn_{nullptr};
     const std::function<void()> *resume_fn_{nullptr};
     std::atomic<bool> waiting_{false};
+
+    // Counts threads currently inside FinishOne(). unfinished_cnt_ may reach
+    // zero before the last finisher completes the resume handshake and stops
+    // touching this stack-allocated request, so waiters treat this as a
+    // lifetime fence before leaving the request's scope.
+    std::atomic<uint32_t> active_finishers_{0};
 };
 struct UpdateCceCkptTsCc : public CcRequestBase
 {

--- a/tx_service/src/cc/cc_req_misc.cpp
+++ b/tx_service/src/cc/cc_req_misc.cpp
@@ -1139,7 +1139,7 @@ void WaitableCc::Wait()
 {
     uint64_t interval_us = 100;
     constexpr uint64_t max_interval = 100000;
-    while (unfinished_cnt_.load(std::memory_order_acquire) > 0)
+    while (!IsFinished())
     {
         bthread_usleep(interval_us);
         interval_us <<= 1;


### PR DESCRIPTION
## Context

Fixes a WaitableCc lifetime race observed as a CI SIGSEGV in FinishOne(): the last finisher could publish unfinished_cnt_ == 0, let a waiter return and destroy the stack request, then continue touching resume_fn_/mux_/waiting_.

This PR also carries the nested eloqstore submodule pointer forward to origin/main (12489d3), including the already-merged eloqstore build/docs updates.

## Behavior before and after

Before, Wait()/IsFinished() treated unfinished_cnt_ == 0 as sufficient completion. After, waiters also require no thread to still be inside FinishOne(), so stack request owners cannot leave scope while the last finisher is still completing the resume handshake.

The RocksDB ParallelIterateTable error path also now records the error without calling FinishOne() from inside the task body, leaving Execute() to perform the single completion for that shard.

## Implementation

WaitableCc now tracks active_finishers_ around FinishOne(). IsFinished() checks both unfinished_cnt_ and active_finishers_. The callback Wait() path uses bthread_usleep(100) while logical completion is published but the final finisher is still active, avoiding a second yield/resume cycle and avoiding bthread condition-variable waits between tx processor context and bthread waiters.

FinishOne() uses a CAS loop so duplicate/extra completion calls cannot underflow unfinished_cnt_. If FinishOne() is called after completion, Release builds log an ERROR and return without corrupting the counter; Debug builds also assert to expose the invariant violation.

SetErrorCode() was split from AbortCcRequest() for task bodies that need to latch an error but still return true to Execute().

## Design decisions and alternatives

The new atomic is documented as a lifetime fence: unfinished_cnt_ can reach zero before FinishOne() is done touching this stack-allocated request. The counter operations use seq_cst because IsFinished() derives object lifetime from two atomics that must be observed consistently.

## Test plan

- [x] Unit/TCL tests
- [ ] Integration or manual validation
- [x] Formatting/build checks
- [ ] Compatibility or performance validation, when relevant

Commands and results:

```text
git -C data_substrate diff --check -- tx_service/include/cc/cc_req_misc.h tx_service/src/cc/cc_req_misc.cpp store_handler/rocksdb_handler.cpp
# passed

cmake --build data_substrate/bld --target CcRequestWait-Test -j 4
# passed

data_substrate/bld/tx_service/tests/CcRequestWait-Test
# passed: All tests passed (2008 assertions in 4 test cases)
```

Not run: clang-format-18 is not installed in this environment. No local RocksDB backend build covered store_handler/rocksdb_handler.cpp; the available local build is ELOQDSS_ELOQSTORE.

## Risk assessment

Regression surface is shared WaitableCc completion semantics. The main risk is a waiter polling slightly longer until the final finisher leaves FinishOne(); this is intentional and bounded by the existing completion path. The seq_cst atomics add a small cost only on WaitableCc completion/wait paths, not per-record data operations.

The eloqstore pointer moves to already-merged upstream commits on eloqdata/eloqstore main.

## Rollback plan

Revert this PR.

## Reviewer guide

Start with tx_service/include/cc/cc_req_misc.h: IsFinished(), Wait(), FinishOne(), and the active_finishers_ comment. Then check store_handler/rocksdb_handler.cpp for the SetErrorCode() usage that avoids double-finishing a WaitableCc. Finally verify the eloqstore submodule pointer bump.

## Follow-up work

A targeted fault-injection regression test could widen the old fetch_sub-to-resume window, but this PR keeps scope to the runtime fix.
