### PR TITLE
fix: calibrate txservice scheduler TSC frequency with Abseil

### DIFF
--- a/store_handler/eloq_data_store_service/build_eloq_store.cmake
+++ b/store_handler/eloq_data_store_service/build_eloq_store.cmake
@@ -132,7 +132,7 @@ set(ELOQ_STORE_SOURCES
 add_library(eloqstore STATIC ${ELOQ_STORE_SOURCES})
 
 target_include_directories(eloqstore PUBLIC ${ELOQ_STORE_INCLUDE})
-target_link_libraries(eloqstore PRIVATE ${URING_LIB} ${BOOST_CONTEXT_TARGET} glog::glog jsoncpp_lib ${CURL_LIBRARIES} ${ZSTD_LIBRARY} ${AWSSDK_LINK_LIBRARIES}
+target_link_libraries(eloqstore PRIVATE ${URING_LIB} ${BOOST_CONTEXT_TARGET} glog::glog jsoncpp_lib ${CURL_LIBRARIES} ${ZSTD_LIBRARY} ${AWSSDK_LINK_LIBRARIES} absl::base
     PUBLIC absl::flat_hash_map
 )
 

--- a/tx_service/CMakeLists.txt
+++ b/tx_service/CMakeLists.txt
@@ -73,6 +73,7 @@ eloq_assert_target_under_prefix(absl::flat_hash_map "Abseil flat_hash_map")
 eloq_assert_target_under_prefix(absl::span "Abseil span")
 
 set(ABSEIL
+    absl::base
     absl::btree
     absl::flat_hash_map
     absl::span

--- a/tx_service/include/util.h
+++ b/tx_service/include/util.h
@@ -25,6 +25,7 @@
 #include <jemalloc/jemalloc.h>
 #endif
 
+#include <algorithm>
 #include <atomic>
 #include <chrono>
 #include <fstream>
@@ -33,10 +34,10 @@
 #include <sstream>
 #include <string>
 #include <string_view>
-#include <thread>
 #include <vector>
 
 #if defined(__x86_64__) || defined(_M_X64)
+#include <absl/base/internal/sysinfo.h>
 #include <x86intrin.h>  // For __rdtsc()
 #endif
 
@@ -476,16 +477,11 @@ static inline void GetJemallocArenaStat(uint32_t arena_id,
     allocated = small_allocated + large_allocated;
 }
 #endif
-// TSC frequency in cycles per microsecond (measured at initialization)
+// Hardware-counter frequency in cycles per microsecond.
 inline std::once_flag tsc_frequency_initialized_;
 inline std::atomic<uint64_t> tsc_cycles_per_microsecond_{0};
 
-/** @brief
- * Measure TSC frequency by sleeping for 1ms and measuring cycles.
- * Retries until stable (within 1% difference) or up to 16ms total.
- * Should be called once during data substrate initialization.
- * This function is thread-safe and will only execute once.
- */
+/** @brief Initialize the hardware-counter frequency once. */
 static void InitializeTscFrequency()
 {
 #if defined(__x86_64__) || defined(_M_X64)
@@ -493,72 +489,18 @@ static void InitializeTscFrequency()
         tsc_frequency_initialized_,
         []()
         {
-            constexpr uint64_t SLEEP_MICROSECONDS = 1000;       // 1ms
-            constexpr uint64_t MAX_TOTAL_MICROSECONDS = 16000;  // 16ms max
-            constexpr double STABILITY_THRESHOLD =
-                0.01;  // 1% difference for stability
-
-            uint64_t prev_freq = 0;
-            uint64_t total_slept = 0;
-            int stable_count = 0;
-            constexpr int REQUIRED_STABLE_COUNT =
-                2;  // Need 2 consecutive stable measurements
-
-            while (total_slept < MAX_TOTAL_MICROSECONDS)
-            {
-                uint64_t start_cycles = __rdtsc();
-                std::this_thread::sleep_for(
-                    std::chrono::microseconds(SLEEP_MICROSECONDS));
-                uint64_t end_cycles = __rdtsc();
-                uint64_t elapsed_cycles = end_cycles - start_cycles;
-                uint64_t freq = elapsed_cycles /
-                                SLEEP_MICROSECONDS;  // cycles per microsecond
-
-                total_slept += SLEEP_MICROSECONDS;
-
-                // Check if frequency is stable (within 1% of previous
-                // measurement)
-                if (prev_freq > 0)
-                {
-                    double diff_ratio =
-                        (freq > prev_freq)
-                            ? static_cast<double>(freq - prev_freq) / prev_freq
-                            : static_cast<double>(prev_freq - freq) / prev_freq;
-                    if (diff_ratio <= STABILITY_THRESHOLD)
-                    {
-                        stable_count++;
-                        if (stable_count >= REQUIRED_STABLE_COUNT)
-                        {
-                            // Frequency is stable, use the average
-                            tsc_cycles_per_microsecond_.store(
-                                (prev_freq + freq) / 2,
-                                std::memory_order_release);
-                            return;
-                        }
-                    }
-                    else
-                    {
-                        stable_count = 0;  // Reset stability counter
-                    }
-                }
-
-                prev_freq = freq;
-            }
-
-            // If we couldn't get stable measurement, use the last measured
-            // value
-            if (prev_freq > 0)
-            {
-                tsc_cycles_per_microsecond_.store(prev_freq,
-                                                  std::memory_order_release);
-            }
-            else
-            {
-                // Fallback to approximate value if measurement failed
-                tsc_cycles_per_microsecond_.store(2000,
-                                                  std::memory_order_release);
-            }
-        });  // End of lambda passed to std::call_once
+            // sleep_for() may oversleep when the initializing thread is
+            // descheduled. Dividing the elapsed TSC ticks by the requested
+            // sleep duration then overestimates the frequency and makes
+            // scheduler budgets run long. Abseil calibrates the raw TSC
+            // against the actual elapsed monotonic time instead.
+            const double frequency_hz =
+                absl::base_internal::NominalCPUFrequency();
+            const uint64_t cycles_per_microsecond = std::max<uint64_t>(
+                1, static_cast<uint64_t>(frequency_hz / 1'000'000.0));
+            tsc_cycles_per_microsecond_.store(cycles_per_microsecond,
+                                              std::memory_order_release);
+        });
 #elif defined(__aarch64__)
     std::call_once(tsc_frequency_initialized_,
                    []()

--- a/tx_service/include/util.h
+++ b/tx_service/include/util.h
@@ -489,11 +489,7 @@ static void InitializeTscFrequency()
         tsc_frequency_initialized_,
         []()
         {
-            // sleep_for() may oversleep when the initializing thread is
-            // descheduled. Dividing the elapsed TSC ticks by the requested
-            // sleep duration then overestimates the frequency and makes
-            // scheduler budgets run long. Abseil calibrates the raw TSC
-            // against the actual elapsed monotonic time instead.
+            // This frequency uses the same raw TSC scale as __rdtsc().
             const double frequency_hz =
                 absl::base_internal::NominalCPUFrequency();
             const uint64_t cycles_per_microsecond = std::max<uint64_t>(

--- a/tx_service/include/util.h
+++ b/tx_service/include/util.h
@@ -489,11 +489,9 @@ static void InitializeTscFrequency()
         tsc_frequency_initialized_,
         []()
         {
-            // sleep_for() may oversleep when the initializing thread is
-            // descheduled. Dividing the elapsed TSC ticks by the requested
-            // sleep duration then overestimates the frequency and makes
-            // scheduler budgets run long. Abseil calibrates the raw TSC
-            // against the actual elapsed monotonic time instead.
+            // Abseil calibrates the raw __rdtsc() counter against actual
+            // monotonic elapsed time. Dividing by a requested sleep duration
+            // would overestimate the frequency when the thread oversleeps.
             const double frequency_hz =
                 absl::base_internal::NominalCPUFrequency();
             const uint64_t cycles_per_microsecond = std::max<uint64_t>(


### PR DESCRIPTION
## Context

The x86 scheduler clock divides raw TSC ticks by a calibrated frequency. Its old calibration divided ticks by the requested `sleep_for(1000us)` duration, so scheduler oversleep systematically overestimated the frequency and made elapsed-time budgets run late. Repeated stable samples did not remove that bias.

## Behavior before and after

Data Substrate now uses Abseil's raw-TSC frequency, measured against actual monotonic elapsed time on Linux/x86. The existing integer cycles-per-microsecond representation and once-only atomic initialization remain; the x86 divisor is clamped to at least one. ARM continues to read `cntfrq_el0`, and the portable clock fallback is unchanged.

This PR now changes only the Data Substrate clock. EloqStore remains pinned to its current main commit `09a4227028cc0de58bd5e4af4e10577438ca5563`, retaining the brpc module compatibility fix. EloqStore's separate calibration fix, eloqdata/eloqstore#495, is still open and is not included or required by this revision.

## Implementation

- Replace the sleep-based x86 calibration in `tx_service/include/util.h` with `absl::base_internal::NominalCPUFrequency()` and explain the oversleep invariant beside it.
- Add the direct `absl::base` dependency to the standalone txservice target. The parent integration in `build_tx_service.cmake` already declares it.
- Rebase onto tx_service main `6474664`. There is no EloqStore gitlink or integration-CMake difference against main.

## Design decisions and alternatives

Abseil's unscaled x86 counter uses the same raw `rdtsc` scale as this clock; its scaled `CycleClock` frequency would not be interchangeable. This uses an internal Abseil API, so dependency upgrades must preserve that contract. No architecture claim changes: calibration is a local algorithm, documented next to the implementation.

## Test plan

- [x] ARM64 Debug parent-project build and link: `eloqkv` and `TestNodeSmoke-Test`.
- [x] TestNode write/read/delete round-trip: 1 CTest case, 25 assertions passed (in-memory test backend).
- [x] Temporary probe using the production `util.h`: 8 concurrent initial readers and 10 comparisons against `steady_clock` passed. On this ARM64 host the counter was 24 cycles/us and maximum observed relative error was 0.0000511791 (approximately 0.0051%). This checks the unchanged ARM path, not the new x86 implementation.
- [x] `clang-format-18` and complete merge-base diff whitespace checks.
- [ ] Local x86 runtime, standalone txservice build, full engine/Redis TCL/HA/recovery suites, sanitizers and performance benchmarks were not run. The new-head CI matrix remains required.

Validated EloqKV `c8d7825`, Data Substrate `24efe9f` (based on main `6474664`), and EloqStore `09a4227`, using the installed third-party prefix. The local temporary probe and command/log records are under `/tmp/eloq-tsc-review-20260911/`; the probe is not a committed test.

Commands run successfully:

```sh
export PATH=/opt/eloq/third_party/bin:$PATH
export LD_LIBRARY_PATH=/opt/eloq/third_party/lib:/opt/eloq/third_party/lib64
cmake -S /tmp/eloq-tsc-review-20260911/eloqkv \
  -B /tmp/eloq-tsc-review-20260911/build \
  -DCMAKE_BUILD_TYPE=Debug -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
  -DWITH_TESTS=ON -DBUILD_WITH_TESTS=OFF \
  -DWITH_DATA_STORE=ELOQDSS_ELOQSTORE -DWITH_LOG_STATE=ROCKSDB \
  -DWITH_LOG_SERVICE=ON -DEXT_TX_PROC_ENABLED=ON -DELOQ_MODULE_ENABLED=ON \
  -DELOQ_THIRD_PARTY_PREFIX=/opt/eloq/third_party \
  -DELOQ_THIRD_PARTY_REQUIRED=ON \
  -DCMAKE_INSTALL_PREFIX=/tmp/eloq-tsc-review-20260911/install
cmake --build /tmp/eloq-tsc-review-20260911/build \
  --target eloqkv TestNodeSmoke-Test --parallel 4
GLOG_minloglevel=2 ctest --test-dir /tmp/eloq-tsc-review-20260911/build/data_substrate \
  -L '^TestNodeSmoke-Test$' --output-on-failure --timeout 180 -V
python3 /tmp/eloq-tsc-review-20260911/build_probe.py
/tmp/eloq-tsc-review-20260911/clock_probe
clang-format-18 --dry-run --Werror \
  /tmp/eloq-tsc-review-20260911/tx_service/tx_service/include/util.h
git -C /tmp/eloq-tsc-review-20260911/tx_service diff origin/main...HEAD --check
git -C /tmp/eloq-tsc-review-20260911/eloqkv diff origin/main...HEAD --check
```

## Risk assessment

Correcting time budgets can change scheduling/yield behavior under load. No latency or throughput benchmark was run. The raw hardware-counter assumptions and integer frequency rounding remain. EloqStore main still has the independent sleep-duration calibration issue tracked by eloqdata/eloqstore#495. No protocol, persisted-data, configuration, or recovery-format changes.

## Rollback plan

Revert this PR and restore the consuming EloqKV submodule reference. No migration is required.

## Reviewer guide

Start at `InitializeTscFrequency`, then the standalone target's `ABSEIL` list. Confirm raw-counter scale, once-only publication, ARM guards, and that EloqStore remains at main. The earlier CodeRabbit request to explain the added EloqStore `absl::base` link no longer applies because that link addition has been removed.

## Follow-up work

Run the new commit's amd64/arm64 CI matrix. Review and land eloqdata/eloqstore#495 separately. EloqKV eloqdata/eloqkv#558 consumes this PR branch for integration and must be repinned to the landed main commit before merging.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved timing calibration on x86 systems for more reliable and consistent performance.
  - Reduced variability caused by timing measurements during startup.

- **Build Improvements**
  - Updated build configuration to support the revised timing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->