### PR TITLE
Fix TTL compaction filter value parsing

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,6 +10,10 @@ on:
   push:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 # The container's default run shell is `sh` (dash); force bash so array/here-doc
 # and `set -o pipefail` in any step behave predictably.
 defaults:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -92,42 +92,12 @@ jobs:
         working-directory: bld
         run: ctest --output-on-failure --timeout 180
 
-  rocksdb-cloud-ttl-test:
-    needs: prime-third-party
-    name: rocksdb-cloud-ttl-test (${{ matrix.arch }})
-    strategy:
-      fail-fast: false
-      matrix:
-        arch: [amd64, arm64]
-    runs-on: ${{ matrix.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
-    container:
-      image: eloqdata/ubuntu-dev:24.04
-      options: --user root
-    env:
-      ELOQ_THIRD_PARTY_PREFIX: /opt/eloq/third_party
-      CMAKE_PREFIX_PATH: /opt/eloq/third_party
-      CMAKE_INCLUDE_PATH: /opt/eloq/third_party/include
-      CMAKE_LIBRARY_PATH: /opt/eloq/third_party/lib
-      LD_LIBRARY_PATH: /opt/eloq/third_party/lib
-    steps:
-      - name: Checkout (recursive submodules)
-        uses: actions/checkout@v4
-        with:
-          submodules: recursive
-
-      - name: Setup third-party (cached)
-        uses: ./.github/actions/setup-third-party
-        with:
-          arch: ${{ matrix.arch }}
-          cache-scope: ubuntu-dev
-
       - name: Configure RocksDB Cloud S3 TTL test
         run: |
           cmake -S . -B bld_rocksdb_cloud_ttl \
             -DWITH_TESTS=ON \
             -DWITH_DATA_STORE=ELOQDSS_ROCKSDB_CLOUD_S3 \
             -DWITH_LOG_STATE=ROCKSDB_CLOUD_S3 \
-            -DWITH_LOG_SERVICE=OFF \
             -DCMAKE_BUILD_TYPE=Debug \
             -DELOQ_THIRD_PARTY_PREFIX=/opt/eloq/third_party \
             -DELOQ_THIRD_PARTY_REQUIRED=ON

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -92,6 +92,59 @@ jobs:
         working-directory: bld
         run: ctest --output-on-failure --timeout 180
 
+  rocksdb-cloud-ttl-test:
+    needs: prime-third-party
+    name: rocksdb-cloud-ttl-test (${{ matrix.arch }})
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [amd64, arm64]
+    runs-on: ${{ matrix.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
+    container:
+      image: eloqdata/ubuntu-dev:24.04
+      options: --user root
+    env:
+      ELOQ_THIRD_PARTY_PREFIX: /opt/eloq/third_party
+      CMAKE_PREFIX_PATH: /opt/eloq/third_party
+      CMAKE_INCLUDE_PATH: /opt/eloq/third_party/include
+      CMAKE_LIBRARY_PATH: /opt/eloq/third_party/lib
+      LD_LIBRARY_PATH: /opt/eloq/third_party/lib
+    steps:
+      - name: Checkout (recursive submodules)
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Setup third-party (cached)
+        uses: ./.github/actions/setup-third-party
+        with:
+          arch: ${{ matrix.arch }}
+          cache-scope: ubuntu-dev
+
+      - name: Configure RocksDB Cloud S3 TTL test
+        run: |
+          cmake -S . -B bld_rocksdb_cloud_ttl \
+            -DWITH_TESTS=ON \
+            -DWITH_DATA_STORE=ELOQDSS_ROCKSDB_CLOUD_S3 \
+            -DWITH_LOG_STATE=ROCKSDB_CLOUD_S3 \
+            -DWITH_LOG_SERVICE=OFF \
+            -DCMAKE_BUILD_TYPE=Debug \
+            -DELOQ_THIRD_PARTY_PREFIX=/opt/eloq/third_party \
+            -DELOQ_THIRD_PARTY_REQUIRED=ON
+
+      - name: Build TTL compaction filter test
+        run: |
+          cmake --build bld_rocksdb_cloud_ttl \
+            --target TTLCompactionFilter-Test \
+            --parallel "$(nproc)"
+
+      - name: Run TTL compaction filter test
+        run: |
+          ctest --test-dir bld_rocksdb_cloud_ttl \
+            --output-on-failure \
+            --timeout 180 \
+            -R '^TTLCompactionFilter-Test$'
+
   log-service-tests:
     needs: prime-third-party
     name: log-service-tests (${{ matrix.arch }})

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -96,9 +96,9 @@ jobs:
         working-directory: bld
         run: ctest --output-on-failure --timeout 180
 
-      - name: Configure RocksDB Cloud S3 TTL test
+      - name: Configure RocksDB Cloud S3
         run: |
-          cmake -S . -B bld_rocksdb_cloud_ttl \
+          cmake -S . -B bld_rocksdb_cloud \
             -DWITH_TESTS=ON \
             -DWITH_DATA_STORE=ELOQDSS_ROCKSDB_CLOUD_S3 \
             -DWITH_LOG_STATE=ROCKSDB_CLOUD_S3 \
@@ -106,18 +106,12 @@ jobs:
             -DELOQ_THIRD_PARTY_PREFIX=/opt/eloq/third_party \
             -DELOQ_THIRD_PARTY_REQUIRED=ON
 
-      - name: Build TTL compaction filter test
-        run: |
-          cmake --build bld_rocksdb_cloud_ttl \
-            --target TTLCompactionFilter-Test \
-            --parallel "$(nproc)"
+      - name: Build RocksDB Cloud S3
+        run: cmake --build bld_rocksdb_cloud --parallel "$(nproc)"
 
-      - name: Run TTL compaction filter test
-        run: |
-          ctest --test-dir bld_rocksdb_cloud_ttl \
-            --output-on-failure \
-            --timeout 180 \
-            -R '^TTLCompactionFilter-Test$'
+      - name: Test (gating — RocksDB Cloud S3 full suite)
+        working-directory: bld_rocksdb_cloud
+        run: ctest --output-on-failure --timeout 180
 
   log-service-tests:
     needs: prime-third-party

--- a/store_handler/eloq_data_store_service/rocksdb_cloud_data_store.cpp
+++ b/store_handler/eloq_data_store_service/rocksdb_cloud_data_store.cpp
@@ -179,9 +179,6 @@ void RocksDBCloudDataStore::Shutdown()
         delete db_;
         DLOG(INFO) << "RocksDBCloudDataStore Shutdown, db_ = nullptr";
         db_ = nullptr;
-        DLOG(INFO) << "RocksDBCloudDataStore Shutdown, "
-                      "ttl_compaction_filter_factory_ = nullptr";
-        ttl_compaction_filter_factory_ = nullptr;
         DLOG(INFO) << "RocksDBCloudDataStore Shutdown, cloud_env_ = nullptr";
         cloud_env_ = nullptr;
         DLOG(INFO) << "RocksDBCloudDataStore Shutdown, cloud_fs_ = nullptr";
@@ -679,10 +676,8 @@ bool RocksDBCloudDataStore::OpenCloudDB(
     options.max_open_files = 0;
 
     // set ttl compaction filter
-    assert(ttl_compaction_filter_factory_ == nullptr);
-    ttl_compaction_filter_factory_ =
+    options.compaction_filter_factory =
         std::make_shared<EloqDS::TTLCompactionFilterFactory>();
-    options.compaction_filter_factory = ttl_compaction_filter_factory_;
 
     // Disable auto compactions before blocking purger
     options.disable_auto_compactions = true;
@@ -733,8 +728,6 @@ bool RocksDBCloudDataStore::OpenCloudDB(
 
     if (!status.ok())
     {
-        ttl_compaction_filter_factory_ = nullptr;
-
         LOG(ERROR) << "Unable to open db at path " << storage_path_
                    << " with bucket " << cfs_options.src_bucket.GetBucketName()
                    << " with error: " << status.ToString();
@@ -761,7 +754,6 @@ bool RocksDBCloudDataStore::OpenCloudDB(
         db_->Close();
         delete db_;
         db_ = nullptr;
-        ttl_compaction_filter_factory_ = nullptr;
         return false;
     }
 
@@ -776,7 +768,6 @@ bool RocksDBCloudDataStore::OpenCloudDB(
         db_->Close();
         delete db_;
         db_ = nullptr;
-        ttl_compaction_filter_factory_ = nullptr;
         return false;
     }
     if (current_epoch.empty())
@@ -802,7 +793,6 @@ bool RocksDBCloudDataStore::OpenCloudDB(
         db_->Close();
         delete db_;
         db_ = nullptr;
-        ttl_compaction_filter_factory_ = nullptr;
         return false;
     }
 
@@ -817,7 +807,6 @@ bool RocksDBCloudDataStore::OpenCloudDB(
         db_->Close();
         delete db_;
         db_ = nullptr;
-        ttl_compaction_filter_factory_ = nullptr;
         return false;
     }
 

--- a/store_handler/eloq_data_store_service/rocksdb_cloud_data_store.cpp
+++ b/store_handler/eloq_data_store_service/rocksdb_cloud_data_store.cpp
@@ -179,9 +179,9 @@ void RocksDBCloudDataStore::Shutdown()
         delete db_;
         DLOG(INFO) << "RocksDBCloudDataStore Shutdown, db_ = nullptr";
         db_ = nullptr;
-        DLOG(INFO) << "RocksDBCloudDataStore Shutdown, ttl_compaction_filter_ "
-                      "= nullptr";
-        ttl_compaction_filter_ = nullptr;
+        DLOG(INFO) << "RocksDBCloudDataStore Shutdown, "
+                      "ttl_compaction_filter_factory_ = nullptr";
+        ttl_compaction_filter_factory_ = nullptr;
         DLOG(INFO) << "RocksDBCloudDataStore Shutdown, cloud_env_ = nullptr";
         cloud_env_ = nullptr;
         DLOG(INFO) << "RocksDBCloudDataStore Shutdown, cloud_fs_ = nullptr";
@@ -679,11 +679,10 @@ bool RocksDBCloudDataStore::OpenCloudDB(
     options.max_open_files = 0;
 
     // set ttl compaction filter
-    assert(ttl_compaction_filter_ == nullptr);
-    ttl_compaction_filter_ = std::make_unique<EloqDS::TTLCompactionFilter>();
-
-    options.compaction_filter =
-        static_cast<rocksdb::CompactionFilter *>(ttl_compaction_filter_.get());
+    assert(ttl_compaction_filter_factory_ == nullptr);
+    ttl_compaction_filter_factory_ =
+        std::make_shared<EloqDS::TTLCompactionFilterFactory>();
+    options.compaction_filter_factory = ttl_compaction_filter_factory_;
 
     // Disable auto compactions before blocking purger
     options.disable_auto_compactions = true;
@@ -734,7 +733,7 @@ bool RocksDBCloudDataStore::OpenCloudDB(
 
     if (!status.ok())
     {
-        ttl_compaction_filter_ = nullptr;
+        ttl_compaction_filter_factory_ = nullptr;
 
         LOG(ERROR) << "Unable to open db at path " << storage_path_
                    << " with bucket " << cfs_options.src_bucket.GetBucketName()
@@ -762,7 +761,7 @@ bool RocksDBCloudDataStore::OpenCloudDB(
         db_->Close();
         delete db_;
         db_ = nullptr;
-        ttl_compaction_filter_ = nullptr;
+        ttl_compaction_filter_factory_ = nullptr;
         return false;
     }
 
@@ -777,7 +776,7 @@ bool RocksDBCloudDataStore::OpenCloudDB(
         db_->Close();
         delete db_;
         db_ = nullptr;
-        ttl_compaction_filter_ = nullptr;
+        ttl_compaction_filter_factory_ = nullptr;
         return false;
     }
     if (current_epoch.empty())
@@ -803,7 +802,7 @@ bool RocksDBCloudDataStore::OpenCloudDB(
         db_->Close();
         delete db_;
         db_ = nullptr;
-        ttl_compaction_filter_ = nullptr;
+        ttl_compaction_filter_factory_ = nullptr;
         return false;
     }
 
@@ -818,7 +817,7 @@ bool RocksDBCloudDataStore::OpenCloudDB(
         db_->Close();
         delete db_;
         db_ = nullptr;
-        ttl_compaction_filter_ = nullptr;
+        ttl_compaction_filter_factory_ = nullptr;
         return false;
     }
 

--- a/store_handler/eloq_data_store_service/rocksdb_data_store.cpp
+++ b/store_handler/eloq_data_store_service/rocksdb_data_store.cpp
@@ -78,7 +78,6 @@ void RocksDBDataStore::Shutdown()
         db_->Close();
         delete db_;
         db_ = nullptr;
-        ttl_compaction_filter_factory_ = nullptr;
     }
 }
 
@@ -242,10 +241,8 @@ bool RocksDBDataStore::StartDB(int64_t term)
     }
 
     // set ttl compaction filter
-    assert(ttl_compaction_filter_factory_ == nullptr);
-    ttl_compaction_filter_factory_ =
+    options.compaction_filter_factory =
         std::make_shared<EloqDS::TTLCompactionFilterFactory>();
-    options.compaction_filter_factory = ttl_compaction_filter_factory_;
 
     auto start = std::chrono::system_clock::now();
     std::unique_lock<std::shared_mutex> db_lk(db_mux_);
@@ -258,8 +255,6 @@ bool RocksDBDataStore::StartDB(int64_t term)
 
     if (!status.ok())
     {
-        ttl_compaction_filter_factory_ = nullptr;
-
         LOG(ERROR) << "Unable to open db at path " << storage_path_
                    << " with error: " << status.ToString();
 

--- a/store_handler/eloq_data_store_service/rocksdb_data_store.cpp
+++ b/store_handler/eloq_data_store_service/rocksdb_data_store.cpp
@@ -78,7 +78,7 @@ void RocksDBDataStore::Shutdown()
         db_->Close();
         delete db_;
         db_ = nullptr;
-        ttl_compaction_filter_ = nullptr;
+        ttl_compaction_filter_factory_ = nullptr;
     }
 }
 
@@ -242,11 +242,10 @@ bool RocksDBDataStore::StartDB(int64_t term)
     }
 
     // set ttl compaction filter
-    assert(ttl_compaction_filter_ == nullptr);
-    ttl_compaction_filter_ = std::make_unique<EloqDS::TTLCompactionFilter>();
-
-    options.compaction_filter =
-        static_cast<rocksdb::CompactionFilter *>(ttl_compaction_filter_.get());
+    assert(ttl_compaction_filter_factory_ == nullptr);
+    ttl_compaction_filter_factory_ =
+        std::make_shared<EloqDS::TTLCompactionFilterFactory>();
+    options.compaction_filter_factory = ttl_compaction_filter_factory_;
 
     auto start = std::chrono::system_clock::now();
     std::unique_lock<std::shared_mutex> db_lk(db_mux_);
@@ -259,7 +258,7 @@ bool RocksDBDataStore::StartDB(int64_t term)
 
     if (!status.ok())
     {
-        ttl_compaction_filter_ = nullptr;
+        ttl_compaction_filter_factory_ = nullptr;
 
         LOG(ERROR) << "Unable to open db at path " << storage_path_
                    << " with error: " << status.ToString();

--- a/store_handler/eloq_data_store_service/rocksdb_data_store_common.cpp
+++ b/store_handler/eloq_data_store_service/rocksdb_data_store_common.cpp
@@ -59,7 +59,16 @@ bool TTLCompactionFilter::Filter(int level,
         return false;
     }
 
-    return header.ttl < current_timestamp_;
+    if (header.ttl < current_timestamp_)
+    {
+        DLOG(INFO) << "TTL compaction filter removes expired key, key: "
+                   << key.ToString(true)
+                   << ", expiration_timestamp: " << header.ttl
+                   << ", compaction_timestamp: " << current_timestamp_;
+        return true;
+    }
+
+    return false;
 }
 
 const char *TTLCompactionFilter::Name() const
@@ -75,6 +84,8 @@ TTLCompactionFilterFactory::CreateCompactionFilter(
         std::chrono::duration_cast<std::chrono::milliseconds>(
             std::chrono::system_clock::now().time_since_epoch())
             .count();
+    DLOG(INFO) << "Create TTL compaction filter, current_timestamp: "
+               << current_timestamp;
     return std::make_unique<TTLCompactionFilter>(current_timestamp);
 }
 

--- a/store_handler/eloq_data_store_service/rocksdb_data_store_common.cpp
+++ b/store_handler/eloq_data_store_service/rocksdb_data_store_common.cpp
@@ -34,9 +34,8 @@ bool TTLCompactionFilter::Filter(int level,
     }
 
     uint64_t rec_ttl;
-    std::memcpy(&rec_ttl,
-                existing_value.data() + sizeof(uint64_t),
-                sizeof(rec_ttl));
+    std::memcpy(
+        &rec_ttl, existing_value.data() + sizeof(uint64_t), sizeof(rec_ttl));
     const uint64_t current_timestamp =
         std::chrono::duration_cast<std::chrono::milliseconds>(
             std::chrono::system_clock::now().time_since_epoch())

--- a/store_handler/eloq_data_store_service/rocksdb_data_store_common.cpp
+++ b/store_handler/eloq_data_store_service/rocksdb_data_store_common.cpp
@@ -14,10 +14,7 @@ bool TTLCompactionFilter::Filter(int level,
                                  std::string *new_value,
                                  bool *value_changed) const
 {
-    if (existing_value.size() < sizeof(uint64_t))
-    {
-        return false;
-    }
+    assert(existing_value.size() >= sizeof(uint64_t));
 
     // The first word is the encoded version timestamp. Its MSB indicates
     // whether the second word contains a TTL expiration timestamp.
@@ -28,10 +25,7 @@ bool TTLCompactionFilter::Filter(int level,
         return false;
     }
 
-    if (existing_value.size() < sizeof(uint64_t) * 2)
-    {
-        return false;
-    }
+    assert(existing_value.size() >= sizeof(uint64_t) * 2);
 
     uint64_t rec_ttl;
     std::memcpy(

--- a/store_handler/eloq_data_store_service/rocksdb_data_store_common.cpp
+++ b/store_handler/eloq_data_store_service/rocksdb_data_store_common.cpp
@@ -1,5 +1,6 @@
 #include "rocksdb_data_store_common.h"
 
+#include <cstring>
 #include <filesystem>
 
 #include "internal_request.h"
@@ -13,44 +14,35 @@ bool TTLCompactionFilter::Filter(int level,
                                  std::string *new_value,
                                  bool *value_changed) const
 {
-    assert(existing_value.size() >= sizeof(uint64_t));
-    bool has_ttl = false;
-    uint64_t ts = *(reinterpret_cast<const uint64_t *>(existing_value.data() +
-                                                       sizeof(uint64_t)));
-
-    // Check if the MSB is set
-    if (ts & MSB)
+    if (existing_value.size() < sizeof(uint64_t))
     {
-        has_ttl = true;
-        ts &= MSB_MASK;  // Clear the MSB
-    }
-    else
-    {
-        has_ttl = false;
+        return false;
     }
 
-    if (has_ttl)
+    // The first word is the encoded version timestamp. Its MSB indicates
+    // whether the second word contains a TTL expiration timestamp.
+    uint64_t encoded_ts;
+    std::memcpy(&encoded_ts, existing_value.data(), sizeof(encoded_ts));
+    if ((encoded_ts & MSB) == 0)
     {
-        assert(existing_value.size() >= sizeof(uint64_t) * 2);
-        uint64_t rec_ttl = *(reinterpret_cast<const uint64_t *>(
-            existing_value.data() + sizeof(uint64_t)));
-        // Get the current timestamp in microseconds
-        // auto current_timestamp =
-        // txservice::LocalCcShards::ClockTsInMillseconds();
-        // FIXME(lzx): only fetch the time at the begin of compaction.
-        uint64_t current_timestamp =
-            std::chrono::duration_cast<std::chrono::milliseconds>(
-                std::chrono::high_resolution_clock::now().time_since_epoch())
-                .count();
-
-        // Check if the timestamp is smaller than the current timestamp
-        if (rec_ttl < current_timestamp)
-        {
-            return true;  // Mark the key for deletion
-        }
+        return false;
     }
 
-    return false;  // Keep the key
+    if (existing_value.size() < sizeof(uint64_t) * 2)
+    {
+        return false;
+    }
+
+    uint64_t rec_ttl;
+    std::memcpy(&rec_ttl,
+                existing_value.data() + sizeof(uint64_t),
+                sizeof(rec_ttl));
+    const uint64_t current_timestamp =
+        std::chrono::duration_cast<std::chrono::milliseconds>(
+            std::chrono::system_clock::now().time_since_epoch())
+            .count();
+
+    return rec_ttl < current_timestamp;
 }
 
 const char *TTLCompactionFilter::Name() const

--- a/store_handler/eloq_data_store_service/rocksdb_data_store_common.cpp
+++ b/store_handler/eloq_data_store_service/rocksdb_data_store_common.cpp
@@ -36,9 +36,8 @@ DecodedValueHeader DecodeValueHeader(const char *data, size_t size)
     if (header.has_ttl)
     {
         assert(size >= sizeof(uint64_t) * 2);
-        std::memcpy(&header.ttl,
-                    data + header.record_offset,
-                    sizeof(header.ttl));
+        std::memcpy(
+            &header.ttl, data + header.record_offset, sizeof(header.ttl));
         header.record_offset += sizeof(uint64_t);
     }
 

--- a/store_handler/eloq_data_store_service/rocksdb_data_store_common.cpp
+++ b/store_handler/eloq_data_store_service/rocksdb_data_store_common.cpp
@@ -30,17 +30,28 @@ bool TTLCompactionFilter::Filter(int level,
     uint64_t rec_ttl;
     std::memcpy(
         &rec_ttl, existing_value.data() + sizeof(uint64_t), sizeof(rec_ttl));
-    const uint64_t current_timestamp =
-        std::chrono::duration_cast<std::chrono::milliseconds>(
-            std::chrono::system_clock::now().time_since_epoch())
-            .count();
-
-    return rec_ttl < current_timestamp;
+    return rec_ttl < current_timestamp_;
 }
 
 const char *TTLCompactionFilter::Name() const
 {
     return "TTLCompactionFilter";
+}
+
+std::unique_ptr<rocksdb::CompactionFilter>
+TTLCompactionFilterFactory::CreateCompactionFilter(
+    const rocksdb::CompactionFilter::Context &)
+{
+    const uint64_t current_timestamp =
+        std::chrono::duration_cast<std::chrono::milliseconds>(
+            std::chrono::system_clock::now().time_since_epoch())
+            .count();
+    return std::make_unique<TTLCompactionFilter>(current_timestamp);
+}
+
+const char *TTLCompactionFilterFactory::Name() const
+{
+    return "TTLCompactionFilterFactory";
 }
 
 void RocksDBEventListener::OnCompactionBegin(

--- a/store_handler/eloq_data_store_service/rocksdb_data_store_common.cpp
+++ b/store_handler/eloq_data_store_service/rocksdb_data_store_common.cpp
@@ -8,29 +8,59 @@
 namespace EloqDS
 {
 
+namespace
+{
+
+struct DecodedValueHeader
+{
+    uint64_t version_ts;
+    uint64_t ttl;
+    size_t record_offset;
+    bool has_ttl;
+};
+
+// The value header written by TransformRecordToValueSlices always contains a
+// version timestamp and contains an expiration timestamp exactly when the
+// version timestamp's MSB is set.
+DecodedValueHeader DecodeValueHeader(const char *data, size_t size)
+{
+    assert(size >= sizeof(uint64_t));
+
+    DecodedValueHeader header;
+    std::memcpy(&header.version_ts, data, sizeof(header.version_ts));
+    header.has_ttl = (header.version_ts & MSB) != 0;
+    header.version_ts &= MSB_MASK;
+    header.record_offset = sizeof(uint64_t);
+    header.ttl = 0;
+
+    if (header.has_ttl)
+    {
+        assert(size >= sizeof(uint64_t) * 2);
+        std::memcpy(&header.ttl,
+                    data + header.record_offset,
+                    sizeof(header.ttl));
+        header.record_offset += sizeof(uint64_t);
+    }
+
+    return header;
+}
+
+}  // namespace
+
 bool TTLCompactionFilter::Filter(int level,
                                  const rocksdb::Slice &key,
                                  const rocksdb::Slice &existing_value,
                                  std::string *new_value,
                                  bool *value_changed) const
 {
-    assert(existing_value.size() >= sizeof(uint64_t));
-
-    // The first word is the encoded version timestamp. Its MSB indicates
-    // whether the second word contains a TTL expiration timestamp.
-    uint64_t encoded_ts;
-    std::memcpy(&encoded_ts, existing_value.data(), sizeof(encoded_ts));
-    if ((encoded_ts & MSB) == 0)
+    const DecodedValueHeader header =
+        DecodeValueHeader(existing_value.data(), existing_value.size());
+    if (!header.has_ttl)
     {
         return false;
     }
 
-    assert(existing_value.size() >= sizeof(uint64_t) * 2);
-
-    uint64_t rec_ttl;
-    std::memcpy(
-        &rec_ttl, existing_value.data() + sizeof(uint64_t), sizeof(rec_ttl));
-    return rec_ttl < current_timestamp_;
+    return header.ttl < current_timestamp_;
 }
 
 const char *TTLCompactionFilter::Name() const
@@ -1376,44 +1406,16 @@ uint16_t RocksDBDataStoreCommon::TransformRecordToValueSlices(
     return value_slice_idx + parts_cnt_per_record;
 }
 
-void RocksDBDataStoreCommon::DecodeHasTTLFromTs(uint64_t &ts, bool &has_ttl)
-{
-    // Check if the MSB is set
-    if (ts & MSB)
-    {
-        has_ttl = true;
-        ts &= MSB_MASK;  // Clear the MSB
-    }
-    else
-    {
-        has_ttl = false;
-    }
-}
-
 void RocksDBDataStoreCommon::DeserializeValueToRecord(const char *data,
                                                       const size_t size,
                                                       std::string &record,
                                                       uint64_t &ts,
                                                       uint64_t &ttl)
 {
-    assert(size >= sizeof(uint64_t));
-    size_t offset = 0;
-    ts = *reinterpret_cast<const uint64_t *>(data);
-    offset += sizeof(uint64_t);
-    bool has_ttl = false;
-    DecodeHasTTLFromTs(ts, has_ttl);
-    if (has_ttl)
-    {
-        assert(size >= sizeof(uint64_t) * 2);
-        ttl = *(reinterpret_cast<const uint64_t *>(data + offset));
-        offset += sizeof(uint64_t);
-    }
-    else
-    {
-        assert(size >= sizeof(uint64_t));
-        ttl = 0;
-    }
-    record.assign(data + offset, size - offset);
+    const DecodedValueHeader header = DecodeValueHeader(data, size);
+    ts = header.version_ts;
+    ttl = header.ttl;
+    record.assign(data + header.record_offset, size - header.record_offset);
 }
 
 rocksdb::InfoLogLevel RocksDBDataStoreCommon::StringToInfoLogLevel(

--- a/store_handler/eloq_data_store_service/rocksdb_data_store_common.h
+++ b/store_handler/eloq_data_store_service/rocksdb_data_store_common.h
@@ -177,7 +177,6 @@ public:
           received_snapshot_path_(storage_path_ + "/received_snapshot/"),
           create_db_if_missing_(create_if_missing),
           tx_enable_cache_replacement_(tx_enable_cache_replacement),
-          ttl_compaction_filter_factory_(nullptr),
           query_worker_number_(config.query_worker_num_)
     {
         info_log_level_ = StringToInfoLogLevel(config.info_log_level_);
@@ -356,8 +355,6 @@ protected:
     const std::string received_snapshot_path_;
     const bool create_db_if_missing_{false};
     bool tx_enable_cache_replacement_{true};
-    std::shared_ptr<EloqDS::TTLCompactionFilterFactory>
-        ttl_compaction_filter_factory_{nullptr};
     size_t query_worker_number_{4};
 
     std::unique_ptr<ThreadWorkerPool> query_worker_pool_;

--- a/store_handler/eloq_data_store_service/rocksdb_data_store_common.h
+++ b/store_handler/eloq_data_store_service/rocksdb_data_store_common.h
@@ -52,11 +52,33 @@ constexpr uint64_t MSB_MASK = ~MSB;   // Mask to clear Bit 63
 class TTLCompactionFilter : public rocksdb::CompactionFilter
 {
 public:
+    /**
+     * @param current_timestamp Epoch time in milliseconds captured when
+     * RocksDB creates this filter for compaction.
+     */
+    explicit TTLCompactionFilter(uint64_t current_timestamp)
+        : current_timestamp_(current_timestamp)
+    {
+    }
+
     bool Filter(int level,
                 const rocksdb::Slice &key,
                 const rocksdb::Slice &existing_value,
                 std::string *new_value,
                 bool *value_changed) const override;
+
+    const char *Name() const override;
+
+private:
+    const uint64_t current_timestamp_;
+};
+
+/** Creates TTL filters with one timestamp snapshot per compaction worker. */
+class TTLCompactionFilterFactory : public rocksdb::CompactionFilterFactory
+{
+public:
+    std::unique_ptr<rocksdb::CompactionFilter> CreateCompactionFilter(
+        const rocksdb::CompactionFilter::Context &) override;
 
     const char *Name() const override;
 };
@@ -155,7 +177,7 @@ public:
           received_snapshot_path_(storage_path_ + "/received_snapshot/"),
           create_db_if_missing_(create_if_missing),
           tx_enable_cache_replacement_(tx_enable_cache_replacement),
-          ttl_compaction_filter_(nullptr),
+          ttl_compaction_filter_factory_(nullptr),
           query_worker_number_(config.query_worker_num_)
     {
         info_log_level_ = StringToInfoLogLevel(config.info_log_level_);
@@ -336,8 +358,8 @@ protected:
     const std::string received_snapshot_path_;
     const bool create_db_if_missing_{false};
     bool tx_enable_cache_replacement_{true};
-    std::unique_ptr<EloqDS::TTLCompactionFilter> ttl_compaction_filter_{
-        nullptr};
+    std::shared_ptr<EloqDS::TTLCompactionFilterFactory>
+        ttl_compaction_filter_factory_{nullptr};
     size_t query_worker_number_{4};
 
     std::unique_ptr<ThreadWorkerPool> query_worker_pool_;

--- a/store_handler/eloq_data_store_service/rocksdb_data_store_common.h
+++ b/store_handler/eloq_data_store_service/rocksdb_data_store_common.h
@@ -302,8 +302,6 @@ protected:
         uint64_t &ts,
         const uint64_t &ttl,
         std::unique_ptr<rocksdb::Slice[]> &value_slices);
-    void DecodeHasTTLFromTs(uint64_t &ts, bool &has_ttl);
-
     void DeserializeValueToRecord(const char *data,
                                   const size_t size,
                                   std::string &record,

--- a/tx_service/tests/CMakeLists.txt
+++ b/tx_service/tests/CMakeLists.txt
@@ -66,6 +66,12 @@ set(CATCH_MAIN_TESTS
     ApplyResponseBoundary-Test
 )
 
+if(WITH_DATA_STORE STREQUAL "ELOQDSS_ROCKSDB" OR
+   WITH_DATA_STORE STREQUAL "ELOQDSS_ROCKSDB_CLOUD_S3" OR
+   WITH_DATA_STORE STREQUAL "ELOQDSS_ROCKSDB_CLOUD_GCS")
+    list(APPEND CATCH_MAIN_TESTS TTLCompactionFilter-Test)
+endif()
+
 # Tests that define their own int main() (they need gflags::ParseCommandLineFlags
 # before brpc is used). They link Catch2::Catch2 (no bundled main).
 set(OWN_MAIN_TESTS

--- a/tx_service/tests/TTLCompactionFilter-Test.cpp
+++ b/tx_service/tests/TTLCompactionFilter-Test.cpp
@@ -15,7 +15,6 @@
  */
 
 #include <catch2/catch_all.hpp>
-
 #include <cstdint>
 #include <cstring>
 #include <limits>
@@ -30,27 +29,24 @@ std::string MakeValue(uint64_t encoded_ts, uint64_t expiration_ts)
 {
     std::string value(sizeof(uint64_t) * 2, '\0');
     std::memcpy(value.data(), &encoded_ts, sizeof(encoded_ts));
-    std::memcpy(value.data() + sizeof(uint64_t),
-                &expiration_ts,
-                sizeof(expiration_ts));
+    std::memcpy(
+        value.data() + sizeof(uint64_t), &expiration_ts, sizeof(expiration_ts));
     return value;
 }
 
 bool ShouldFilter(const std::string &value)
 {
     EloqDS::TTLCompactionFilter filter;
-    return filter.Filter(0,
-                         rocksdb::Slice("key"),
-                         rocksdb::Slice(value),
-                         nullptr,
-                         nullptr);
+    return filter.Filter(
+        0, rocksdb::Slice("key"), rocksdb::Slice(value), nullptr, nullptr);
 }
 
 }  // namespace
 
-TEST_CASE("TTL compaction filter reads the TTL marker from the encoded "
-          "timestamp",
-          "[rocksdb][ttl]")
+TEST_CASE(
+    "TTL compaction filter reads the TTL marker from the encoded "
+    "timestamp",
+    "[rocksdb][ttl]")
 {
     SECTION("expired TTL value is removed")
     {
@@ -60,8 +56,8 @@ TEST_CASE("TTL compaction filter reads the TTL marker from the encoded "
 
     SECTION("unexpired TTL value is retained")
     {
-        const std::string value = MakeValue(
-            EloqDS::MSB | 42, std::numeric_limits<uint64_t>::max());
+        const std::string value =
+            MakeValue(EloqDS::MSB | 42, std::numeric_limits<uint64_t>::max());
         REQUIRE_FALSE(ShouldFilter(value));
     }
 

--- a/tx_service/tests/TTLCompactionFilter-Test.cpp
+++ b/tx_service/tests/TTLCompactionFilter-Test.cpp
@@ -25,6 +25,8 @@
 namespace
 {
 
+constexpr uint64_t kCompactionTimestamp = 100;
+
 std::string MakeValue(uint64_t encoded_ts, uint64_t expiration_ts)
 {
     std::string value(sizeof(uint64_t) * 2, '\0');
@@ -34,9 +36,9 @@ std::string MakeValue(uint64_t encoded_ts, uint64_t expiration_ts)
     return value;
 }
 
-bool ShouldFilter(const std::string &value)
+bool ShouldFilter(const std::string &value, uint64_t current_timestamp)
 {
-    EloqDS::TTLCompactionFilter filter;
+    EloqDS::TTLCompactionFilter filter(current_timestamp);
     return filter.Filter(
         0, rocksdb::Slice("key"), rocksdb::Slice(value), nullptr, nullptr);
 }
@@ -51,19 +53,19 @@ TEST_CASE(
     SECTION("expired TTL value is removed")
     {
         const std::string value = MakeValue(EloqDS::MSB | 42, 1);
-        REQUIRE(ShouldFilter(value));
+        REQUIRE(ShouldFilter(value, kCompactionTimestamp));
     }
 
     SECTION("unexpired TTL value is retained")
     {
         const std::string value =
             MakeValue(EloqDS::MSB | 42, std::numeric_limits<uint64_t>::max());
-        REQUIRE_FALSE(ShouldFilter(value));
+        REQUIRE_FALSE(ShouldFilter(value, kCompactionTimestamp));
     }
 
     SECTION("value without TTL is retained")
     {
         const std::string value(sizeof(uint64_t), '\0');
-        REQUIRE_FALSE(ShouldFilter(value));
+        REQUIRE_FALSE(ShouldFilter(value, kCompactionTimestamp));
     }
 }

--- a/tx_service/tests/TTLCompactionFilter-Test.cpp
+++ b/tx_service/tests/TTLCompactionFilter-Test.cpp
@@ -1,0 +1,73 @@
+/**
+ *    Copyright (C) 2026 EloqData Inc.
+ *
+ *    This program is free software: you can redistribute it and/or modify
+ *    it under either of the following two licenses:
+ *    1. GNU Affero General Public License, version 3, as published by the Free
+ *    Software Foundation.
+ *    2. GNU General Public License as published by the Free Software
+ *    Foundation; version 2 of the License.
+ *
+ *    This program is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+ *    General Public License or GNU General Public License for more details.
+ */
+
+#include <catch2/catch_all.hpp>
+
+#include <cstdint>
+#include <cstring>
+#include <limits>
+#include <string>
+
+#include "eloq_data_store_service/rocksdb_data_store_common.h"
+
+namespace
+{
+
+std::string MakeValue(uint64_t encoded_ts, uint64_t expiration_ts)
+{
+    std::string value(sizeof(uint64_t) * 2, '\0');
+    std::memcpy(value.data(), &encoded_ts, sizeof(encoded_ts));
+    std::memcpy(value.data() + sizeof(uint64_t),
+                &expiration_ts,
+                sizeof(expiration_ts));
+    return value;
+}
+
+bool ShouldFilter(const std::string &value)
+{
+    EloqDS::TTLCompactionFilter filter;
+    return filter.Filter(0,
+                         rocksdb::Slice("key"),
+                         rocksdb::Slice(value),
+                         nullptr,
+                         nullptr);
+}
+
+}  // namespace
+
+TEST_CASE("TTL compaction filter reads the TTL marker from the encoded "
+          "timestamp",
+          "[rocksdb][ttl]")
+{
+    SECTION("expired TTL value is removed")
+    {
+        const std::string value = MakeValue(EloqDS::MSB | 42, 1);
+        REQUIRE(ShouldFilter(value));
+    }
+
+    SECTION("unexpired TTL value is retained")
+    {
+        const std::string value = MakeValue(
+            EloqDS::MSB | 42, std::numeric_limits<uint64_t>::max());
+        REQUIRE_FALSE(ShouldFilter(value));
+    }
+
+    SECTION("value without TTL is retained")
+    {
+        const std::string value(sizeof(uint64_t), '\0');
+        REQUIRE_FALSE(ShouldFilter(value));
+    }
+}

--- a/tx_service/tests/TTLCompactionFilter-Test.cpp
+++ b/tx_service/tests/TTLCompactionFilter-Test.cpp
@@ -14,12 +14,14 @@
  *    General Public License or GNU General Public License for more details.
  */
 
+// clang-format off
 #include <cstdint>
 #include <cstring>
 #include <limits>
 #include <string>
 
 #include <catch2/catch_all.hpp>
+// clang-format on
 
 #include "eloq_data_store_service/rocksdb_data_store_common.h"
 

--- a/tx_service/tests/TTLCompactionFilter-Test.cpp
+++ b/tx_service/tests/TTLCompactionFilter-Test.cpp
@@ -14,11 +14,12 @@
  *    General Public License or GNU General Public License for more details.
  */
 
-#include <catch2/catch_all.hpp>
 #include <cstdint>
 #include <cstring>
 #include <limits>
 #include <string>
+
+#include <catch2/catch_all.hpp>
 
 #include "eloq_data_store_service/rocksdb_data_store_common.h"
 


### PR DESCRIPTION
## What

- Read the TTL-presence marker from the encoded version timestamp at value offset 0.
- Read the expiration timestamp from offset 8 only when that marker is set.
- Use `memcpy` for word decoding while preserving the existing value-size invariants.
- Share one value-header decoder between compaction filtering and normal record deserialization so the persisted layout cannot drift between paths.
- Create a filter per compaction worker and capture the current time once instead of once per record.
- Emit debug logs when a filter is created and when it removes an expired key, including the relevant timestamps.
- Add focused regression coverage for expired, unexpired, and non-TTL values on EloqDSS RocksDB backends.
- After the EloqStore unit suite, configure `ELOQDSS_ROCKSDB_CLOUD_S3` and build/run the full suite in the same amd64/arm64 CI jobs.
- Cancel superseded `Tests` workflow runs when a newer commit is pushed to the same PR or ref.

## Why / root cause

EloqDSS RocksDB values are stored as:

```text
[encoded version timestamp with TTL MSB][expiration timestamp][record]
```

`TTLCompactionFilter` incorrectly checked offset 8 for the TTL MSB. Offset 8 is the expiration timestamp, whose high bit is clear for ordinary epoch-millisecond values, so expired records were retained during both automatic and manual compaction.

## Observable impact

Expired records can accumulate physically in RocksDB even though reads treat them as deleted. Scans must traverse and deserialize those records before filtering them, which can make sparse ranges progressively slower. After this fix is deployed, subsequent compactions can reclaim expired records; cleanup is still governed by normal compaction scheduling and backlog and is not immediate at expiration time.

## Design notes

- The change is limited to the EloqDSS RocksDB/RocksDB Cloud compaction filter.
- Assertions document that every value has an encoded timestamp and TTL-marked values also have an expiration timestamp.
- A RocksDB-owned `CompactionFilterFactory` captures `system_clock` epoch milliseconds when it creates each compaction filter; all records processed by that filter use the same timestamp.
- This does not change SCAN batching or its behavior when it encounters long runs of expired records.

## Checks

- `git diff --check origin/main...HEAD` — passed.
- `.github/workflows/tests.yml` YAML parse — passed.
- Full CMake build and Catch2 test execution — not run because this host does not have CMake or the development dependency environment installed.

## Risk and rollback

The main risk is deleting a record whose first-word TTL marker and second-word expiration are corrupt but happen to look valid. Correctly encoded non-TTL and unexpired values are retained by regression coverage. Rollback is a revert of these commits; already compacted expired records do not need restoration.

## Reviewer focus

- Confirm the value layout at `TransformRecordToValueSlices` and `DeserializeValueToRecord` matches offsets 0 and 8 used here.
- Confirm the 8-byte and 16-byte assertions match the persisted value-format invariants.
- Confirm the RocksDB-owned factory lifetime and per-compaction-worker timestamp semantics for both local and cloud RocksDB.
