### PR TITLE
Fix EloqStore cloud cleanup and reject multi-shard processes

### DIFF
--- a/core/src/data_substrate.cpp
+++ b/core/src/data_substrate.cpp
@@ -69,14 +69,7 @@ DEFINE_string(tx_standby_ip_port_list, "", "Standby IP list");
 DEFINE_string(tx_voter_ip_port_list, "", "Voter IP list");
 
 DEFINE_string(cluster_config_file, "", "Cluster configuration file");
-DEFINE_int32(node_group_replica_num,
-#ifdef DATA_STORE_TYPE_ELOQDSS_ELOQSTORE
-             1
-#else
-             3
-#endif
-             ,
-             "Node group replica number");
+DEFINE_int32(node_group_replica_num, 3, "Node group replica number");
 DEFINE_bool(
     bind_all,
     false,
@@ -578,14 +571,6 @@ bool DataSubstrate::LoadNetworkConfig(bool is_bootstrap,
             : config_reader.GetInteger("cluster",
                                        "node_group_replica_num",
                                        FLAGS_node_group_replica_num);
-
-#ifdef DATA_STORE_TYPE_ELOQDSS_ELOQSTORE
-    if (network_config.node_group_replica_num > 1)
-    {
-        LOG(ERROR) << "EloqStore only supports node_group_replica_num=1.";
-        return false;
-    }
-#endif
 
     network_config.bind_all =
         !CheckCommandLineFlagIsDefault("bind_all")

--- a/core/src/data_substrate.cpp
+++ b/core/src/data_substrate.cpp
@@ -69,7 +69,14 @@ DEFINE_string(tx_standby_ip_port_list, "", "Standby IP list");
 DEFINE_string(tx_voter_ip_port_list, "", "Voter IP list");
 
 DEFINE_string(cluster_config_file, "", "Cluster configuration file");
-DEFINE_int32(node_group_replica_num, 3, "Node group replica number");
+DEFINE_int32(node_group_replica_num,
+#ifdef DATA_STORE_TYPE_ELOQDSS_ELOQSTORE
+             1
+#else
+             3
+#endif
+             ,
+             "Node group replica number");
 DEFINE_bool(
     bind_all,
     false,
@@ -571,6 +578,14 @@ bool DataSubstrate::LoadNetworkConfig(bool is_bootstrap,
             : config_reader.GetInteger("cluster",
                                        "node_group_replica_num",
                                        FLAGS_node_group_replica_num);
+
+#ifdef DATA_STORE_TYPE_ELOQDSS_ELOQSTORE
+    if (network_config.node_group_replica_num > 1)
+    {
+        LOG(ERROR) << "EloqStore only supports node_group_replica_num=1.";
+        return false;
+    }
+#endif
 
     network_config.bind_all =
         !CheckCommandLineFlagIsDefault("bind_all")

--- a/store_handler/eloq_data_store_service/data_store_service.cpp
+++ b/store_handler/eloq_data_store_service/data_store_service.cpp
@@ -373,6 +373,15 @@ bool DataStoreService::StartService(bool create_db_if_missing)
     auto dss_shards = cluster_manager_.GetShardsForThisNode();
     LOG(INFO) << "DataStoreService start with shards: " << dss_shards.size();
 
+#ifdef DATA_STORE_TYPE_ELOQDSS_ELOQSTORE
+    if (dss_shards.size() > 1)
+    {
+        LOG(ERROR)
+            << "EloqStore-backed DataStoreService supports at most one shard.";
+        return false;
+    }
+#endif
+
     if (!dss_shards.empty())
     {
         for (uint32_t shard_id : dss_shards)


### PR DESCRIPTION
## Context

EloqStore cloud-mode table drops could leave partition files behind. Separately, the generic EloqDSS adapter creates one data-store instance per DSS shard, while EloqStore currently supports only one running instance per process because its runtime includes process-global state.

Includes the EloqStore changes from eloqdata/eloqstore#494.

## Behavior before and after

Before:
- Cloud `DropTable` cleanup could miss files or match table-name prefixes incorrectly.
- A `DataStoreService` process assigned multiple DSS shards would create multiple EloqStore instances sharing process-global state and storage paths.

After:
- EloqStore cloud drop and GC collect the correct table files and handle non-append segment compaction.
- EloqStore-backed `DataStoreService` rejects configurations assigning more than one DSS shard to a process.
- RocksDB and RocksDBCloud retain their existing multi-shard behavior.
- `node_group_replica_num` remains configurable with its existing default; EloqKV CI explicitly selects `1` for its EloqStore scenarios.

## Implementation

- Update the EloqStore submodule with scoped partition listing, cloud dropped-file collection, reusable partition path buffers, prefix-collision coverage, and GC support for non-append segment compaction.
- Validate the DSS shards owned by the local process before creating EloqStore-backed data-store instances.

## Design decisions and alternatives

The adapter is intentionally restricted to one EloqStore instance per process instead of introducing shared ownership across multiple DSS shard adapters. Sharing one instance would also require redesigning shard-specific term and partition-group identity handling in cloud mode.

The generic `node_group_replica_num` setting is not restricted: it controls topology completion, voters, and failover behavior. Deployments must arrange EloqStore topology so each process owns at most one DSS shard; unsupported layouts fail explicitly at service startup.

## Test plan

- [ ] Unit/CTest coverage
- [ ] Parent-project integration or manual validation
- [ ] Formatting/build checks
- [ ] Recovery, compatibility, or performance validation, when relevant
- [ ] Documentation updated, when behavior changed

Commands and results:

```text
No local build or tests were run in this workspace.
The EloqKV PR branch was updated to this data_substrate head and explicitly passes node_group_replica_num=1 for EloqStore CI scenarios; CI results are pending.
```

## Risk assessment

The startup validation is intentionally incompatible with EloqStore deployments assigning more than one local DSS shard to a process. Those configurations were already unsafe because they create multiple EloqStore instances in one process. Other data-store backends are unaffected.

Cloud drop/GC behavior changes file deletion and compaction paths; reviewers should focus on table-prefix matching, file-key construction, and shutdown/GC ordering in the EloqStore submodule update.

## Rollback plan

Revert this PR and restore the previous EloqStore submodule pointer. EloqStore deployments must still keep one DSS shard per process to avoid the existing runtime conflict.

## Reviewer guide

- `store_handler/eloq_data_store_service/data_store_service.cpp`: per-process DSS shard guard.
- `store_handler/eloq_data_store_service/eloqstore`: cloud DropTable, file GC, and CloseFiles changes from eloqdata/eloqstore#494.

## Follow-up work

Support one shared EloqStore instance across multiple DSS shard adapters, including correct per-partition-group cloud term semantics.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup validation for EloqStore-backed configurations.
  * Services now stop with an error when multiple DSS shards are configured on the same node, preventing unsupported deployments from starting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->