### PR TITLE
Fix DDL catalog livelock, Find() End() crashes, and DataSync meta-lock deadlock

### DIFF
--- a/docs/03-concurrency-control.md
+++ b/docs/03-concurrency-control.md
@@ -258,6 +258,20 @@ WriteIntent; plain `Read` ⇒ NoLock under ReadCommitted/Snapshot, ReadLock unde
 with `Locking`, ReadIntent under RR/Serializable with OCC/OccRead; `ReadSkIndex` ⇒ NoLock for
 snapshot or covering read-committed scans, else ReadLock.
 
+Note that the protocol changes only the *status* of a failed acquisition, never the lock type.
+That is what lets a catalog read-for-write run under `OCC` while still taking a `WriteIntent`
+(see the read-local rule in [04](04-transaction-execution.md#isolation--protocols)).
+
+**Why catalog write intents must not wait.** A catalog entry is the one entry where DDL and DML
+meet, and an API layer typically holds its `ReadLock` on that entry before escalating to a
+`WriteIntent` on the same entry. If the escalation blocks, the resulting wait edge closes a
+cycle: the DDL holding the `WriteIntent` waits in `acquire_all_lock_op_` for `NoReadLockConflict`
+so it can upgrade to a `WriteLock`, which cannot happen until the blocked waiter releases the
+read lock it is still holding. The deadlock detector sees the cycle, but a DDL past its prepare
+log cannot be aborted, so its recovery action is a no-op and the cycle re-forms. Failing fast
+instead means the waiter never enters `blocking_queue_`, so no edge is produced and the cycle
+cannot form.
+
 Release paths (`ReleaseWriteLock`, `ReleaseReadLock`, `ClearTx`, `DowngradeWriteLock`) all end in
 `TryPopBlockingQueue(ccs)`: pop queue heads while they are now grantable, granting the lock
 *before* re-enqueueing the request to the shard queue (so a resumed request already owns its

--- a/docs/04-transaction-execution.md
+++ b/docs/04-transaction-execution.md
@@ -86,6 +86,19 @@ Aborts run the same tail (UpdateTxnStatus → PostProcess with rollback). A txm 
 
 Set per tx at init (`iso_level_`, `protocol_`): `IsolationLevel` {ReadCommitted, Snapshot (requires `enable_mvcc`), RepeatableRead, Serializable} × `CcProtocol` {OCC, OccRead, Locking}. The lock type taken by each operation is decided by `LockTypeUtil::DeduceLockType` (`tx_service/include/cc_protocol.h`); `DeduceReadLockType` additionally special-cases meta tables and covering-key index reads. Snapshot reads use MVCC version chains and `TxStartTsCollector` ([07](07-durability-and-recovery.md)).
 
+**Read-local overrides the tx's settings** (`Process(ReadOperation&)`, `tx_service/src/tx_execution.cpp`). `ReadLocal` is used for catalog reads, which must take a real read lock whatever the tx asked for, so the isolation level is forced up to at least `RepeatableRead`. The protocol is then chosen by `is_for_write_`:
+
+| `is_for_write_` | protocol | lock | on conflict |
+|---|---|---|---|
+| `false` (catalog read) | `Locking` | `ReadLock` | blocks in the entry's queue |
+| `true` (catalog read for write) | `OCC` | `WriteIntent` | **fails fast** → `ACQUIRE_KEY_LOCK_FAILED_FOR_WW_CONFLICT` |
+
+The lock type is identical in both rows — `DeduceLockType` returns `WriteIntent` for `ReadForWrite` under every protocol. Only the failure status differs. Waiting on a catalog write intent closes a lock cycle against a DDL that is already past its prepare log and therefore cannot be aborted; see the rationale in [03](03-concurrency-control.md#5-nonblockinglock-non_blocking_lockh-non_blocking_lockcpp). `UpsertTableIndexOp::acquire_all_intent_op_` and `CatalogAcquireAllOp::acquire_all_intent_op_` already picked `OCC` for the same reason.
+
+`Process(ScanOpenOperation&)` still hardcodes `Locking` for read-local scans, so a read-local scan for write would take a blocking write intent. No in-tree caller constructs one today.
+
+A failed `CatalogAcquireAllOp` reports `AcquireAllOp::RepresentativeError()` on `bool_resp_` before aborting. `fail_cnt_` alone cannot supply a code — it is also raised on the dedup read-version-mismatch path where every handler result is successful — and an abort reported as `NO_ERROR` reads as success at the API boundary. Within one op, an infrastructure error (`REQUESTED_NODE_NOT_LEADER`, `NG_TERM_CHANGED`, timeouts) outranks a conflict error (`IsConflictError`, `error_messages.h`), because API layers retry conflicts and some of those retry loops have no bound of their own.
+
 ## Gotchas
 
 - Operation objects are *members* of the txm (`read_`, `acquire_write_`, `write_log_`, ...) — they are reused across requests; `Reset()` correctness on every path matters.

--- a/tx_service/include/cc/catalog_cc_map.h
+++ b/tx_service/include/cc/catalog_cc_map.h
@@ -248,7 +248,12 @@ public:
         Iterator it =
             TemplateCcMap<CatalogKey, CatalogRecord, true, false>::Find(
                 *table_key);
-        CcEntry<CatalogKey, CatalogRecord, true, false> *cce_ptr = it->second;
+        // Find() returns End() when the key is absent, and End() is not
+        // dereferenceable. The null-entry case below is expected here (it is
+        // exactly the failed-over node group the comment describes), so the
+        // iterator has to be range-checked before it->second.
+        CcEntry<CatalogKey, CatalogRecord, true, false> *cce_ptr =
+            it == End() ? nullptr : it->second;
 
         // Check whether cce key lock holder is the given tx of the
         // PostWriteAllCc before applying change.
@@ -1312,7 +1317,12 @@ public:
         {
             CatalogKey table_key(table_name);
             Iterator it = Find(table_key);
-            CcEntry<CatalogKey, CatalogRecord, true, false> *cce = it->second;
+            // Find() returns End() when the key is absent (template_cc_map.h),
+            // and End() is not dereferenceable. During replay the catalog entry
+            // is normally absent -- that is the whole point of replaying it --
+            // so the iterator must be range-checked before it->second.
+            CcEntry<CatalogKey, CatalogRecord, true, false> *cce =
+                it == End() ? nullptr : it->second;
             if (cce != nullptr)
             {
                 req.SetFinish();
@@ -2236,7 +2246,31 @@ public:
         Iterator it =
             TemplateCcMap<CatalogKey, CatalogRecord, true, false>::Find(
                 catalog_key);
-        CcEntry<CatalogKey, CatalogRecord, true, false> *cce = it->second;
+        CcEntry<CatalogKey, CatalogRecord, true, false> *cce =
+            it == End() ? nullptr : it->second;
+
+        if (cce == nullptr)
+        {
+            // The catalog write lock was taken on the old leader by
+            // InvalidateTableCacheCompositeOp's acquire_all_lock_op_, and there
+            // is no leader-term re-check before this request is routed. If the
+            // node group failed over in between, this lands on a new leader
+            // whose catalog cc map has neither the entry nor the lock -- cc
+            // entries and locks do not survive failover. The ng_term check
+            // above still passes, because the new leader's term is valid. There
+            // is nothing cached to invalidate, so finish the request instead of
+            // dereferencing.
+            if (shard_->core_id_ < shard_->core_cnt_ - 1)
+            {
+                req.ResetCcm();
+                MoveRequest(&req, shard_->core_id_ + 1);
+                return false;
+            }
+            hd_res->SetFinished();
+            return true;
+        }
+
+        // Only meaningful when the entry survived, i.e. no failover happened.
         assert(cce->GetKeyLock()->HasWriteLock(req.Txn()));
 
         if (cce->PayloadStatus() == RecordStatus::Unknown)

--- a/tx_service/include/cc/local_cc_shards.h
+++ b/tx_service/include/cc/local_cc_shards.h
@@ -2017,6 +2017,22 @@ private:
                               const TableName &table_name,
                               uint32_t id);
 
+    /**
+     * Atomically removes and returns every pending task of the limiter
+     * identified by (ng_id, ng_term, table_name, id), erasing the limiter.
+     * Call while holding meta_data_mux_ so a concurrent re-creation of the
+     * same table cannot enqueue next-generation tasks into the limiter
+     * before it is detached. Finalize the returned tasks
+     * (SetError/SetScanTaskFinished) only after releasing the metadata
+     * lock -- task finalization can issue RPCs and must not park a worker
+     * that holds it (see DataSyncForRangePartition).
+     */
+    std::deque<std::shared_ptr<DataSyncTask>> DetachAllPendingTasks(
+        NodeGroupId ng_id,
+        int64_t ng_term,
+        const TableName &table_name,
+        uint32_t id);
+
     void PostProcessHashPartitionDataSyncTask(
         std::shared_ptr<DataSyncTask> task,
         TransactionExecution *data_sync_txm,

--- a/tx_service/include/error_messages.h
+++ b/tx_service/include/error_messages.h
@@ -437,4 +437,34 @@ static inline const std::string CcErrorMessage(CcErrorCode error_code)
     }
     return "CcErrorCode:" + std::to_string(static_cast<int>(error_code));
 }
+
+/**
+ * @brief Whether the error means "another transaction got there first".
+ *
+ * Conflict errors are the ones an API layer is expected to resolve by
+ * re-running the whole transaction, so they map to a retryable error at the
+ * API boundary (e.g. mongo's WriteConflictException). Everything else --
+ * leadership changes, term changes, timeouts, transport failures -- is an
+ * infrastructure failure that retrying the same transaction will not clear,
+ * and reporting one of those as a conflict feeds a retry loop that may have
+ * no bound of its own.
+ *
+ * Keep this list aligned with the codes an API layer converts into its
+ * retryable exception.
+ */
+static inline bool IsConflictError(CcErrorCode error_code)
+{
+    switch (error_code)
+    {
+    case CcErrorCode::ACQUIRE_KEY_LOCK_FAILED_FOR_RW_CONFLICT:
+    case CcErrorCode::ACQUIRE_KEY_LOCK_FAILED_FOR_WW_CONFLICT:
+    case CcErrorCode::ACQUIRE_GAP_LOCK_FAILED:
+    case CcErrorCode::VALIDATION_FAILED_FOR_VERSION_MISMATCH:
+    case CcErrorCode::VALIDATION_FAILED_FOR_CONFILICTED_TXS:
+    case CcErrorCode::DEAD_LOCK_ABORT:
+        return true;
+    default:
+        return false;
+    }
+}
 }  // namespace txservice

--- a/tx_service/include/tx_operation.h
+++ b/tx_service/include/tx_operation.h
@@ -538,6 +538,16 @@ struct AcquireAllOp : public TransactionOperation
 
     bool IsDeadlock() const;
 
+    /**
+     * @brief Returns a concrete error code for a failed AcquireAllOp.
+     *
+     * fail_cnt_ alone cannot supply one: it is also raised on the dedup
+     * read-version mismatch path, where every handler result is successful.
+     * A failed AcquireAll must never be reported as NO_ERROR, or the caller
+     * aborts the transaction while telling the client it succeeded.
+     */
+    CcErrorCode RepresentativeError() const;
+
     std::vector<CcHandlerResult<AcquireAllResult>> hd_results_;
     uint32_t upload_cnt_{0};
     std::atomic<uint32_t> finish_cnt_{0};

--- a/tx_service/src/cc/local_cc_shards.cpp
+++ b/tx_service/src/cc/local_cc_shards.cpp
@@ -3700,6 +3700,18 @@ void LocalCcShards::DataSyncForRangePartition(
 
     if (!during_split_range)
     {
+        // Decide under the metadata lock, act after releasing it (see the
+        // switch below).
+        enum class PreCheck
+        {
+            Process,
+            TableDropped,
+            NotOwner,
+            AlreadySynced,
+        };
+        PreCheck outcome = PreCheck::Process;
+        std::deque<std::shared_ptr<DataSyncTask>> detached_tasks;
+
         std::shared_lock<std::shared_mutex> meta_lk(meta_data_mux_);
 
         TableName range_tbl_name{table_name.StringView(),
@@ -3709,11 +3721,13 @@ void LocalCcShards::DataSyncForRangePartition(
             GetTableRangeEntryInternal(range_tbl_name, ng_id, range_id);
         if (range_entry == nullptr)
         {
-            // table dropped
-            data_sync_task->SetError(CcErrorCode::REQUESTED_TABLE_NOT_EXISTS);
-            data_sync_task->SetScanTaskFinished();
-            data_sync_task->ResetRangeSplittingStatus();
-            ClearAllPendingTasks(ng_id, expected_ng_term, table_name, range_id);
+            // table dropped. Detach the limiter's pending tasks while the
+            // metadata lock still excludes a concurrent re-creation of the
+            // same table, so next-generation tasks cannot join the limiter
+            // between our unlock and their finalization below.
+            outcome = PreCheck::TableDropped;
+            detached_tasks = DetachAllPendingTasks(
+                ng_id, expected_ng_term, table_name, range_id);
         }
         else
         {
@@ -3748,12 +3762,7 @@ void LocalCcShards::DataSyncForRangePartition(
                 last_sync_ts = is_dirty ? 0 : range_entry->GetLastSyncTs();
                 if (data_sync_task->data_sync_ts_ <= last_sync_ts && !is_dirty)
                 {
-                    data_sync_task->SetFinish();
-                    data_sync_task->SetScanTaskFinished();
-                    data_sync_task->ResetRangeSplittingStatus();
-                    PopPendingTask(
-                        ng_id, expected_ng_term, table_name, range_id);
-                    assert(need_process == false);
+                    outcome = PreCheck::AlreadySynced;
                 }
                 else
                 {
@@ -3763,20 +3772,49 @@ void LocalCcShards::DataSyncForRangePartition(
             else
             {
                 // range no longer belong to this ng.
-                data_sync_task->SetError(
-                    CcErrorCode::REQUESTED_NODE_NOT_LEADER);
-                data_sync_task->SetScanTaskFinished();
-                data_sync_task->ResetRangeSplittingStatus();
-                PopPendingTask(ng_id, expected_ng_term, table_name, range_id);
+                outcome = PreCheck::NotOwner;
             }
         }
 
-        if (!need_process)
-        {
-            return;
-        }
-
         meta_lk.unlock();
+
+        // Act only after the metadata lock is released: SetFinish()'s
+        // last-task path issues RPCs (LogAgent::UpdateCheckpointTs,
+        // BrocastPrimaryCkptTs) that park this worker, and holding
+        // meta_data_mux_ across that wait blocks every catalog writer
+        // (CreateDirtyCatalog/UpdateDirtyCatalog) on the cc shard's
+        // processor slot and wedges the node. The helpers below only touch
+        // task bookkeeping guarded by task_limiter_mux_; none of them need
+        // the metadata lock.
+        switch (outcome)
+        {
+        case PreCheck::TableDropped:
+            data_sync_task->SetError(CcErrorCode::REQUESTED_TABLE_NOT_EXISTS);
+            data_sync_task->SetScanTaskFinished();
+            data_sync_task->ResetRangeSplittingStatus();
+            for (auto &task : detached_tasks)
+            {
+                task->SetError(CcErrorCode::REQUESTED_TABLE_NOT_EXISTS);
+                task->SetScanTaskFinished();
+            }
+            return;
+        case PreCheck::NotOwner:
+            data_sync_task->SetError(CcErrorCode::REQUESTED_NODE_NOT_LEADER);
+            data_sync_task->SetScanTaskFinished();
+            data_sync_task->ResetRangeSplittingStatus();
+            PopPendingTask(ng_id, expected_ng_term, table_name, range_id);
+            return;
+        case PreCheck::AlreadySynced:
+            assert(!need_process);
+            data_sync_task->SetFinish();
+            data_sync_task->SetScanTaskFinished();
+            data_sync_task->ResetRangeSplittingStatus();
+            PopPendingTask(ng_id, expected_ng_term, table_name, range_id);
+            return;
+        case PreCheck::Process:
+            assert(need_process);
+            break;
+        }
 
         // Check the leader
         // In order to avoid range entry be dropped by ClearCcNodeGroup, should
@@ -4627,6 +4665,18 @@ void LocalCcShards::DataSyncForHashPartition(
     int64_t expected_ng_term = data_sync_task->node_group_term_;
     bool is_dirty = data_sync_task->is_dirty_;
 
+    // Decide under the metadata lock, act after releasing it; see
+    // DataSyncForRangePartition for why task finalization must not run
+    // while meta_data_mux_ is held.
+    enum class PreCheck
+    {
+        Process,
+        TableDropped,
+        AlreadySynced,
+    };
+    PreCheck outcome = PreCheck::Process;
+    std::deque<std::shared_ptr<DataSyncTask>> detached_tasks;
+
     std::shared_lock<std::shared_mutex> meta_lk(meta_data_mux_);
     uint64_t last_sync_ts = 0;
     bool need_process = false;
@@ -4639,9 +4689,12 @@ void LocalCcShards::DataSyncForHashPartition(
 
     if (catalog_entry == nullptr)
     {
-        data_sync_task->SetError(CcErrorCode::REQUESTED_TABLE_NOT_EXISTS);
-        data_sync_task->SetScanTaskFinished();
-        ClearAllPendingTasks(ng_id, expected_ng_term, table_name, worker_idx);
+        // table dropped. Detach under the lock so a concurrent re-creation
+        // cannot enqueue next-generation tasks into the limiter before
+        // their finalization below.
+        outcome = PreCheck::TableDropped;
+        detached_tasks = DetachAllPendingTasks(
+            ng_id, expected_ng_term, table_name, worker_idx);
     }
     else
     {
@@ -4672,12 +4725,7 @@ void LocalCcShards::DataSyncForHashPartition(
         last_sync_ts = is_dirty ? 0 : catalog_entry->GetLastSyncTs(worker_idx);
         if (data_sync_task->data_sync_ts_ <= last_sync_ts && !is_dirty)
         {
-            data_sync_task->SetFinish();
-            data_sync_task->SetScanTaskFinished();
-
-            PopPendingTask(ng_id, expected_ng_term, table_name, worker_idx);
-
-            assert(need_process == false);
+            outcome = PreCheck::AlreadySynced;
         }
         else
         {
@@ -4685,12 +4733,29 @@ void LocalCcShards::DataSyncForHashPartition(
         }
     }
 
-    if (!need_process)
-    {
-        return;
-    }
-
     meta_lk.unlock();
+
+    switch (outcome)
+    {
+    case PreCheck::TableDropped:
+        data_sync_task->SetError(CcErrorCode::REQUESTED_TABLE_NOT_EXISTS);
+        data_sync_task->SetScanTaskFinished();
+        for (auto &task : detached_tasks)
+        {
+            task->SetError(CcErrorCode::REQUESTED_TABLE_NOT_EXISTS);
+            task->SetScanTaskFinished();
+        }
+        return;
+    case PreCheck::AlreadySynced:
+        assert(!need_process);
+        data_sync_task->SetFinish();
+        data_sync_task->SetScanTaskFinished();
+        PopPendingTask(ng_id, expected_ng_term, table_name, worker_idx);
+        return;
+    case PreCheck::Process:
+        assert(need_process);
+        break;
+    }
 
     int64_t ng_term = -1;
     if (data_sync_task->is_standby_node_ckpt_)
@@ -4958,7 +5023,13 @@ void LocalCcShards::DataSyncForHashPartition(
                 const auto bucket_infos = GetAllBucketInfosNoLocking(ng_id);
                 if (bucket_infos == nullptr)
                 {
-                    // no longer node group owner, abort the task
+                    // No longer node group owner, abort the task -- but only
+                    // after releasing the metadata lock:
+                    // PostProcessHashPartitionDataSyncTask's SCAN_ERROR path
+                    // reaches AbortTx()/CommitTxRequest::Wait(), and parking
+                    // this worker with meta_data_mux_ held blocks catalog
+                    // writers on the cc shard's processor slot.
+                    meta_lk.unlock();
                     LOG(ERROR) << "DataSync: Failed to get bucket infos for "
                                   "ng#"
                                << ng_id;
@@ -5409,6 +5480,30 @@ void LocalCcShards::PopPendingTask(NodeGroupId ng_id,
     {
         task_limiters_.erase(iter);
     }
+}
+
+std::deque<std::shared_ptr<DataSyncTask>> LocalCcShards::DetachAllPendingTasks(
+    NodeGroupId ng_id,
+    int64_t ng_term,
+    const TableName &table_name,
+    uint32_t id)
+{
+    assert(!table_name.IsMeta());
+
+    auto task_limiter_key = TaskLimiterKey(ng_id,
+                                           ng_term,
+                                           table_name.StringView(),
+                                           table_name.Type(),
+                                           table_name.Engine(),
+                                           id);
+
+    std::deque<std::shared_ptr<DataSyncTask>> detached;
+    std::lock_guard<std::mutex> task_limiter_lk(task_limiter_mux_);
+    auto iter = task_limiters_.find(task_limiter_key);
+    assert(iter != task_limiters_.end());
+    detached.swap(iter->second->pending_tasks_);
+    task_limiters_.erase(iter);
+    return detached;
 }
 
 void LocalCcShards::ClearAllPendingTasks(NodeGroupId ng_id,

--- a/tx_service/src/cc/non_blocking_lock.cpp
+++ b/tx_service/src/cc/non_blocking_lock.cpp
@@ -459,7 +459,9 @@ bool NonBlockingLock::AcquireWriteIntent(CcRequestBase *cc_req,
             blocking_queue_.Enqueue(
                 LockQueueEntry(cc_req, LockType::WriteIntent));
         }
-        // OccRead doesn't enqueue request.
+        // OCC doesn't enqueue the request: the caller fails fast instead of
+        // waiting, so no wait edge is produced. OccRead and Locking both
+        // enqueue.
         return false;
     }
 }

--- a/tx_service/src/tx_execution.cpp
+++ b/tx_service/src/tx_execution.cpp
@@ -1825,8 +1825,23 @@ void TransactionExecution::Process(ReadOperation &read)
         {
             // So far ReadLocal() is use exclusively for reading catalogs.
             // Reading catalogs needs to put read locks, regardless of the tx's
-            // concurrency control protocol. So for now, a read's isolation
-            // level and cc protocol is fixed.
+            // concurrency control protocol. So the isolation level is forced up
+            // to at least RepeatableRead.
+            //
+            // The cc protocol depends on what the read is for. A plain catalog
+            // read takes a read lock under Locking and waits, as before. A read
+            // for write takes a write intent, and under Locking it would wait
+            // in the entry's blocking queue. A catalog write intent is exactly
+            // where DDL and DML meet, so waiting there closes a lock cycle:
+            // the waiter holds this entry's read lock while the DDL holding the
+            // write intent waits for that read lock to be released so it can
+            // upgrade to a write lock. OCC makes the acquisition fail instead
+            // of enqueueing, so no wait edge is ever produced and the cycle
+            // cannot form. The lock type is unchanged either way --
+            // DeduceLockType returns WriteIntent for ReadForWrite under both
+            // protocols. UpsertTableIndexOp::acquire_all_intent_op_ and
+            // CatalogAcquireAllOp::acquire_all_intent_op_ already pick OCC for
+            // the same reason.
             if (iso_level_ < IsolationLevel::RepeatableRead)
             {
                 read.iso_level_ = IsolationLevel::RepeatableRead;
@@ -1835,7 +1850,9 @@ void TransactionExecution::Process(ReadOperation &read)
             {
                 read.iso_level_ = iso_level_;
             }
-            read.protocol_ = CcProtocol::Locking;
+            read.protocol_ = read.read_tx_req_->is_for_write_
+                                 ? CcProtocol::OCC
+                                 : CcProtocol::Locking;
 
             bool finished = true;
             if (!read.read_tx_req_->is_str_key_)
@@ -4026,6 +4043,20 @@ void TransactionExecution::PostProcess(
     }
     else
     {
+        // Every failure branch of CatalogAcquireAllOp::Forward sets the error
+        // code before it gets here. Leaving it at NO_ERROR would abort the
+        // transaction while TxErrorCodeToMongoStatus (and its equivalents in
+        // the other API layers) reports success to the client, silently
+        // dropping the writes. Guard against a future failure branch that
+        // forgets to set one.
+        assert(bool_resp_->ErrorCode() != TxErrorCode::NO_ERROR);
+        if (bool_resp_->ErrorCode() == TxErrorCode::NO_ERROR)
+        {
+            LOG(ERROR) << "CatalogAcquireAllOp failed without an error code, "
+                          "tx_number: "
+                       << TxNumber();
+            bool_resp_->SetErrorCode(TxErrorCode::UNDEFINED_ERR);
+        }
         catalog_acquire_all_.Reset();
         Abort();
     }

--- a/tx_service/src/tx_operation.cpp
+++ b/tx_service/src/tx_operation.cpp
@@ -2079,6 +2079,51 @@ bool AcquireAllOp::IsDeadlock() const
     return false;
 }
 
+CcErrorCode AcquireAllOp::RepresentativeError() const
+{
+    CcErrorCode conflict = CcErrorCode::NO_ERROR;
+
+    // Iterate to upload_cnt_, not hd_results_.size(): the vector is reserved
+    // to 8 and grown, so its tail holds results of an earlier round.
+    for (size_t idx = 0; idx < upload_cnt_; ++idx)
+    {
+        if (!hd_results_[idx].IsError())
+        {
+            continue;
+        }
+
+        CcErrorCode err = hd_results_[idx].ErrorCode();
+        // An infrastructure failure must win over a lock conflict. Reporting
+        // a lost leadership as a retryable conflict makes the API layer retry
+        // forever against a node group that will never serve the request.
+        if (!IsConflictError(err))
+        {
+            return err;
+        }
+        if (conflict == CcErrorCode::NO_ERROR)
+        {
+            // Keep the first conflict in index order, so the reported code is
+            // deterministic across runs.
+            conflict = err;
+        }
+    }
+
+    if (conflict != CcErrorCode::NO_ERROR)
+    {
+        return conflict;
+    }
+
+    // fail_cnt_ was raised with every handler result successful. The only
+    // producer is the dedup read-version mismatch in Forward(), i.e. a broken
+    // repeatable read.
+    if (fail_cnt_.load(std::memory_order_relaxed) > 0)
+    {
+        return CcErrorCode::VALIDATION_FAILED_FOR_VERSION_MISMATCH;
+    }
+
+    return CcErrorCode::NO_ERROR;
+}
+
 PostWriteAllOp::PostWriteAllOp(TransactionExecution *txm) : hd_result_(txm)
 {
 }
@@ -2212,6 +2257,8 @@ void CatalogAcquireAllOp::Forward(TransactionExecution *txm)
         {
             LOG(ERROR) << "Upsert table read cluster config failed, tx_number:"
                        << txm->TxNumber();
+            txm->bool_resp_->SetErrorCode(TransactionExecution::ConvertCcError(
+                lock_cluster_config_op_.hd_result_->ErrorCode()));
             txm->PostProcess(*this);
         }
         else
@@ -2228,6 +2275,8 @@ void CatalogAcquireAllOp::Forward(TransactionExecution *txm)
         {
             LOG(ERROR) << "Upsert table acquire write intent failed, tx_number:"
                        << txm->TxNumber();
+            txm->bool_resp_->SetErrorCode(TransactionExecution::ConvertCcError(
+                acquire_all_intent_op_.RepresentativeError()));
             txm->PostProcess(*this);
         }
         else
@@ -2245,6 +2294,8 @@ void CatalogAcquireAllOp::Forward(TransactionExecution *txm)
             LOG(ERROR) << "Upsert table schema transaction failed to "
                           "acquire write lock, tx_number:"
                        << txm->TxNumber();
+            txm->bool_resp_->SetErrorCode(TransactionExecution::ConvertCcError(
+                acquire_all_lock_op_.RepresentativeError()));
             txm->PostProcess(*this);
         }
         else

--- a/tx_service/tests/AcquireAllError-Test.cpp
+++ b/tx_service/tests/AcquireAllError-Test.cpp
@@ -1,0 +1,167 @@
+/**
+ *    Copyright (C) 2025 EloqData Inc.
+ *
+ *    This program is free software: you can redistribute it and/or  modify
+ *    it under either of the following two licenses:
+ *    1. GNU Affero General Public License, version 3, as published by the Free
+ *    Software Foundation.
+ *    2. GNU General Public License as published by the Free Software
+ *    Foundation; version 2 of the License.
+ *
+ *    This program is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU Affero General Public License or GNU General Public License for more
+ *    details.
+ *
+ *    You should have received a copy of the GNU Affero General Public License
+ *    and GNU General Public License V2 along with this program.  If not, see
+ *    <http://www.gnu.org/licenses/>.
+ *
+ */
+// Let Catch provide main():
+#include <catch2/catch_all.hpp>
+
+#include "error_messages.h"
+#include "tx_operation.h"
+
+using txservice::AcquireAllOp;
+using txservice::CcErrorCode;
+
+namespace
+{
+/**
+ * @brief An AcquireAllOp with `count` handler results and no txm.
+ *
+ * CcHandlerResult only dereferences txm_ when is_blocking_ is set, which no
+ * plain SetError() path does, so a null txm is enough to drive the real
+ * post_lambda_ that maintains fail_cnt_. The op is held in place: its handler
+ * results' post_lambda_ capture `this`, and its atomics make it immovable.
+ */
+struct TestOp
+{
+    explicit TestOp(uint32_t count) : op(nullptr)
+    {
+        op.Resize(count);
+        op.upload_cnt_ = count;
+    }
+
+    AcquireAllOp op;
+};
+}  // namespace
+
+TEST_CASE(
+    "RepresentativeError reports a version mismatch when only fail_cnt_ "
+    "is raised",
+    "[AcquireAllOp]")
+{
+    // AcquireAllOp::Forward raises fail_cnt_ on the dedup read-version
+    // mismatch path *without* erroring the handler result. An accessor that
+    // only scanned hd_results_ would return NO_ERROR there, and a NO_ERROR on
+    // a failed operation reads as success at the API boundary -- the silent
+    // write loss this change fixes.
+    TestOp t{3};
+    AcquireAllOp &op = t.op;
+
+    REQUIRE(op.RepresentativeError() == CcErrorCode::NO_ERROR);
+
+    op.fail_cnt_.fetch_add(1, std::memory_order_relaxed);
+
+    REQUIRE(op.RepresentativeError() ==
+            CcErrorCode::VALIDATION_FAILED_FOR_VERSION_MISMATCH);
+}
+
+TEST_CASE("RepresentativeError prefers an infrastructure error over a conflict",
+          "[AcquireAllOp]")
+{
+    // Conflicts are converted to a retryable exception at the API boundary,
+    // and some of those retry loops are unbounded (mongo's writeConflictRetry
+    // is `while (true)`). Reporting a node-group that lost leadership as a
+    // conflict would retry it forever. A plain first-error-in-index-order
+    // accessor passes a "not NO_ERROR" assertion but fails this one.
+    SECTION("conflict first in index order")
+    {
+        TestOp t{3};
+        AcquireAllOp &op = t.op;
+        op.hd_results_[0].SetError(
+            CcErrorCode::ACQUIRE_KEY_LOCK_FAILED_FOR_WW_CONFLICT);
+        op.hd_results_[1].SetError(CcErrorCode::REQUESTED_NODE_NOT_LEADER);
+
+        REQUIRE(op.RepresentativeError() ==
+                CcErrorCode::REQUESTED_NODE_NOT_LEADER);
+    }
+
+    SECTION("infrastructure error first in index order")
+    {
+        TestOp t{3};
+        AcquireAllOp &op = t.op;
+        op.hd_results_[0].SetError(CcErrorCode::NG_TERM_CHANGED);
+        op.hd_results_[1].SetError(
+            CcErrorCode::ACQUIRE_KEY_LOCK_FAILED_FOR_WW_CONFLICT);
+
+        REQUIRE(op.RepresentativeError() == CcErrorCode::NG_TERM_CHANGED);
+    }
+}
+
+TEST_CASE("RepresentativeError keeps the first conflict when all are conflicts",
+          "[AcquireAllOp]")
+{
+    // Within one class the result must be deterministic across runs, so the
+    // first in index order wins.
+    TestOp t{4};
+    AcquireAllOp &op = t.op;
+    op.hd_results_[1].SetError(CcErrorCode::DEAD_LOCK_ABORT);
+    op.hd_results_[2].SetError(
+        CcErrorCode::ACQUIRE_KEY_LOCK_FAILED_FOR_WW_CONFLICT);
+
+    REQUIRE(op.RepresentativeError() == CcErrorCode::DEAD_LOCK_ABORT);
+}
+
+TEST_CASE("RepresentativeError ignores stale results past upload_cnt_",
+          "[AcquireAllOp]")
+{
+    // hd_results_ is reserved to 8 and grown, never shrunk, so an earlier
+    // round's error can sit in the tail. MaxTs() and IsDeadlock() already stop
+    // at upload_cnt_ for the same reason.
+    TestOp t{8};
+    AcquireAllOp &op = t.op;
+    op.hd_results_[5].SetError(CcErrorCode::DATA_STORE_ERR);
+
+    // While the entry is in range it is reported, so the assertion below is
+    // not vacuous.
+    REQUIRE(op.RepresentativeError() == CcErrorCode::DATA_STORE_ERR);
+
+    // Now the state a smaller next round leaves behind. Reset(node_cnt)
+    // clears fail_cnt_ and recomputes upload_cnt_ together, so the stale
+    // handler result in the tail is the only thing still carrying the old
+    // round's error.
+    op.upload_cnt_ = 2;
+    op.fail_cnt_.store(0, std::memory_order_relaxed);
+
+    REQUIRE(op.RepresentativeError() == CcErrorCode::NO_ERROR);
+}
+
+TEST_CASE("IsConflictError classifies the retryable group", "[AcquireAllOp]")
+{
+    // This list must stay aligned with the codes an API layer converts into
+    // its retryable exception; see ThrowIfWriteConflict on the eloqdoc side.
+    using txservice::IsConflictError;
+
+    REQUIRE(
+        IsConflictError(CcErrorCode::ACQUIRE_KEY_LOCK_FAILED_FOR_WW_CONFLICT));
+    REQUIRE(
+        IsConflictError(CcErrorCode::ACQUIRE_KEY_LOCK_FAILED_FOR_RW_CONFLICT));
+    REQUIRE(IsConflictError(CcErrorCode::ACQUIRE_GAP_LOCK_FAILED));
+    REQUIRE(
+        IsConflictError(CcErrorCode::VALIDATION_FAILED_FOR_VERSION_MISMATCH));
+    REQUIRE(
+        IsConflictError(CcErrorCode::VALIDATION_FAILED_FOR_CONFILICTED_TXS));
+    REQUIRE(IsConflictError(CcErrorCode::DEAD_LOCK_ABORT));
+
+    REQUIRE_FALSE(IsConflictError(CcErrorCode::NO_ERROR));
+    REQUIRE_FALSE(IsConflictError(CcErrorCode::REQUESTED_NODE_NOT_LEADER));
+    REQUIRE_FALSE(IsConflictError(CcErrorCode::NG_TERM_CHANGED));
+    REQUIRE_FALSE(IsConflictError(CcErrorCode::REQUEST_LOST));
+    REQUIRE_FALSE(IsConflictError(CcErrorCode::DATA_STORE_ERR));
+    REQUIRE_FALSE(IsConflictError(CcErrorCode::READ_CATALOG_FAIL));
+}

--- a/tx_service/tests/CMakeLists.txt
+++ b/tx_service/tests/CMakeLists.txt
@@ -63,6 +63,7 @@ set(CATCH_MAIN_TESTS
     LargeObjLRU-Test
     CcRequestWait-Test
     NonBlockingLock-Test
+    AcquireAllError-Test
     StandbyForward-Test
     ApplyResponseBoundary-Test
 )

--- a/tx_service/tests/NonBlockingLock-Test.cpp
+++ b/tx_service/tests/NonBlockingLock-Test.cpp
@@ -137,3 +137,100 @@ TEST_CASE("a write lock request from a non-holder still queues FIFO",
     REQUIRE(queued[0] == kQueuedFirst);
     REQUIRE(queued[1] == kQueuedSecond);
 }
+
+TEST_CASE("a write intent under OCC fails instead of queueing",
+          "[NonBlockingLock]")
+{
+    // Catalog reads-for-write run under OCC precisely so that a conflict does
+    // not produce a wait edge: the waiter would still be holding this entry's
+    // read lock, which is what the intent holder needs released before it can
+    // upgrade to a write lock. Under Locking the same request queues, which is
+    // the shape that closes the cycle.
+    constexpr txservice::TxNumber kHolder = 1001;
+    constexpr txservice::TxNumber kWaiter = 1002;
+
+    using txservice::LockOpStatus;
+    using txservice::LockType;
+
+    SECTION("OCC: Failed, and nothing is queued")
+    {
+        NonBlockingLock lock;
+        StubCcRequest holder_intent{kHolder};
+        StubCcRequest waiter_intent{kWaiter};
+
+        REQUIRE(lock.AcquireLock(
+                    &holder_intent, CcProtocol::OCC, LockType::WriteIntent) ==
+                LockOpStatus::Successful);
+        REQUIRE(lock.AcquireLock(
+                    &waiter_intent, CcProtocol::OCC, LockType::WriteIntent) ==
+                LockOpStatus::Failed);
+
+        REQUIRE_FALSE(lock.FindQueueRequest(kWaiter));
+        REQUIRE(lock.GetBlockTxIds(0).empty());
+    }
+
+    SECTION("Locking: Blocked, and the waiter is queued")
+    {
+        NonBlockingLock lock;
+        StubCcRequest holder_intent{kHolder};
+        StubCcRequest waiter_intent{kWaiter};
+
+        REQUIRE(lock.AcquireLock(&holder_intent,
+                                 CcProtocol::Locking,
+                                 LockType::WriteIntent) ==
+                LockOpStatus::Successful);
+        REQUIRE(lock.AcquireLock(&waiter_intent,
+                                 CcProtocol::Locking,
+                                 LockType::WriteIntent) ==
+                LockOpStatus::Blocked);
+
+        REQUIRE(lock.FindQueueRequest(kWaiter));
+        std::vector<txservice::TxNumber> queued = lock.GetBlockTxIds(0);
+        REQUIRE(queued.size() == 1);
+        REQUIRE(queued[0] == kWaiter);
+    }
+
+    SECTION("OccRead still queues -- only OCC skips the enqueue")
+    {
+        // Guards the comment at the enqueue site, which used to claim OccRead
+        // does not enqueue.
+        NonBlockingLock lock;
+        StubCcRequest holder_intent{kHolder};
+        StubCcRequest waiter_intent{kWaiter};
+
+        REQUIRE(lock.AcquireLock(&holder_intent,
+                                 CcProtocol::OccRead,
+                                 LockType::WriteIntent) ==
+                LockOpStatus::Successful);
+        REQUIRE(lock.AcquireLock(&waiter_intent,
+                                 CcProtocol::OccRead,
+                                 LockType::WriteIntent) ==
+                LockOpStatus::Blocked);
+        REQUIRE(lock.FindQueueRequest(kWaiter));
+    }
+}
+
+TEST_CASE("the protocol changes the failure status, never the lock type",
+          "[NonBlockingLock]")
+{
+    // The catalog fix relies on this: switching a read-for-write from Locking
+    // to OCC must not silently downgrade the lock it takes.
+    using txservice::CcOperation;
+    using txservice::IsolationLevel;
+    using txservice::LockType;
+    using txservice::LockTypeUtil;
+
+    for (CcProtocol proto :
+         {CcProtocol::OCC, CcProtocol::OccRead, CcProtocol::Locking})
+    {
+        for (IsolationLevel iso : {IsolationLevel::ReadCommitted,
+                                   IsolationLevel::Snapshot,
+                                   IsolationLevel::RepeatableRead,
+                                   IsolationLevel::Serializable})
+        {
+            REQUIRE(LockTypeUtil::DeduceLockType(
+                        CcOperation::ReadForWrite, iso, proto, false) ==
+                    LockType::WriteIntent);
+        }
+    }
+}


### PR DESCRIPTION
## What

Three concurrency fixes in the catalog/DDL path, found and validated by a 30-minute DDL fuzz (12 workers, createIndexes/dropIndexes/insert storms plus parked aggregation cursors, `ttlMonitorEnabled: true`) against a 3-node EloqDoc cluster:

1. **Catalog write-intent livelock (fail-fast + error propagation).** DDL acquire-all and DML for-write catalog reads both take write intents; under the Locking protocol the loser enqueued and the two sides starved each other (90 s retry exhaustion on two concurrent `createIndexes`). For-write catalog reads now use OCC and fail fast; `CatalogAcquireAllOp` failure branches set a representative error on the commit response instead of hanging the waiter (`RepresentativeError()` ranks infrastructure errors above conflicts and guards the reused `hd_results_` stale tail). Reproduction: 90 s → 0.12 s, one winner, one clean `WriteConflict` loser.
2. **`CatalogCcMap::Find()` returns `End()` for absent keys** — three `Execute` paths dereferenced it unconditionally (PostWriteAllCc, replay, InvalidateTableCacheCc) and crashed once DDL throughput made the window reachable. All three now take the absent-entry branch.
3. **DataSync deadlock: workers parked while holding `meta_data_mux_`.** Live-process forensics on a wedged cluster (glibc rwlock owner extraction + stack scans of parked bthread stacks; full write-up in `DDL_CATALOG_LIVELOCK_PLAN.md` §13.8) showed `DataSyncForRangePartition` holding the global metadata shared lock across `SetFinish()`'s checkpoint RPCs while a catalog writer blocked on the write lock from the cc shard's only processor slot — freezing the node and, via peer `[E1008]` retry storms, the cluster. All three park-capable sections (range, hash, hash forward-cache error branch) now decide under the lock and act after releasing it, and the new `DetachAllPendingTasks()` removes the limiter atomically under the metadata lock so a concurrent re-creation of the same table cannot have its next-generation tasks killed by the deferred finalization.

## Verification

- Unit: new `AcquireAllError-Test` (classification, stale tail, in-range reporting), extended `NonBlockingLock-Test` (OCC WriteIntent does not enqueue; Locking does).
- Integration: 30-minute fuzz runs recorded in the plan document — the final run (§13.9) completed with zero crashes, zero cores, zero wedges (no operation ever exceeded 120 s; the pre-fix wedge froze operations for 37+ minutes), conflict-class 0.07%, canaries 29/29.
- Review: three adversarial review rounds (Codex + Kimi concurrency/distributed-state) on this branch, final round double-PASS; the full meta-lock critical-section inventory (41 sites) was audited in the process.

`DDL_CATALOG_LIVELOCK_PLAN.md` carries the complete design, forensics, and follow-up list (notably: `TransactionExecution::Execute` accepts requests from a caller bound to a recycled txm — defensive identity assert suggested; `PinRangeSlices` dispatches store loads under the plain shared meta lock, an invariant hazard if the store handler ever blocks).

Companion PR in eloqdoc carries the mongo-layer half (Collection lifetime pinning, cursor save/restore across transactions, dispose-path fix) and the submodule bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented catalog-related deadlocks and livelocks during concurrent schema and data operations.
  - Improved handling of transaction conflicts, retries, metadata waits, dropped tables, and cursor recovery.
  - Prevented crashes caused by missing catalog entries and unsafe cleanup timing.
  - Reported more specific conflict and validation errors instead of generic failures.

- **Documentation**
  - Added guidance on concurrency behavior, read consistency, conflict handling, and fail-fast write operations.

- **Tests**
  - Added regression coverage for conflict classification, lock behavior, error selection, and version mismatches.
  - Completed extended multi-node concurrency testing without crashes or permanently stuck transactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->