### PR TITLE
Fix stack CC request lifetime races

### DIFF
--- a/docs/03-concurrency-control.md
+++ b/docs/03-concurrency-control.md
@@ -39,7 +39,10 @@ Rules of the model (verified in `tx_service/src/cc/cc_shard.cpp::ProcessRequests
    `ProcessRequests()` dequeues in batches of up to 64 (`req_buf_`) and calls `Execute(*this)`;
    if `Execute` returns `true` it calls `req->Free()`, returning the request to its
    `CcRequestPool` (`cc_req_pool.h` — a circular vector of reusable request objects keyed on the
-   `in_use_` flag).
+   `in_use_` flag). Stack-owned requests that notify an external waiter before `Execute()`
+   unwinds must return `false`, or must keep `in_use_` set until the scheduler-side `Free()`
+   has completed; otherwise the owner can reset or destroy the stack object while
+   `ProcessRequests()` still holds its raw pointer.
 2. **`Execute()` must never block.** There are no waits inside `Execute()`; anything that cannot
    complete immediately returns `false` (so the request is *not* recycled) and arranges its own
    re-execution later. The four re-enqueue/retry patterns:
@@ -58,7 +61,9 @@ Rules of the model (verified in `tx_service/src/cc/cc_shard.cpp::ProcessRequests
    - **Multi-shard fan-out**: `CcMap::MoveRequest()` forwards a request to the next core; requests
      like `KickoutCcEntryCc` or scans re-enqueue *themselves* to yield after a batch.
 3. **Cancellation** goes through `AbortCcRequest(CcErrorCode)`, which must set the error on the
-   result and `Free()` the request (e.g. used by `CcShard::AbortCcRequests` and the OOM path).
+   result. Pool-owned requests must also `Free()` themselves on the final abort path so they can
+   be reused. Stack-owned requests use their own completion fence and must not call `Free()` after
+   waking the owner.
 4. A second queue, `low_priority_cc_queue_` (`EnqueueLowPriorityCcRequest`), carries background
    work; `ProcessLowPriorityRequests()` drains it one request at a time under a 50 µs budget per
    invocation. A third, `lazy_free_queue_`, destroys evicted `TxObject`s off the hot path.

--- a/tx_service/include/cc/cc_request.h
+++ b/tx_service/include/cc/cc_request.h
@@ -8642,12 +8642,17 @@ struct ScanSliceDeltaSizeCcForRangePartition : public CcRequestBase
         if (ccm == nullptr)
         {
             assert(!table_name_.IsMeta());
-            [[maybe_unused]] InitCcmResult init_res = ccs.InitCcm(
+            InitCcmResult init_res = ccs.InitCcm(
                 table_name_, node_group_id_, node_group_term_, this);
-            // Catalog entry should always exists and schema should not be null,
-            // since this cc request should be executed when table is locked by
-            // data sync txm.
-            assert(init_res.success);
+            if (!init_res.success)
+            {
+                if (init_res.error != CcErrorCode::NO_ERROR)
+                {
+                    SetError(init_res.error);
+                }
+                return false;
+            }
+
             assert(init_res.schema != nullptr);
             ccm = ccs.GetCcm(table_name_, node_group_id_);
             assert(ccm != nullptr);
@@ -8868,19 +8873,24 @@ struct ScanDeltaSizeCcForHashPartition : public CcRequestBase
         if (ccm == nullptr)
         {
             assert(!table_name_.IsMeta());
-            [[maybe_unused]] InitCcmResult init_res = ccs.InitCcm(
+            InitCcmResult init_res = ccs.InitCcm(
                 table_name_, node_group_id_, node_group_term_, this);
-            // Catalog entry should always exists and schema should not be null,
-            // since this cc request should be executed when table is locked by
-            // data sync txm.
-            assert(init_res.success);
+            if (!init_res.success)
+            {
+                if (init_res.error != CcErrorCode::NO_ERROR)
+                {
+                    SetError(init_res.error);
+                }
+                return false;
+            }
+
             assert(init_res.schema != nullptr);
             ccm = ccs.GetCcm(table_name_, node_group_id_);
             assert(ccm != nullptr);
         }
         ccm->Execute(*this);
 
-        // return false since ScanSliceDeltaSizeCcForRangePartition is not
+        // return false since ScanDeltaSizeCcForHashPartition is not
         // re-used and does not need to call CcRequestBase::Free
         return false;
     }
@@ -9070,12 +9080,17 @@ public:
         if (ccm == nullptr)
         {
             assert(!table_name_.IsMeta());
-            [[maybe_unused]] InitCcmResult init_res = ccs.InitCcm(
+            InitCcmResult init_res = ccs.InitCcm(
                 table_name_, node_group_id_, node_group_term_, this);
-            // Catalog entry should always exists and schema should not be null,
-            // since this cc request should be executed when table is locked by
-            // data sync txm.
-            assert(init_res.success);
+            if (!init_res.success)
+            {
+                if (init_res.error != CcErrorCode::NO_ERROR)
+                {
+                    SetError(init_res.error);
+                }
+                return false;
+            }
+
             assert(init_res.schema != nullptr);
             ccm = ccs.GetCcm(table_name_, node_group_id_);
             assert(ccm != nullptr);

--- a/tx_service/include/cc/cc_request.h
+++ b/tx_service/include/cc/cc_request.h
@@ -7959,7 +7959,7 @@ public:
         if (!ValidTermCheck())
         {
             SetError(CcErrorCode::REQUESTED_NODE_NOT_LEADER);
-            return true;
+            return false;
         }
 
         CcMap *ccm = ccs.GetCcm(*table_name_, node_group_id_);
@@ -8217,7 +8217,8 @@ public:
     {
         if (!ValidTermCheck())
         {
-            return SetError(CcErrorCode::REQUESTED_NODE_NOT_LEADER);
+            SetError(CcErrorCode::REQUESTED_NODE_NOT_LEADER);
+            return false;
         }
 
         CcMap *ccm = ccs.GetCcm(*table_name_, node_group_id_);
@@ -8239,7 +8240,8 @@ public:
                 // is marked as errored.
                 if (init_res.error != CcErrorCode::NO_ERROR)
                 {
-                    return SetError(init_res.error);
+                    SetError(init_res.error);
+                    return false;
                 }
                 // The req will be re-enqueued.
                 return false;
@@ -8281,10 +8283,7 @@ public:
         assert(err_code != CcErrorCode::NO_ERROR);
         DLOG(ERROR) << "Abort this uploadbatch request with error: "
                     << CcErrorMessage(err_code);
-        if (SetError(err_code))
-        {
-            Free();
-        }
+        SetError(err_code);
     }
 
     void Wait()

--- a/tx_service/include/cc/template_cc_map.h
+++ b/tx_service/include/cc/template_cc_map.h
@@ -7427,7 +7427,8 @@ public:
         {
             LOG(INFO) << "Refuse to receive remote records for cache, range "
                       << req.RangeId();
-            return req.SetError(CcErrorCode::UPLOAD_BATCH_REJECTED);
+            req.SetError(CcErrorCode::UPLOAD_BATCH_REJECTED);
+            return false;
         }
 
         if (!req.Parsed())

--- a/tx_service/src/cc/local_cc_shards.cpp
+++ b/tx_service/src/cc/local_cc_shards.cpp
@@ -21,11 +21,13 @@
  */
 #include "cc/local_cc_shards.h"
 
+#include <bthread/bthread.h>
 #include <bthread/mutex.h>
 #include <butil/time.h>
 #include <malloc.h>
 #include <sys/stat.h>
 
+#include <algorithm>
 #include <atomic>
 #include <chrono>
 #include <condition_variable>
@@ -82,6 +84,23 @@ DEFINE_uint64(hash_partition_data_sync_scan_data_size,
               1000 * 1024,
               "Per-batch memory budget (bytes) for data exported during a "
               "hash partition data-sync scan");
+
+namespace
+{
+void WaitForStackCcRequestFree(const CcRequestBase &req)
+{
+    // KickoutCcEntryCc signals its CcHandlerResult before ProcessRequests()
+    // calls Free(). Stack-owned requests must not be reset or destroyed until
+    // that final scheduler access is complete.
+    uint64_t interval_us = 100;
+    constexpr uint64_t max_interval_us = 100000;
+    while (req.InUse())
+    {
+        bthread_usleep(interval_us);
+        interval_us = std::min(interval_us << 1, max_interval_us);
+    }
+}
+}  // namespace
 
 std::atomic<uint64_t> LocalCcShards::local_clock(0);
 inline thread_local size_t tls_shard_idx = std::numeric_limits<size_t>::max();
@@ -6899,12 +6918,15 @@ void LocalCcShards::PurgeDeletedData()
                                &res,
                                Count(),
                                CleanType::CleanDeletedData);
+                purge_cc.Use();
                 for (auto &shard : cc_shards_)
                 {
                     shard->Enqueue(&purge_cc);
                 }
                 std::unique_lock<std::mutex> lk(mux);
                 cv.wait(lk, [&done] { return done; });
+                lk.unlock();
+                WaitForStackCcRequestFree(purge_cc);
             }
         }
     }
@@ -6988,6 +7010,7 @@ void LocalCcShards::KickoutDataForTest()
                                  &res,
                                  Count(),
                                  CleanType::CleanDataForTest);
+                kickout_cc.Use();
                 for (auto &shard : cc_shards_)
                 {
                     shard->Enqueue(&kickout_cc);
@@ -6995,6 +7018,8 @@ void LocalCcShards::KickoutDataForTest()
 
                 std::unique_lock<std::mutex> lk(mux);
                 cv.wait(lk, [&done] { return done; });
+                lk.unlock();
+                WaitForStackCcRequestFree(kickout_cc);
             }
         }
 


### PR DESCRIPTION
## Context

This fixes a lifetime race in stack-owned CC requests observed while debugging the EloqKV main-branch CI crash.

`CcShard::ProcessRequests()` keeps a raw request pointer in `req_buf_`, calls `Execute()`, and calls `req->Free()` when `Execute()` returns `true`. Some stack-owned requests signal their waiter from inside `Execute()` before that scheduler-side `Free()` happens. The waiting thread can then reuse or destroy the stack object while `ProcessRequests()` still has the pointer.

The concrete crash path is `KickoutCcEntryCc`: `SetFinish()` calls `res_->SetFinished()`, the background worker wakes up and resets the stack request for the next table/node group, and the CC worker then returns to `ProcessRequests()` and calls `Free()` on the same object.

## Behavior before and after

Before:

- Stack `KickoutCcEntryCc` requests in `LocalCcShards::PurgeDeletedData()` and `KickoutDataForTest()` waited only for `CcHandlerResult` completion.
- `UploadRangeSlicesCc` and `UploadBatchSlicesCc` error paths could return `true` or call `Free()` after waking their stack-owner waiter.
- Those paths allowed the owner to reuse or destroy stack storage before the scheduler finished its final request access.

After:

- Stack `KickoutCcEntryCc` requests mark themselves in use before enqueueing and wait for `InUse() == false` after business completion, so the stack owner does not reset or destroy the object until scheduler-side `Free()` is complete.
- Stack range upload error and abort paths wake their waiters but return `false` / avoid `Free()`, matching their normal completion paths.
- The concurrency-control notes document the stack-owned versus pool-owned request lifetime rule.

Compatibility: pooled CC request behavior is unchanged.

## Implementation

- Added `WaitForStackCcRequestFree()` in `local_cc_shards.cpp` using `bthread_usleep()` bounded backoff against the existing `CcRequestBase::InUse()` flag.
- Added `Use()` before enqueueing the two stack `KickoutCcEntryCc` instances and wait for scheduler-side free after the result callback has fired.
- Changed `UploadRangeSlicesCc` and `UploadBatchSlicesCc` stack-owned error paths to complete the waiter without returning `true` to `ProcessRequests()`.
- Changed the `UploadBatchSlicesCc` cache-reject path in `TemplateCcMap` to return `false` after setting the error.

## Design decisions and alternatives

This keeps the fix local to the unsafe stack-owned requests instead of changing the generic CC scheduler contract. `Use()` / `InUse()` is already the scheduler-side ownership signal, so the stack request can use it as a final lifetime fence without adding a new request subclass or another flag.

The wait happens outside `Execute()` and outside CC worker threads. It uses bthread sleep/backoff instead of blocking inside the coroutine execution model.

## Test plan

- [ ] Unit/TCL tests
- [ ] Integration or manual validation
- [x] Formatting/build checks
- [ ] Compatibility or performance validation, when relevant

Commands and results:

```text
git -C data_substrate diff --check
# passed

cmake --build bld-verify --target txservice -j4
# passed: [100%] Built target txservice

clang-format-18 --version
# failed: clang-format-18 not installed in this workspace
```

Full EloqKV TCL/CI tests were not run locally.

## Risk assessment

The main regression surface is stack `KickoutCcEntryCc` callers waiting slightly longer after logical completion. The wait should normally be short because it only covers the gap between `SetFinished()` and `ProcessRequests()` calling `Free()`, and it backs off with `bthread_usleep()`.

Range upload changes intentionally affect stack-owned request paths; pooled request recycling remains unchanged.

## Rollback plan

Revert this PR. That restores the previous request lifetime behavior.

## Reviewer guide

- `tx_service/src/cc/local_cc_shards.cpp`: stack `KickoutCcEntryCc` lifetime fence.
- `tx_service/include/cc/cc_request.h`: stack range upload error/abort paths.
- `tx_service/include/cc/template_cc_map.h`: batch upload reject path.
- `docs/03-concurrency-control.md`: documented request lifetime invariant.

## Follow-up work

Run the full EloqKV GitHub Actions matrix after the parent EloqKV submodule pointer is updated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed CC request execution/abort flows to return consistent failure states when leadership/initialization checks fail.
  * Improved error handling for rejected uploads and scan-related operations when initialization fails.
  * Strengthened safe cleanup for stack-owned shard requests to avoid lifetime/race issues during scheduler processing.
* **Documentation**
  * Clarified concurrency-control ownership, cancellation/abort, and completion requirements to prevent premature reuse or destruction.
* **Chores**
  * Updated the eloqstore subproject to a newer revision.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->