### PR TITLE
Adapt EloqStore IO QoS configuration

### DIFF
--- a/store_handler/eloq_data_store_service/eloq_store_config.cpp
+++ b/store_handler/eloq_data_store_service/eloq_store_config.cpp
@@ -108,9 +108,10 @@ DEFINE_uint64(
 DEFINE_uint32(eloq_store_rate_limit_burst_ms,
               2,
               "EloqStore rate-limit burst capacity in milliseconds.");
-DEFINE_string(eloq_store_rate_limit_io_unit,
-              "2KB",
-              "EloqStore IO size charged as one operation by the rate limiter.");
+DEFINE_string(
+    eloq_store_rate_limit_io_unit,
+    "2KB",
+    "EloqStore IO size charged as one operation by the rate limiter.");
 DEFINE_uint32(eloq_store_rate_bg_ratio,
               25,
               "EloqStore percentage of the rate budget reserved for "
@@ -667,24 +668,21 @@ EloqStoreConfig::EloqStoreConfig(const INIReader &config_reader,
     eloqstore_configs_.disk_rate_limit_iops =
         !CheckCommandLineFlagIsDefault("eloq_store_disk_rate_limit_iops")
             ? FLAGS_eloq_store_disk_rate_limit_iops
-            : config_reader.GetInteger(
-                  "store",
-                  "eloq_store_disk_rate_limit_iops",
-                  FLAGS_eloq_store_disk_rate_limit_iops);
+            : config_reader.GetInteger("store",
+                                       "eloq_store_disk_rate_limit_iops",
+                                       FLAGS_eloq_store_disk_rate_limit_iops);
     eloqstore_configs_.disk_rate_limit_mbps =
         !CheckCommandLineFlagIsDefault("eloq_store_disk_rate_limit_mbps")
             ? FLAGS_eloq_store_disk_rate_limit_mbps
-            : config_reader.GetInteger(
-                  "store",
-                  "eloq_store_disk_rate_limit_mbps",
-                  FLAGS_eloq_store_disk_rate_limit_mbps);
+            : config_reader.GetInteger("store",
+                                       "eloq_store_disk_rate_limit_mbps",
+                                       FLAGS_eloq_store_disk_rate_limit_mbps);
     eloqstore_configs_.rate_limit_burst_ms =
         !CheckCommandLineFlagIsDefault("eloq_store_rate_limit_burst_ms")
             ? FLAGS_eloq_store_rate_limit_burst_ms
-            : config_reader.GetInteger(
-                  "store",
-                  "eloq_store_rate_limit_burst_ms",
-                  FLAGS_eloq_store_rate_limit_burst_ms);
+            : config_reader.GetInteger("store",
+                                       "eloq_store_rate_limit_burst_ms",
+                                       FLAGS_eloq_store_rate_limit_burst_ms);
     std::string rate_limit_io_unit =
         !CheckCommandLineFlagIsDefault("eloq_store_rate_limit_io_unit")
             ? FLAGS_eloq_store_rate_limit_io_unit

--- a/store_handler/eloq_data_store_service/eloq_store_config.cpp
+++ b/store_handler/eloq_data_store_service/eloq_store_config.cpp
@@ -98,9 +98,27 @@ DEFINE_uint32(eloq_store_io_queue_size,
 DEFINE_uint32(eloq_store_max_inflight_write,
               64 << 10,
               "EloqStore max inflight write.");
-DEFINE_uint32(eloq_store_max_write_batch_pages,
-              32,
-              "EloqStore max write batch pages.");
+DEFINE_uint64(eloq_store_disk_rate_limit_iops,
+              275000,
+              "EloqStore per-disk IOPS limit; 0 disables IOPS limiting.");
+DEFINE_uint64(
+    eloq_store_disk_rate_limit_mbps,
+    0,
+    "EloqStore per-disk throughput limit in MB/s; 0 disables byte limiting.");
+DEFINE_uint32(eloq_store_rate_limit_burst_ms,
+              2,
+              "EloqStore rate-limit burst capacity in milliseconds.");
+DEFINE_string(eloq_store_rate_limit_io_unit,
+              "2KB",
+              "EloqStore IO size charged as one operation by the rate limiter.");
+DEFINE_uint32(eloq_store_rate_bg_ratio,
+              25,
+              "EloqStore percentage of the rate budget reserved for "
+              "background IO.");
+DEFINE_uint32(
+    eloq_store_max_inflight_io,
+    0,
+    "EloqStore maximum in-flight device commands per shard; 0 disables it.");
 DEFINE_uint32(eloq_store_coroutine_stack_size,
               32 * 1024,
               "EloqStore coroutine stack size.");
@@ -646,12 +664,46 @@ EloqStoreConfig::EloqStoreConfig(const INIReader &config_reader,
                                        "eloq_store_max_inflight_write",
                                        FLAGS_eloq_store_max_inflight_write);
     eloqstore_configs_.max_inflight_write /= eloqstore_configs_.num_threads;
-    eloqstore_configs_.max_write_batch_pages =
-        !CheckCommandLineFlagIsDefault("eloq_store_max_write_batch_pages")
-            ? FLAGS_eloq_store_max_write_batch_pages
+    eloqstore_configs_.disk_rate_limit_iops =
+        !CheckCommandLineFlagIsDefault("eloq_store_disk_rate_limit_iops")
+            ? FLAGS_eloq_store_disk_rate_limit_iops
+            : config_reader.GetInteger(
+                  "store",
+                  "eloq_store_disk_rate_limit_iops",
+                  FLAGS_eloq_store_disk_rate_limit_iops);
+    eloqstore_configs_.disk_rate_limit_mbps =
+        !CheckCommandLineFlagIsDefault("eloq_store_disk_rate_limit_mbps")
+            ? FLAGS_eloq_store_disk_rate_limit_mbps
+            : config_reader.GetInteger(
+                  "store",
+                  "eloq_store_disk_rate_limit_mbps",
+                  FLAGS_eloq_store_disk_rate_limit_mbps);
+    eloqstore_configs_.rate_limit_burst_ms =
+        !CheckCommandLineFlagIsDefault("eloq_store_rate_limit_burst_ms")
+            ? FLAGS_eloq_store_rate_limit_burst_ms
+            : config_reader.GetInteger(
+                  "store",
+                  "eloq_store_rate_limit_burst_ms",
+                  FLAGS_eloq_store_rate_limit_burst_ms);
+    std::string rate_limit_io_unit =
+        !CheckCommandLineFlagIsDefault("eloq_store_rate_limit_io_unit")
+            ? FLAGS_eloq_store_rate_limit_io_unit
+            : config_reader.GetString("store",
+                                      "eloq_store_rate_limit_io_unit",
+                                      FLAGS_eloq_store_rate_limit_io_unit);
+    eloqstore_configs_.rate_limit_io_unit = parse_size(rate_limit_io_unit);
+    eloqstore_configs_.rate_bg_ratio =
+        !CheckCommandLineFlagIsDefault("eloq_store_rate_bg_ratio")
+            ? FLAGS_eloq_store_rate_bg_ratio
             : config_reader.GetInteger("store",
-                                       "eloq_store_max_write_batch_pages",
-                                       FLAGS_eloq_store_max_write_batch_pages);
+                                       "eloq_store_rate_bg_ratio",
+                                       FLAGS_eloq_store_rate_bg_ratio);
+    eloqstore_configs_.max_inflight_io =
+        !CheckCommandLineFlagIsDefault("eloq_store_max_inflight_io")
+            ? FLAGS_eloq_store_max_inflight_io
+            : config_reader.GetInteger("store",
+                                       "eloq_store_max_inflight_io",
+                                       FLAGS_eloq_store_max_inflight_io);
     eloqstore_configs_.coroutine_stack_size =
         !CheckCommandLineFlagIsDefault("eloq_store_coroutine_stack_size")
             ? FLAGS_eloq_store_coroutine_stack_size


### PR DESCRIPTION
## Context

EloqStore's `io_qos` branch replaces the obsolete per-write-task batch knob with per-device rate limiting and an optional in-flight IO window. Data Substrate needs to expose those options through its gflags/INI integration before EloqKV and other consumers can configure them.

## Behavior before and after

Before this change, `EloqStoreConfig` could not pass the new IO QoS settings to `eloqstore::KvOptions`, and still exposed `eloq_store_max_write_batch_pages`, which EloqStore now treats as deprecated and ineffective.

After this change, command-line flags and `[store]` INI values can configure:

- `eloq_store_disk_rate_limit_iops`
- `eloq_store_disk_rate_limit_mbps`
- `eloq_store_rate_limit_burst_ms`
- `eloq_store_rate_limit_io_unit`
- `eloq_store_rate_bg_ratio`
- `eloq_store_max_inflight_io`

The obsolete `eloq_store_max_write_batch_pages` integration is removed.

## Implementation

- Add gflags matching the new `KvOptions` defaults.
- Preserve the existing precedence rule: explicit command-line flag, then INI value, then gflag default.
- Parse `rate_limit_io_unit` through the existing size parser so values such as `2KB` map to bytes.
- Pass per-device limits through unchanged; EloqStore divides them across store paths and shards internally.
- Advance the EloqStore submodule to the `io_qos` implementation commit.

## Design decisions and alternatives

The adapter does not divide the new rate limits by `eloq_store_worker_num`. These are defined by EloqStore as per-disk values and EloqStore owns the path/shard allocation. Dividing them again in Data Substrate would under-limit IO.

## Test plan

- [ ] Unit/TCL tests
- [ ] Integration or manual validation
- [x] Formatting/build checks
- [ ] Compatibility or performance validation

Commands and results:

```text
cmake --build bld --target data_substrate --parallel 4
# Built target data_substrate

cmake --build bld --target eloqkv --parallel 4
# Built target eloqkv

git -C data_substrate diff --check
# passed

git diff --check
# passed
```

`clang-format-18` and `clang-format` were unavailable in the current environment. Runtime and performance tests were not run because this PR only wires configuration into the already-tested EloqStore implementation.

## Risk assessment

The main operational risk is misconfigured device limits. The defaults mirror EloqStore, `0` retains the documented disable behavior where applicable, and command-line precedence remains compatible. Removing `eloq_store_max_write_batch_pages` means deployments still setting that obsolete flag must remove it rather than silently relying on a no-op.

This draft currently points at an EloqStore `io_qos` branch commit. The EloqStore change must land first, then this PR's submodule pointer must be updated to the final commit reachable from EloqStore's target branch.

## Rollback plan

Revert this PR and restore the previous EloqStore submodule pointer.

## Reviewer guide

Start with `store_handler/eloq_data_store_service/eloq_store_config.cpp`. Verify the flag defaults against `eloqstore::KvOptions`, the command-line-over-INI precedence, and that per-disk rates are not divided in the adapter. Then verify the EloqStore submodule commit and dependency order.

## Follow-up work

Expose the same settings in each parent project's sample INI and update the submodule pointer after the EloqStore PR lands.