### PR TITLE
Reduce EloqKV cold-read handoff overhead

### DIFF
--- a/store_handler/data_store_service_client_closure.cpp
+++ b/store_handler/data_store_service_client_closure.cpp
@@ -168,14 +168,12 @@ void FetchRecordCallback(void *data,
     }
     else if (err_code == remote::DataStoreError::NO_ERROR)
     {
-        uint64_t now = txservice::LocalCcShards::ClockTsInMillseconds();
-        uint64_t rec_ttl = read_closure->Ttl();
-        std::string_view val = read_closure->Value();
-
         if (fetch_cc->table_name_.Engine() == txservice::TableEngine::EloqKv)
         {
             // Hash partition
-            if (rec_ttl > 0 && rec_ttl < now)
+            const uint64_t rec_ttl = read_closure->Ttl();
+            if (rec_ttl > 0 &&
+                rec_ttl < txservice::LocalCcShards::ClockTsInMillseconds())
             {
                 // expired record
                 fetch_cc->rec_status_ = txservice::RecordStatus::Deleted;
@@ -191,6 +189,7 @@ void FetchRecordCallback(void *data,
         }
         else
         {
+            const std::string_view val = read_closure->Value();
             // Range partition
             bool is_deleted = false;
             size_t offset = 0;

--- a/store_handler/data_store_service_client_closure.cpp
+++ b/store_handler/data_store_service_client_closure.cpp
@@ -186,7 +186,7 @@ void FetchRecordCallback(void *data,
 
             fetch_cc->rec_status_ = txservice::RecordStatus::Normal;
             fetch_cc->rec_ts_ = read_closure->Ts();
-            fetch_cc->rec_str_.assign(val.data(), val.size());
+            fetch_cc->rec_str_ = read_closure->TakeValue();
             fetch_cc->SetFinish(0);
         }
         else

--- a/store_handler/data_store_service_client_closure.h
+++ b/store_handler/data_store_service_client_closure.h
@@ -1018,6 +1018,18 @@ public:
         }
     }
 
+    // Transfers the completed read buffer to its consumer. ReadClosure is
+    // returned to its pool after the callback, so retaining a second copy here
+    // only adds allocation and memcpy cost on the cold-read path.
+    std::string TakeValue()
+    {
+        if (is_local_request_)
+        {
+            return std::move(value_);
+        }
+        return std::move(*response_.mutable_value());
+    }
+
     uint64_t Ts() const
     {
         if (is_local_request_)

--- a/tx_service/include/cc/cc_req_misc.h
+++ b/tx_service/include/cc/cc_req_misc.h
@@ -85,12 +85,13 @@ public:
     metrics::TimePoint start_;
 
 protected:
+    FetchCc() = default;
     FetchCc(CcShard &ccs, NodeGroupId cc_ng_id, int64_t cc_ng_term);
 
     std::vector<CcRequestBase *> requesters_;
-    CcShard &ccs_;
-    NodeGroupId cc_ng_id_;
-    int64_t cc_ng_term_;
+    CcShard *ccs_{nullptr};
+    NodeGroupId cc_ng_id_{0};
+    int64_t cc_ng_term_{-1};
 };
 
 struct FetchCatalogCc : public FetchCc
@@ -562,7 +563,7 @@ public:
 struct FetchRecordCc : public FetchCc
 {
 public:
-    FetchRecordCc() = delete;
+    FetchRecordCc() = default;
     FetchRecordCc(const TableName *tbl_name,
                   const TableSchema *tbl_schema,
                   TxKey tx_key,
@@ -577,6 +578,19 @@ public:
                   bool reopen = false);
     ~FetchRecordCc() = default;
 
+    void Reset(const TableName *tbl_name,
+               const TableSchema *tbl_schema,
+               TxKey tx_key,
+               LruEntry *cce,
+               CcShard &ccs,
+               NodeGroupId cc_ng_id,
+               int64_t cc_ng_term,
+               int32_t partition_id,
+               bool fetch_from_primary = false,
+               uint64_t snapshot_read_ts = 0,
+               bool only_fetch_archives = false,
+               bool reopen = false);
+
     bool ValidTermCheck();
 
     bool Execute(CcShard &ccs) override;
@@ -584,33 +598,35 @@ public:
     void SetFinish(int err);
 
     // table_name is a string view, cannot access it outside TxProcessor.
-    TableName table_name_;
+    TableName table_name_{
+        std::string(""), TableType::Primary, TableEngine::None};
     const TableSchema *table_schema_{nullptr};
     std::string kv_table_name_;
     TxKey tx_key_;
     LruEntry *cce_{nullptr};
     KeyGapLockAndExtraData *lock_{nullptr};
     uint64_t rec_ts_{0};
-    RecordStatus rec_status_{RecordStatus::Unknown};
-    std::string rec_str_;
-    int error_code_{0};
-    int partition_id_;
-    bool fetch_from_primary_{false};
-
     // If set snapshot_read_ts_ (not equal 0), the snapshot_read_ts_ will be
     // used to fetch record from archives table.
     uint64_t snapshot_read_ts_{0};
-    // If set only_fetch_archives_ (true), don't fetch record from base table.
-    bool only_fetch_archives_{false};
-    bool reopen_{false};
     std::unique_ptr<
         std::vector<std::tuple<uint64_t, RecordStatus, std::string>>>
         archive_records_{nullptr};
+
+    std::string rec_str_;
 
     // These variables only be used in DataStoreHandler
     std::string kv_session_id_;
     std::string kv_start_key_;
     std::string kv_end_key_;
+
+    int error_code_{0};
+    int partition_id_{0};
+    RecordStatus rec_status_{RecordStatus::Unknown};
+    bool fetch_from_primary_{false};
+    // If set only_fetch_archives_ (true), don't fetch record from base table.
+    bool only_fetch_archives_{false};
+    bool reopen_{false};
 };
 
 struct FetchBucketDataCc;

--- a/tx_service/include/cc/cc_shard.h
+++ b/tx_service/include/cc/cc_shard.h
@@ -1351,8 +1351,11 @@ private:
 
     std::unordered_map<TableName, std::unique_ptr<FetchCc>> fetch_reqs_;
 
-    // For load record from kvstore asynchronously
-    std::unordered_map<LruEntry *, FetchRecordCc> fetch_record_reqs_;
+    // FetchRecordCc addresses must remain stable while data-store callbacks are
+    // in flight. The pool owns the requests and the flat map only indexes the
+    // active single-flight fetch for each entry.
+    absl::flat_hash_map<LruEntry *, FetchRecordCc *> fetch_record_reqs_;
+    CcRequestPool<FetchRecordCc> fetch_record_cc_pool_;
 
     // For load snapshot from kvstore asynchronously
     CcRequestPool<FetchSnapshotCc> fetch_snapshot_cc_pool_;

--- a/tx_service/src/cc/cc_req_misc.cpp
+++ b/tx_service/src/cc/cc_req_misc.cpp
@@ -49,7 +49,7 @@
 namespace txservice
 {
 FetchCc::FetchCc(CcShard &ccs, NodeGroupId cc_ng_id, int64_t cc_ng_term)
-    : ccs_(ccs), cc_ng_id_(cc_ng_id), cc_ng_term_(cc_ng_term)
+    : ccs_(&ccs), cc_ng_id_(cc_ng_id), cc_ng_term_(cc_ng_term)
 {
 }
 
@@ -187,7 +187,7 @@ void FetchCatalogCc::SetFinish(RecordStatus status, int err)
         commit_ts_ = 0;
         catalog_image_.clear();
     });
-    ccs_.Enqueue(this);
+    ccs_->Enqueue(this);
 }
 
 FetchTableStatisticsCc::FetchTableStatisticsCc(const TableName &table_name,
@@ -256,7 +256,7 @@ void FetchTableStatisticsCc::SetFinish(int err)
         current_version_ = 0;
         sample_pool_map_.clear();
     });
-    ccs_.Enqueue(this);
+    ccs_->Enqueue(this);
 }
 
 FetchTableRangesCc::FetchTableRangesCc(const TableName &table_name,
@@ -343,7 +343,7 @@ void FetchTableRangesCc::SetFinish(int err)
         ranges_vec_.clear();
         partition_ranges_vec_.clear();
     });
-    ccs_.Enqueue(this);
+    ccs_->Enqueue(this);
 }
 
 void FetchTableRangesCc::Merge()
@@ -810,12 +810,57 @@ FetchRecordCc::FetchRecordCc(const TableName *tbl_name,
       tx_key_(std::move(tx_key)),
       cce_(cce),
       lock_(cce->GetKeyGapLockAndExtraData()),
+      snapshot_read_ts_(snapshot_read_ts),
       partition_id_(partition_id),
       fetch_from_primary_(fetch_from_primary),
-      snapshot_read_ts_(snapshot_read_ts),
       only_fetch_archives_(only_fetch_archives),
       reopen_(reopen)
 {
+}
+
+void FetchRecordCc::Reset(const TableName *tbl_name,
+                          const TableSchema *tbl_schema,
+                          TxKey tx_key,
+                          LruEntry *cce,
+                          CcShard &ccs,
+                          NodeGroupId cc_ng_id,
+                          int64_t cc_ng_term,
+                          int32_t partition_id,
+                          bool fetch_from_primary,
+                          uint64_t snapshot_read_ts,
+                          bool only_fetch_archives,
+                          bool reopen)
+{
+    // A request never migrates between shards: its pool and active-fetch map
+    // are both owned by the shard captured on first use.
+    assert(ccs_ == nullptr || ccs_ == &ccs);
+    ccs_ = &ccs;
+    cc_ng_id_ = cc_ng_id;
+    cc_ng_term_ = cc_ng_term;
+    requesters_.clear();
+    start_ = metrics::TimePoint{};
+
+    table_name_ =
+        TableName(tbl_name->StringView(), tbl_name->Type(), tbl_name->Engine());
+    table_schema_ = tbl_schema;
+    kv_table_name_ =
+        table_schema_->GetKVCatalogInfo()->GetKvTableName(table_name_);
+    tx_key_ = std::move(tx_key);
+    cce_ = cce;
+    lock_ = cce->GetKeyGapLockAndExtraData();
+    rec_ts_ = 0;
+    snapshot_read_ts_ = snapshot_read_ts;
+    archive_records_.reset();
+    rec_str_.clear();
+    kv_session_id_.clear();
+    kv_start_key_.clear();
+    kv_end_key_.clear();
+    error_code_ = 0;
+    partition_id_ = partition_id;
+    rec_status_ = RecordStatus::Unknown;
+    fetch_from_primary_ = fetch_from_primary;
+    only_fetch_archives_ = only_fetch_archives;
+    reopen_ = reopen;
 }
 
 bool FetchRecordCc::ValidTermCheck()
@@ -987,7 +1032,7 @@ bool FetchRecordCc::Execute(CcShard &ccs)
 void FetchRecordCc::SetFinish(int err)
 {
     error_code_ = err;
-    ccs_.Enqueue(this);
+    ccs_->Enqueue(this);
 }
 
 bool RecoverDeadTxCc::Execute(CcShard &ccs)

--- a/tx_service/src/cc/cc_shard.cpp
+++ b/tx_service/src/cc/cc_shard.cpp
@@ -2410,10 +2410,7 @@ store::DataStoreHandler::DataStoreOpStatus CcShard::FetchBucketData(
 void CcShard::RemoveFetchRecordRequest(LruEntry *cce)
 {
     auto fetch_it = fetch_record_reqs_.find(cce);
-    if (fetch_it == fetch_record_reqs_.end())
-    {
-        return;
-    }
+    assert(fetch_it != fetch_record_reqs_.end());
     FetchRecordCc *fetch_req = fetch_it->second;
     fetch_record_reqs_.erase(fetch_it);
 

--- a/tx_service/src/cc/cc_shard.cpp
+++ b/tx_service/src/cc/cc_shard.cpp
@@ -130,6 +130,8 @@ CcShard::CcShard(
       system_handler_(system_handler),
       active_si_txs_()
 {
+    fetch_record_reqs_.reserve(64);
+
     // Reserve range_slice_memory_limit_percent% for range slice info.
     // We update this to dynamically reserve the configured range slice
     // percentage.
@@ -2184,20 +2186,32 @@ store::DataStoreHandler::DataStoreOpStatus CcShard::FetchRecord(
     bool only_fetch_archives,
     bool reopen)
 {
-    auto tab_it = fetch_record_reqs_.try_emplace(cce,
-                                                 &table_name,
-                                                 tbl_schema,
-                                                 std::move(key),
-                                                 cce,
-                                                 *this,
-                                                 cc_ng_id,
-                                                 cc_ng_term,
-                                                 partition_id,
-                                                 fetch_from_primary,
-                                                 snapshot_read_ts,
-                                                 only_fetch_archives,
-                                                 reopen);
-    FetchRecordCc *fetch_req = &(tab_it.first->second);
+    auto tab_it = fetch_record_reqs_.find(cce);
+    FetchRecordCc *fetch_req = nullptr;
+    if (tab_it == fetch_record_reqs_.end())
+    {
+        fetch_req = fetch_record_cc_pool_.NextRequest();
+        fetch_req->Reset(&table_name,
+                         tbl_schema,
+                         std::move(key),
+                         cce,
+                         *this,
+                         cc_ng_id,
+                         cc_ng_term,
+                         partition_id,
+                         fetch_from_primary,
+                         snapshot_read_ts,
+                         only_fetch_archives,
+                         reopen);
+        const bool inserted =
+            fetch_record_reqs_.try_emplace(cce, fetch_req).second;
+        assert(inserted);
+        (void) inserted;
+    }
+    else
+    {
+        fetch_req = tab_it->second;
+    }
     fetch_req->AddRequester(requester);
 
     CODE_FAULT_INJECTOR("disable_fetch_record", {
@@ -2395,7 +2409,18 @@ store::DataStoreHandler::DataStoreOpStatus CcShard::FetchBucketData(
 
 void CcShard::RemoveFetchRecordRequest(LruEntry *cce)
 {
-    fetch_record_reqs_.erase(cce);
+    auto fetch_it = fetch_record_reqs_.find(cce);
+    if (fetch_it == fetch_record_reqs_.end())
+    {
+        return;
+    }
+    FetchRecordCc *fetch_req = fetch_it->second;
+    fetch_record_reqs_.erase(fetch_it);
+
+    // Free marks the request reusable while its Execute call is unwinding, but
+    // both FetchRecord and resumed requesters run on this shard, so NextRequest
+    // cannot observe it until control returns to the shard loop.
+    fetch_req->Free();
 }
 
 CcMap *CcShard::CreateOrUpdatePkCcMap(const TableName &table_name,


### PR DESCRIPTION
## Context

EloqKV cold reads copied the completed serialized value from `ReadClosure` into
`FetchRecordCc::rec_str_` before `BackFill` deserialized it into the CCMap
payload. Each new single-flight fetch also constructed a `FetchRecordCc` inside
an `std::unordered_map` node and destroyed it when the fetch completed.

For 1–4 KiB values, the value copy adds one full-value memcpy and temporarily
keeps two serialized copies alive. The short-lived fetch object and map node
also add allocator traffic, including the first allocation of its requester
vector.

## Behavior before and after

Before this change, a successful EloqKV read copied the serialized value into
`FetchRecordCc`, and every new active fetch allocated map/object state that was
freed at completion.

After this change:

- the callback transfers ownership of the serialized value into
  `FetchRecordCc`;
- each shard reuses `FetchRecordCc` objects from `CcRequestPool`;
- an `absl::flat_hash_map<LruEntry *, FetchRecordCc *>` indexes active fetches
  without allocating one node per fetch after the table reaches capacity; and
- `FetchRecordCc` member reordering reduces `sizeof(FetchRecordCc)` from 384 to
  368 bytes on the current 64-bit build.

The Redis-visible value, TTL semantics, record timestamp, coalescing behavior,
error handling, range-partition decoding, durability, and recovery behavior are
unchanged.

## Allocation accounting

This change does reduce allocations after pool/map warm-up: it reuses the
`FetchRecordCc` object, its `requesters_` capacity, and the active-fetch hash
table storage instead of allocating an `unordered_map` node containing a new
object for each cold fetch.

It does **not** eliminate the local serialized-value allocation. Moving
`ReadClosure::value_` into `rec_str_` gives up the closure's reusable buffer, so
a later local EloqStore read allocates a new buffer when filling that closure.
The local-path improvement is one fewer full-value memcpy and one fewer
simultaneously live serialized copy, not one fewer steady-state value-buffer
allocation. `BackFill` also still deserializes into the final CCMap payload, so
that final allocation/copy remains.

For remote reads, cleanup already releases the protobuf response storage.
Moving its string also avoids the separate destination allocation previously
performed by `rec_str_.assign(...)`.

## Implementation

- Add `ReadClosure::TakeValue()` as the explicit consuming API for local and
  RPC-backed reads.
- Use it only in the EloqKV hash-partition success path; range-partition decoding
  retains the existing `string_view` flow.
- Make `FetchRecordCc` resettable and pool it per `CcShard`.
- Keep pooled object addresses stable while asynchronous data-store callbacks
  are in flight; the flat map is only a non-owning active-fetch index.
- Reset request state between uses while retaining reusable requester/string
  capacity. Archive result storage is released to avoid retaining an
  unexpectedly large vector indefinitely.
- Read the clock only when a record has a non-zero TTL.
- Group naturally aligned members to remove 16 bytes of padding per object.

## Concurrency and lifetime

The pool and active-fetch map are owned by the same `CcShard`. A request never
migrates between shards, and `Reset()` asserts that invariant. Removing a fetch
erases the map entry before returning the request to the pool. Although `Free()`
can run while `FetchRecordCc::Execute()` is unwinding, new fetches and resumed
requesters execute serially on the owning shard, so `NextRequest()` cannot reuse
that object until control returns to the shard loop.

Reopen operations retain the same active request and do not return it to the
pool. The data-store callback has completed before the request is removed, so no
callback can retain a pointer to a freed/reused request.

## Test plan

- [ ] Unit/CTest coverage
- [x] Standalone data_substrate build
- [x] Parent-project integration and manual validation
- [x] Formatting/build checks
- [x] Performance validation
- [x] Documentation reviewed; no externally visible behavior changed

Commands and results:

```text
clang-format-18 --dry-run --Werror <changed C++ files>
PASS

git diff --check origin/main...HEAD
PASS

cmake -S . -B bld-pr -DCMAKE_BUILD_TYPE=Release \
  -DELOQ_THIRD_PARTY_PREFIX=/mnt/dev/eloqkv/data_substrate/third_party/install \
  -DWITH_DATA_STORE=ELOQDSS_ELOQSTORE -DWITH_LOG_SERVICE=ON
cmake --build bld-pr --parallel 16
PASS (data_substrate target and dependencies)

cmake --build /mnt/dev/eloqkv/bld --parallel 16
cmake --install /mnt/dev/eloqkv/bld
PASS (parent EloqKV Release build/install containing the change)

ctest --test-dir bld-pr --output-on-failure
No tests were found in this build configuration.
```

Cold-read comparison with the same 16-core EloqKV / 16-core memtier setup and
1–4 KiB values:

```text
before pool: 248,744.50 QPS, 0.32160 ms average,
             p99.9 0.671 ms, p99.99 3.119 ms
after pool:  248,845.50 QPS, 0.32144 ms average,
             p99.9 0.679 ms, p99.99 3.295 ms
```

The approximately +0.04% QPS difference is within run-to-run noise; this test
does not demonstrate a measurable performance gain from request pooling. It
does show that these control-object allocations are not the dominant bottleneck
in the tested workload. The ownership move remains useful because it removes a
full-value copy.

No standalone TCL suite or dedicated remote/range/reopen/failover test was run.

## Risk assessment

The main regression surface is pooled request lifetime and reset completeness.
The pool keeps a small baseline of eight `FetchRecordCc` objects per shard and
can retain requester/string capacities reached by prior requests. Large archive
vectors are explicitly released. The flat map reserves 64 active-fetch slots
per shard to avoid hot-path rehashing.

`FetchCc` now stores its shard as a pointer so pooled instances can be default
constructed; existing non-pooled subclasses continue to initialize it through
the same constructor. This is an internal in-process layout change with no wire,
storage-format, locking, or durability impact.

## Rollback plan

Revert this PR. The first restores copying the read result;
the second restores per-fetch construction in `std::unordered_map`.

## Reviewer guide

1. Review `FetchRecordCallback` and `ReadClosure::TakeValue()` for the ownership
   transfer and local/remote allocation distinction.
2. Review `CcShard::FetchRecord()` and `RemoveFetchRecordRequest()` for
   single-flight indexing, pool lifetime, and same-shard serialization.
3. Review `FetchRecordCc::Reset()` for complete state reset across retries,
   reopen, archive reads, and errors.

## Follow-up work

Reducing the remaining 1–4 KiB local value-buffer allocation requires a broader
handoff design, such as filling a reusable consumer-owned buffer or pooling the
serialized buffer separately across the asynchronous fetch/backfill lifetime.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved record retrieval efficiency by reducing unnecessary value copying.
  * Optimized fetch request allocation and cleanup for smoother processing under load.
* **Reliability**
  * Improved handling of record expiration and fetch request state resets.
  * Added safer initialization and lifecycle management for fetch operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->