### PR TITLE
chore: simplify payload ownership updates

### DIFF
--- a/tx_service/include/cc/cc_entry.h
+++ b/tx_service/include/cc/cc_entry.h
@@ -814,14 +814,7 @@ struct VersionedPayload
 
     void PassInCurrentPayload(std::unique_ptr<TxRecord> payload)
     {
-        if (payload == nullptr)
-        {
-            cur_payload_ = nullptr;
-        }
-        else
-        {
-            cur_payload_.reset(static_cast<ValueT *>(payload.release()));
-        }
+        cur_payload_.reset(static_cast<ValueT *>(payload.release()));
     }
 
     void DeserializeCurrentPayload(const char *data, size_t &offset)
@@ -883,22 +876,11 @@ struct NonVersionedPayload
 
     void PassInCurrentPayload(std::unique_ptr<TxRecord> payload)
     {
-        if (payload == nullptr)
-        {
-            cur_payload_ = nullptr;
-        }
-        else
-        {
-            cur_payload_.reset(static_cast<ValueT *>(payload.release()));
-        }
+        cur_payload_.reset(static_cast<ValueT *>(payload.release()));
     }
 
     void DeserializeCurrentPayload(const char *data, size_t &offset)
     {
-        if (cur_payload_ == nullptr)
-        {
-            cur_payload_ = std::make_unique<ValueT>();
-        }
         ValueT tx_obj;
         cur_payload_.reset(static_cast<ValueT *>(
             tx_obj.DeserializeObject(data, offset).release()));


### PR DESCRIPTION
## Context

`VersionedPayload` and `NonVersionedPayload` handled null incoming payloads with explicit branches even though `release()` plus `reset()` already provides the same ownership semantics. `NonVersionedPayload::DeserializeCurrentPayload()` also allocated a default payload that was immediately replaced by the deserialized object.

## Behavior before and after

There is no intended observable behavior change. Passing a null payload still clears the current payload, passing a non-null payload still transfers ownership, and deserialization still replaces the current payload with the decoded object.

## Implementation

- Use `release()` and `reset()` directly in both `PassInCurrentPayload()` implementations.
- Remove the immediately discarded allocation from `NonVersionedPayload::DeserializeCurrentPayload()`.

## Design decisions and alternatives

The change preserves the existing type conversion and ownership flow while removing redundant control flow and allocation. No public API or serialized format changes.

## Test plan

- [ ] Unit/CTest coverage
- [ ] Parent-project integration or manual validation
- [ ] Formatting/build checks
- [ ] Recovery, compatibility, or performance validation, when relevant
- [ ] Documentation updated, when behavior changed

Commands and results:

```text
Not run at the request of the author.
```

## Risk assessment

Low. The null and non-null ownership outcomes are unchanged. The only removed runtime work is an unused default allocation before deserialization.

## Rollback plan

Revert commit `617a2f7`.

## Reviewer guide

Review the `VersionedPayload::PassInCurrentPayload()`, `NonVersionedPayload::PassInCurrentPayload()`, and `NonVersionedPayload::DeserializeCurrentPayload()` changes in `tx_service/include/cc/cc_entry.h`.

## Follow-up work

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved payload replacement and deserialization consistency.
  * Ensured current payloads are refreshed from released or deserialized data without relying on existing payload state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->