### PR TITLE
fix: queue a write-intent holder's lock upgrade at the head

### DIFF
--- a/docs/03-concurrency-control.md
+++ b/docs/03-concurrency-control.md
@@ -230,6 +230,19 @@ WL**. A read lock is also refused when a write lock sits at the head of the bloc
 requests (read-committed pk reads waiting for a newer pk version after an sk read) go to the
 *front* of the queue since they conflict with nothing.
 
+Queue placement is FIFO (`blocking_queue_.Enqueue`) with one exception: a **WriteLock request
+from the tx that already holds this entry's WriteIntent** — a lock upgrade — is inserted at the
+*front* instead. Everything else queued on the entry conflicts with that WriteIntent and cannot
+be granted until the upgrading tx finishes and releases it, so appending the upgrade behind them
+deadlocks the entry (`TryPopBlockingQueue` stops at the first head it cannot grant and never
+reaches the upgrade). Head placement is not an early grant: the upgrade is still gated on
+`NoReadLockConflict` and waits for outstanding read locks to drain. It also closes the reader
+admission gate above, which only admits new readers while the head is a WriteIntent — without
+that, arriving readers keep `NoReadLockConflict` false and starve the upgrade. Since WriteIntent
+is mutually exclusive among writers, at most one such upgrade exists per entry, and leading
+`ReadLock` entries are always drained by `TryPopBlockingQueue` before an intent holder can
+request the upgrade, so the head is never a read request at insertion time.
+
 Behavior on conflict by protocol (`AcquireLock`, `cc_protocol.h`):
 
 | Requested | OCC | OccRead | Locking |

--- a/tx_service/include/cc/non_blocking_lock.h
+++ b/tx_service/include/cc/non_blocking_lock.h
@@ -361,11 +361,11 @@ private:
     // path.
     int read_cnt_{};
 
-    WriteLockType write_lk_type_;
+    WriteLockType write_lk_type_{WriteLockType::NoWritelock};
     TxNumber write_txn_{0};
 
     // The time when a write tx acquires the write lock on this lock.
-    uint64_t wlock_ts_;
+    uint64_t wlock_ts_{0};
 
     // blocking_queue_ stores the requests that 1) want to acquire
     // lock/intent but failed due to conflict, or 2) want to read a pk

--- a/tx_service/src/cc/non_blocking_lock.cpp
+++ b/tx_service/src/cc/non_blocking_lock.cpp
@@ -245,9 +245,32 @@ bool NonBlockingLock::AcquireWriteLock(CcRequestBase *cc_req,
         // lock fails.
         if (protocol == CcProtocol::Locking || protocol == CcProtocol::OccRead)
         {
-            // block the request by putting it into the blocking queue.
-            blocking_queue_.Enqueue(
-                LockQueueEntry(cc_req, LockType::WriteLock));
+            if (write_lk_type_ == WriteLockType::WriteIntent &&
+                write_txn_ == tx_number)
+            {
+                // This tx already holds the write intent and is upgrading it
+                // to the write lock. Every other request queued on this entry
+                // conflicts with that write intent, so none of them can be
+                // granted until this tx finishes and releases it. Appending
+                // the upgrade behind them would therefore deadlock the entry:
+                // TryPopBlockingQueue() stops at the first queue head it
+                // cannot grant and never reaches the upgrade.
+                //
+                // Putting it at the head is not an early grant - it is still
+                // gated on NoReadLockConflict() and keeps waiting for the
+                // outstanding read locks to drain. It also closes the reader
+                // admission gate in AcquireReadLock(Fast), which only lets new
+                // readers in while the queue head is a WriteIntent; without
+                // that a stream of readers can keep NoReadLockConflict() false
+                // forever and starve the upgrade.
+                InsertBlockingQueue(cc_req, LockType::WriteLock);
+            }
+            else
+            {
+                // block the request by putting it into the blocking queue.
+                blocking_queue_.Enqueue(
+                    LockQueueEntry(cc_req, LockType::WriteLock));
+            }
         }
         // OCC doesn't enqueue request.
         return false;

--- a/tx_service/tests/CMakeLists.txt
+++ b/tx_service/tests/CMakeLists.txt
@@ -62,6 +62,7 @@ set(CATCH_MAIN_TESTS
     CcPage-Test
     LargeObjLRU-Test
     CcRequestWait-Test
+    NonBlockingLock-Test
     StandbyForward-Test
     ApplyResponseBoundary-Test
 )

--- a/tx_service/tests/NonBlockingLock-Test.cpp
+++ b/tx_service/tests/NonBlockingLock-Test.cpp
@@ -47,21 +47,6 @@ struct StubCcRequest : public txservice::CcRequestBase
     }
 };
 
-/**
- * @brief NonBlockingLock's default constructor leaves write_lk_type_ and
- * wlock_ts_ indeterminate; production only ever reaches a lock through
- * KeyGapLockAndExtraData::Reset(), which resets the embedded lock. Tests that
- * construct one directly must do the same to be deterministic.
- */
-struct FreshLock
-{
-    FreshLock()
-    {
-        lock.Reset();
-    }
-
-    txservice::NonBlockingLock lock;
-};
 }  // namespace
 
 using txservice::CcProtocol;
@@ -78,8 +63,7 @@ TEST_CASE("write intent holder's upgrade is queued at the head",
     constexpr txservice::TxNumber kOtherWriter = 1002;
     constexpr txservice::TxNumber kReader = 2001;
 
-    FreshLock fresh;
-    NonBlockingLock &lock = fresh.lock;
+    NonBlockingLock lock;
     StubCcRequest holder_intent{kHolder};
     StubCcRequest other_intent{kOtherWriter};
     StubCcRequest holder_upgrade{kHolder};
@@ -111,8 +95,7 @@ TEST_CASE("upgrade still waits for outstanding read locks", "[NonBlockingLock]")
     constexpr txservice::TxNumber kHolder = 1001;
     constexpr txservice::TxNumber kReader = 2001;
 
-    FreshLock fresh;
-    NonBlockingLock &lock = fresh.lock;
+    NonBlockingLock lock;
     StubCcRequest holder_intent{kHolder};
     StubCcRequest holder_upgrade{kHolder};
 
@@ -125,8 +108,7 @@ TEST_CASE("upgrade still waits for outstanding read locks", "[NonBlockingLock]")
 
     // With no reader in the way the same upgrade succeeds outright, which is
     // the state TryPopBlockingQueue() reaches once the reader releases.
-    FreshLock fresh2;
-    NonBlockingLock &unblocked = fresh2.lock;
+    NonBlockingLock unblocked;
     StubCcRequest intent2{kHolder};
     StubCcRequest upgrade2{kHolder};
     REQUIRE(unblocked.AcquireWriteIntent(&intent2, CcProtocol::Locking));
@@ -141,8 +123,7 @@ TEST_CASE("a write lock request from a non-holder still queues FIFO",
     constexpr txservice::TxNumber kQueuedFirst = 1002;
     constexpr txservice::TxNumber kQueuedSecond = 1003;
 
-    FreshLock fresh;
-    NonBlockingLock &lock = fresh.lock;
+    NonBlockingLock lock;
     StubCcRequest holder_intent{kHolder};
     StubCcRequest first_intent{kQueuedFirst};
     StubCcRequest second_write{kQueuedSecond};

--- a/tx_service/tests/NonBlockingLock-Test.cpp
+++ b/tx_service/tests/NonBlockingLock-Test.cpp
@@ -1,0 +1,158 @@
+/**
+ *    Copyright (C) 2025 EloqData Inc.
+ *
+ *    This program is free software: you can redistribute it and/or  modify
+ *    it under either of the following two licenses:
+ *    1. GNU Affero General Public License, version 3, as published by the Free
+ *    Software Foundation.
+ *    2. GNU General Public License as published by the Free Software
+ *    Foundation; version 2 of the License.
+ *
+ *    This program is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU Affero General Public License or GNU General Public License for more
+ *    details.
+ *
+ *    You should have received a copy of the GNU Affero General Public License
+ *    and GNU General Public License V2 along with this program.  If not, see
+ *    <http://www.gnu.org/licenses/>.
+ *
+ */
+// Let Catch provide main():
+#include <catch2/catch_all.hpp>
+
+#include "cc/cc_req_base.h"
+#include "cc/non_blocking_lock.h"
+#include "cc_protocol.h"
+
+namespace
+{
+/**
+ * @brief Minimal CcRequestBase with a settable tx number. NonBlockingLock only
+ * reads Txn() off the queued requests, so Execute() is never reached.
+ */
+struct StubCcRequest : public txservice::CcRequestBase
+{
+    explicit StubCcRequest(txservice::TxNumber txn)
+    {
+        tx_number_ = txn;
+        proto_ = txservice::CcProtocol::Locking;
+        isolation_level_ = txservice::IsolationLevel::RepeatableRead;
+    }
+
+    bool Execute(txservice::CcShard &) override
+    {
+        return false;
+    }
+};
+
+/**
+ * @brief NonBlockingLock's default constructor leaves write_lk_type_ and
+ * wlock_ts_ indeterminate; production only ever reaches a lock through
+ * KeyGapLockAndExtraData::Reset(), which resets the embedded lock. Tests that
+ * construct one directly must do the same to be deterministic.
+ */
+struct FreshLock
+{
+    FreshLock()
+    {
+        lock.Reset();
+    }
+
+    txservice::NonBlockingLock lock;
+};
+}  // namespace
+
+using txservice::CcProtocol;
+using txservice::NonBlockingLock;
+
+TEST_CASE("write intent holder's upgrade is queued at the head",
+          "[NonBlockingLock]")
+{
+    // The holder of a WriteIntent cannot be satisfied by waiting behind other
+    // requests on the same entry: they all conflict with the intent it still
+    // holds, so none of them can be granted until it finishes and releases.
+    // Its WriteIntent -> WriteLock upgrade must therefore jump the queue.
+    constexpr txservice::TxNumber kHolder = 1001;
+    constexpr txservice::TxNumber kOtherWriter = 1002;
+    constexpr txservice::TxNumber kReader = 2001;
+
+    FreshLock fresh;
+    NonBlockingLock &lock = fresh.lock;
+    StubCcRequest holder_intent{kHolder};
+    StubCcRequest other_intent{kOtherWriter};
+    StubCcRequest holder_upgrade{kHolder};
+
+    REQUIRE(lock.AcquireWriteIntent(&holder_intent, CcProtocol::Locking));
+
+    // A read lock coexists with a write intent, and is what will keep the
+    // upgrade from being granted outright.
+    REQUIRE(lock.AcquireReadLockFast(kReader));
+
+    // A second writer conflicts with the held intent and queues.
+    REQUIRE_FALSE(lock.AcquireWriteIntent(&other_intent, CcProtocol::Locking));
+
+    // The holder now upgrades. It is blocked by the outstanding read lock, so
+    // it queues -- but ahead of the other writer, not behind it.
+    REQUIRE_FALSE(lock.AcquireWriteLock(&holder_upgrade, CcProtocol::Locking));
+
+    std::vector<txservice::TxNumber> queued = lock.GetBlockTxIds(0);
+    REQUIRE(queued.size() == 2);
+    REQUIRE(queued[0] == kHolder);       // upgrade at the head
+    REQUIRE(queued[1] == kOtherWriter);  // the earlier request behind it
+}
+
+TEST_CASE("upgrade still waits for outstanding read locks", "[NonBlockingLock]")
+{
+    // Head placement must not turn into an early grant: while a read lock is
+    // outstanding the upgrade stays queued, and it is only grantable once the
+    // reader is gone.
+    constexpr txservice::TxNumber kHolder = 1001;
+    constexpr txservice::TxNumber kReader = 2001;
+
+    FreshLock fresh;
+    NonBlockingLock &lock = fresh.lock;
+    StubCcRequest holder_intent{kHolder};
+    StubCcRequest holder_upgrade{kHolder};
+
+    REQUIRE(lock.AcquireWriteIntent(&holder_intent, CcProtocol::Locking));
+    REQUIRE(lock.AcquireReadLockFast(kReader));
+
+    // Blocked by the read lock, not granted.
+    REQUIRE_FALSE(lock.AcquireWriteLock(&holder_upgrade, CcProtocol::Locking));
+    REQUIRE(lock.FindQueueRequest(kHolder));
+
+    // With no reader in the way the same upgrade succeeds outright, which is
+    // the state TryPopBlockingQueue() reaches once the reader releases.
+    FreshLock fresh2;
+    NonBlockingLock &unblocked = fresh2.lock;
+    StubCcRequest intent2{kHolder};
+    StubCcRequest upgrade2{kHolder};
+    REQUIRE(unblocked.AcquireWriteIntent(&intent2, CcProtocol::Locking));
+    REQUIRE(unblocked.AcquireWriteLock(&upgrade2, CcProtocol::Locking));
+}
+
+TEST_CASE("a write lock request from a non-holder still queues FIFO",
+          "[NonBlockingLock]")
+{
+    // Regression guard: only the intent holder's own upgrade jumps the queue.
+    constexpr txservice::TxNumber kHolder = 1001;
+    constexpr txservice::TxNumber kQueuedFirst = 1002;
+    constexpr txservice::TxNumber kQueuedSecond = 1003;
+
+    FreshLock fresh;
+    NonBlockingLock &lock = fresh.lock;
+    StubCcRequest holder_intent{kHolder};
+    StubCcRequest first_intent{kQueuedFirst};
+    StubCcRequest second_write{kQueuedSecond};
+
+    REQUIRE(lock.AcquireWriteIntent(&holder_intent, CcProtocol::Locking));
+    REQUIRE_FALSE(lock.AcquireWriteIntent(&first_intent, CcProtocol::Locking));
+    REQUIRE_FALSE(lock.AcquireWriteLock(&second_write, CcProtocol::Locking));
+
+    std::vector<txservice::TxNumber> queued = lock.GetBlockTxIds(0);
+    REQUIRE(queued.size() == 2);
+    REQUIRE(queued[0] == kQueuedFirst);
+    REQUIRE(queued[1] == kQueuedSecond);
+}


### PR DESCRIPTION
## Context

Fixes eloqdata/tx_service#541.

A transaction that holds an entry's `WriteIntent` and then requests the `WriteLock` upgrade had its request appended to the tail of `NonBlockingLock::blocking_queue_` like any other request. Everything else queued on that entry conflicts with the intent it still holds, so none of those can be granted until it finishes and releases — appending the upgrade behind them deadlocks the entry, because `TryPopBlockingQueue()` stops at the first head it cannot grant and never reaches the upgrade.

Found on a locally built 3-node-group EloqDoc cluster running a concurrent DDL fuzz workload (12 workers issuing `createIndexes`/`dropIndexes` across 50 collections). The cluster stalled permanently ~22 seconds after the workload started. Live inspection of the wedged node showed:

```
LOCK@0x…fa00  write_lk_type_=WriteIntent  write_txn_=134011
              read_intentions_=0  read_locks_=0  read_cnt_=0
  blocking_queue_ (head → tail):
    q[0]  WriteIntent  ReadCc        txn=134031
    q[1]  WriteLock    AcquireAllCc  txn=134011   ← the holder's own upgrade

AcquireAllOp: upload_cnt_=3  finish_cnt_=2  fail_cnt_=0
  ng 0 (local): is_finished_=false  ref_cnt_=1     ← never completes
  ng 1 / ng 2:  is_finished_=true
```

`134031` waited for `134011` to release the intent; `134011` waited behind `134031` to upgrade. Twelve further `UpsertTableIndexOp` transactions piled up behind them, and every later `createIndexes` — on any collection in any database — joined the same queue.

## Behavior before and after

**Before:** a `WriteLock` request from the entry's `WriteIntent` holder is queued FIFO. If any conflicting request was queued first, the upgrade is unreachable and the entry deadlocks permanently. Separately, because both read-acquire paths admit new readers whenever `blocking_queue_.Peek().lk_type_ == WriteIntent`, an upgrade buried behind another transaction's `WriteIntent` leaves the reader gate open, so arriving readers can keep `NoReadLockConflict` false and starve it even without a deadlock.

**After:** such an upgrade is inserted at the head. It is still gated on `NoWriteConflict && NoReadLockConflict`, so it keeps waiting for outstanding read locks to drain — this is not an early grant. At the head it also closes the reader-admission gate, which is what allows the read locks to actually drain.

No change for any other request: non-holder `WriteLock` requests, `WriteIntent` requests and `ReadLock` requests all still queue FIFO. No API or on-disk format change.

## Implementation

One branch in `NonBlockingLock::AcquireWriteLock`'s failure path. When `write_lk_type_ == WriteIntent && write_txn_ == cc_req->Txn()`, route the request through the existing `InsertBlockingQueue()` (i.e. `CircularQueue::EnqueueAsFirst`) instead of `blocking_queue_.Enqueue()`.

The second commit fixes an unrelated defect found while writing the test: `write_lk_type_` and `wlock_ts_` had no default member initializer while `read_cnt_` and `write_txn_` did, so a directly-constructed `NonBlockingLock` started with indeterminate write-lock state. Production never hit this because locks come from `CcShard::lock_vec_` and always pass through `KeyGapLockAndExtraData::Reset()`.

## Design decisions and alternatives

**Why the head, and not "ahead of other write requests only".** These denote the same position, so the simpler rule wins. Leading `ReadLock` entries cannot be present when the upgrade is enqueued: every transition that makes a queued read grantable ends in `TryPopBlockingQueue()`, whose `ReadLock` branch tests `NoWriteLockConflict` — true while an intent is held — so leading reads are drained synchronously (`DowngradeWriteLock` L454, `ReleaseWriteIntent` L473, `ReleaseReadLockFast` L283, `ClearTx` L581). A `ReadLock` can still sit *behind* a conflicting write request, which does not affect the insertion point.

**Why head placement cannot starve readers.** A held `WriteIntent` never blocks readers (`NoWriteLockConflict` is false only for `WriteLock`), so readers flow freely right up until the upgrade reaches the head. From there they are blocked only until the currently-held read locks drain and the holder releases — a bounded window, and a necessary one, since otherwise the upgrade can never satisfy `NoReadLockConflict`. Because `WriteIntent` is mutually exclusive among writers, at most one such upgrade exists per entry, so the head cannot be monopolised.

**Why not grant the upgrade immediately.** `WriteLock` conflicts with read locks; the upgrade must wait for them. Head placement changes where it waits, not whether it waits.

**Rejected: taking the write lock up front so no upgrade is needed.** DML can escalate to a catalog write (an insert that first makes an index multikey rewrites the table metadata via `MongoTableSchema::IndexesSetMultiKeyAttr`), so a transaction cannot know at start whether it will write the catalog. Pessimistically taking `WriteIntent` for every DML would serialize all concurrent writers on a collection.

## Test plan

- [x] Unit/CTest coverage — new `tx_service/tests/NonBlockingLock-Test.cpp`, registered in `CATCH_MAIN_TESTS`
- [ ] Parent-project integration or manual validation — **not run**; see Follow-up
- [x] Formatting/build checks — `clang-format-18 --dry-run --Werror` clean on all changed C++ files
- [x] Recovery, compatibility, or performance validation, when relevant — n/a, no format or protocol change
- [x] Documentation updated — `docs/03-concurrency-control.md` §5

Three cases: the holder's upgrade lands at the head ahead of an earlier-queued writer; the upgrade still blocks while a read lock is outstanding, and is granted outright when none is; a `WriteLock` request from a non-holder still queues FIFO.

Commands and results:

```text
$ cmake -S . -B bld -DWITH_TESTS=ON -DWITH_DATA_STORE=ELOQDSS_ROCKSDB -DWITH_LOG_STATE=ROCKSDB \
        -DCMAKE_PREFIX_PATH=<third_party_install> -DCMAKE_BUILD_TYPE=RelWithDebInfo
-- Configuring done / Generating done

$ cmake --build bld --target NonBlockingLock-Test -j6      # exit 0
   (note: LD_LIBRARY_PATH must point at the third-party libs, otherwise
    catch_discover_tests fails to run the binary at build time)

$ ./bld/tx_service/tests/NonBlockingLock-Test
All tests passed (19 assertions in 3 test cases)

$ for i in 1..10; do ./NonBlockingLock-Test --rng-seed $((i*7919)); done
10/10 passed

Full Catch2 suite, rebuilt and run on this branch:
  NonBlockingLock-Test         All tests passed (19 assertions in 3 test cases)
  CcEntry-Test                 All tests passed (186 assertions in 5 test cases)
  CcPage-Test                  All tests passed (41 assertions in 1 test case)
  LargeObjLRU-Test             All tests passed (3679 assertions in 23 test cases)
  CcRequestWait-Test           All tests passed (2008 assertions in 4 test cases)
  StandbyForward-Test          All tests passed (6 assertions in 2 test cases)
  ApplyResponseBoundary-Test   All tests passed (25 assertions in 5 test cases)

$ clang-format-18 --dry-run --Werror \
    tx_service/src/cc/non_blocking_lock.cpp \
    tx_service/include/cc/non_blocking_lock.h \
    tx_service/tests/NonBlockingLock-Test.cpp
(clean)
```

**Not run:** the DDL fuzz workload has not been re-run against a cluster built from this branch, so the end-to-end fix is argued from the lock-state analysis above rather than demonstrated. The cluster used for the investigation has been shut down.

## Risk assessment

Concurrency-sensitive but narrowly scoped: the new branch is reachable only when the requesting transaction already holds the entry's `WriteIntent`, and `WriteIntent` is exclusive among writers, so at most one request per entry can take it. All other queueing is byte-for-byte unchanged.

The main behavioral risk is reader latency: while an upgrade sits at the head, new readers on that entry queue instead of proceeding. This is bounded (see above) and is the intended writer-preference semantics the existing `Peek()`-based gate was already written for — the gate simply was not being reached.

No durability, recovery, format or wire-compatibility impact.

## Rollback plan

Revert this PR. The change is two commits touching one function, one header line pair, one test file and one doc section, with no persisted state.

## Reviewer guide

- `tx_service/src/cc/non_blocking_lock.cpp` — `AcquireWriteLock()`, the new branch in the failure path. This is the whole fix.
- `tx_service/src/cc/non_blocking_lock.cpp` — `TryPopBlockingQueue()` (unchanged) is the function that made the old behavior fatal; worth reading alongside.
- Invariant to check: `WriteIntent` is mutually exclusive among writers, so at most one self-upgrade request can exist per entry and there is no contest for the head slot.
- `tx_service/tests/NonBlockingLock-Test.cpp` — the third case is the regression guard that non-holder requests still queue FIFO.

## Follow-up work

- The **mutual-upgrade** shape is not addressed and cannot be fixed by any queue policy: A holds a `ReadLock` and requests `WriteIntent` while B holds `WriteIntent` and requests `WriteLock`. B's upgrade fails `NoReadLockConflict` because of A's read lock, and A cannot release it while queued. `AcquireWriteIntent` never inspects read locks, so both can legitimately hold at once, and this is reachable from `createIndexes` (which resolves the collection under `MODE_IX` first, mapping to a catalog read lock, then escalates within the same command-level transaction). Resolving it requires aborting a participant — see eloqdata/tx_service#542, which reports that deadlock detection stops running once the system quiesces.
- Re-running the DDL fuzz workload against a cluster built from this branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved write-lock upgrades so transactions holding a write intent are prioritized correctly while remaining blocked by active readers.
  * Preserved FIFO ordering for other lock requests.

* **Documentation**
  * Clarified lock-queue behavior, reader admission, and starvation prevention during write-lock upgrades.

* **Tests**
  * Added regression coverage for upgrade ordering, reader blocking, successful unblocking, and standard request ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->