### PR TITLE
chore: update brpc for eventfd worker wakeup

### DIFF
--- a/.github/actions/setup-third-party/action.yml
+++ b/.github/actions/setup-third-party/action.yml
@@ -33,17 +33,21 @@ runs:
       shell: bash
       run: |
         git config --global --add safe.directory '*'
-        # ls-files -s emits the blob SHA for regular files and the gitlink SHA
-        # for submodule paths, so one hash captures the build scripts, manifest,
-        # patches, system-package list, and the pinned source submodule commits
-        # (brpc / braft / mimalloc / rocksdb-cloud) — cheap (reads the index only).
+        # Discover retained third-party submodules from .gitmodules so their
+        # gitlinks are the sole version pins and new ones cannot be omitted from
+        # the cache key. ls-files -s emits the gitlink SHA without initializing
+        # the submodules.
+        mapfile -t submodule_paths < <(
+          git config -f .gitmodules --get-regexp '^submodule\..*\.path$' \
+            | awk '$2 ~ /^third_party\/src\// {print $2}'
+        )
         h=$(git ls-files -s -- \
+              .gitmodules \
               scripts/third_party \
               third_party/manifest.yml \
               third_party/patches \
               third_party/system-packages.ubuntu2404.txt \
-              third_party/src/brpc third_party/src/braft \
-              third_party/src/mimalloc third_party/src/rocksdb-cloud \
+              "${submodule_paths[@]}" \
             | sha256sum | cut -c1-16)
         echo "key=tp-${{ inputs.arch }}-${{ inputs.cache-scope }}-${h}" >> "$GITHUB_OUTPUT"
 

--- a/.github/actions/setup-third-party/action.yml
+++ b/.github/actions/setup-third-party/action.yml
@@ -33,22 +33,19 @@ runs:
       shell: bash
       run: |
         git config --global --add safe.directory '*'
-        # Discover retained third-party submodules from .gitmodules so their
-        # gitlinks are the sole version pins and new ones cannot be omitted from
-        # the cache key. ls-files -s emits the gitlink SHA without initializing
-        # the submodules.
-        mapfile -t submodule_paths < <(
-          git config -f .gitmodules --get-regexp '^submodule\..*\.path$' \
-            | awk '$2 ~ /^third_party\/src\// {print $2}'
-        )
-        h=$(git ls-files -s -- \
-              .gitmodules \
-              scripts/third_party \
-              third_party/manifest.yml \
-              third_party/patches \
-              third_party/system-packages.ubuntu2404.txt \
-              "${submodule_paths[@]}" \
-            | sha256sum | cut -c1-16)
+        # Mode 160000 entries are gitlinks. Hash them directly from the index,
+        # without initializing submodules or duplicating their commits in the
+        # dependency manifest.
+        h=$({
+              git ls-files -s -- \
+                .gitmodules \
+                scripts/third_party \
+                third_party/manifest.yml \
+                third_party/patches \
+                third_party/system-packages.ubuntu2404.txt
+              git ls-files -s -- third_party/src \
+                | awk '$1 == "160000"'
+            } | sha256sum | cut -c1-16)
         echo "key=tp-${{ inputs.arch }}-${{ inputs.cache-scope }}-${h}" >> "$GITHUB_OUTPUT"
 
     - name: Restore third-party cache

--- a/third_party/README.md
+++ b/third_party/README.md
@@ -4,7 +4,10 @@
 
 Layout:
 
-- `manifest.yml` records every source-managed dependency, its repo, ref, pinned commit, source mode, patches, and consumers.
+- `manifest.yml` records non-submodule source-managed dependencies, their repos,
+  refs, commits, source modes, patches, and consumers.
+- `.gitmodules` records retained third-party submodule repositories, and each
+  gitlink is the sole version pin.
 - `system-packages.ubuntu2404.txt` records apt packages that remain system prerequisites.
 - `src/` contains transient upstream source archives and the retained Eloq fork submodules.
 - `install/` contains locally installed headers, libraries, and CMake package config files.
@@ -31,7 +34,9 @@ Policy:
 - Keep official upstream dependencies out of `.gitmodules` when they are only pinned to a tag or commit.
 - Keep small local source changes as patches under `patches/` unless the dependency needs an active Eloq fork.
 - Retained third-party submodules are limited to Eloq-maintained forks that still need independent Git history.
-- Update `manifest.yml` in the same commit that changes a dependency ref, patch, or retained submodule pointer.
+- Do not duplicate retained submodules in `manifest.yml`; discover their
+  repositories from `.gitmodules` and their versions from gitlinks.
+- Update `manifest.yml` when dependency metadata or patches change.
 - Upstream archive sources are removed after successful local installation unless `ELOQ_THIRD_PARTY_KEEP_SOURCES=1` is set.
 - Builder image `latest` must be rebuilt when dependencies or build scripts change.
 - Normal CI must not initialize `third_party/src`.

--- a/third_party/manifest.yml
+++ b/third_party/manifest.yml
@@ -44,7 +44,7 @@ dependencies:
   - name: brpc
     repo: https://github.com/eloqdata/brpc.git
     ref: feature/eventfd-worker-wakeup
-    commit: df50efb984ba2b852b7b0aeab9b0f6eb4f2c31b7
+    commit: a192af98010f873f669652aa5d07c31ceee19521
     kind: eloq-fork
     source: git_submodule
     consumers: [data_substrate, eloqkv, log_service]

--- a/third_party/manifest.yml
+++ b/third_party/manifest.yml
@@ -5,7 +5,6 @@ install_prefix: third_party/install
 policy:
   source_management: hybrid
   upstream_source_management: archive_or_pinned_git
-  retained_submodules: [brpc, braft, mimalloc, rocksdb-cloud]
   cleanup_source_after_build: true
   install_scope: repository_local
   ci_install_prefix: /opt/eloq/third_party
@@ -41,27 +40,6 @@ dependencies:
     kind: upstream
     source: archive
     consumers: [brpc, eloqstore]
-  - name: brpc
-    repo: https://github.com/eloqdata/brpc.git
-    ref: master
-    commit: c12822d4931a59a9c2cc42df061975e114e93590
-    kind: eloq-fork
-    source: git_submodule
-    consumers: [data_substrate, eloqkv, log_service]
-  - name: braft
-    repo: https://github.com/eloqdata/braft.git
-    ref: pinned-head-2026-06-04
-    commit: b24534029f23bcffc256914fe0638615652cc183
-    kind: eloq-fork
-    source: git_submodule
-    consumers: [log_service, host_manager]
-  - name: mimalloc
-    repo: https://github.com/eloqdata/mimalloc.git
-    ref: eloq-v2.1.2
-    commit: f58bb7633640b30d02078d05fd35cb6566275bd5
-    kind: eloq-fork
-    source: git_submodule
-    consumers: [data_substrate, tx_service]
   - name: cuckoofilter
     repo: https://github.com/efficient/cuckoofilter.git
     ref: upstream-base-917583d
@@ -153,13 +131,6 @@ dependencies:
     kind: upstream
     source: archive
     consumers: [unit-tests]
-  - name: rocksdb-cloud
-    repo: https://github.com/eloqdata/rocksdb-cloud.git
-    ref: main-pinned-2026-06-04
-    commit: b815dc3ebac93f4b3ccb6f1ed8189fe49a132810
-    kind: eloq-fork
-    source: git_submodule
-    consumers: [rocksdb-cloud-s3, rocksdb-cloud-gcs]
   - name: usearch
     repo: https://github.com/unum-cloud/usearch.git
     ref: v2.21.0

--- a/third_party/manifest.yml
+++ b/third_party/manifest.yml
@@ -43,8 +43,8 @@ dependencies:
     consumers: [brpc, eloqstore]
   - name: brpc
     repo: https://github.com/eloqdata/brpc.git
-    ref: feature/eventfd-worker-wakeup
-    commit: a192af98010f873f669652aa5d07c31ceee19521
+    ref: master
+    commit: c12822d4931a59a9c2cc42df061975e114e93590
     kind: eloq-fork
     source: git_submodule
     consumers: [data_substrate, eloqkv, log_service]

--- a/third_party/manifest.yml
+++ b/third_party/manifest.yml
@@ -43,8 +43,8 @@ dependencies:
     consumers: [brpc, eloqstore]
   - name: brpc
     repo: https://github.com/eloqdata/brpc.git
-    ref: pinned-head-2026-06-04
-    commit: 3f74e38192da5ff3059ce060cb9966491da8df8d
+    ref: feature/eventfd-worker-wakeup
+    commit: df50efb984ba2b852b7b0aeab9b0f6eb4f2c31b7
     kind: eloq-fork
     source: git_submodule
     consumers: [data_substrate, eloqkv, log_service]


### PR DESCRIPTION
## Context

Consume the eventfd worker-wakeup support merged in [eloqdata/brpc#25](https://github.com/eloqdata/brpc/pull/25) and run it through Data Substrate's CI matrices.

## Changes

- Advance `third_party/src/brpc` to `c12822d4931a59a9c2cc42df061975e114e93590` on brpc `master`.
- Remove retained submodules from `third_party/manifest.yml`; `.gitmodules` and
  gitlinks are now their repository and version sources of truth.
- Scan indexed `third_party/src` entries for mode `160000` and include those
  gitlink SHAs in the CI third-party cache key.

There is no Data Substrate API, transaction, durability, recovery, or data-format change.

## Validation

```text
git diff --check origin/main...HEAD
PASS
```

The full build and test matrix is running in this PR's CI. Parent integration runs in EloqKV #554 and EloqDoc #487.

## Risk and rollback

Risk is limited to brpc worker idle waiting and shutdown when io_uring is enabled. Non-io_uring processes retain the condition-variable path. Revert this PR to restore the previous brpc gitlink and manifest pin.

## Reviewer guide

Verify `third_party/src/brpc` at brpc `master` commit `c12822d4931a59a9c2cc42df061975e114e93590`, and review `.github/actions/setup-third-party/action.yml` for mode-`160000` gitlink hashing. Functional review is in the merged brpc PR #25.
