### PR TITLE
fix: reset stale TTL on reused FlushRecord and bump rocksdb-cloud roll guard

### DIFF
--- a/tx_service/include/cc/cc_entry.h
+++ b/tx_service/include/cc/cc_entry.h
@@ -223,6 +223,10 @@ public:
         else
         {
             std::get<1>(payload_).value_.clear();
+            // The BlobTxRecord is reused across scan batches; clear the
+            // previous record's TTL so a no-TTL record is not flushed with a
+            // stale expiration.
+            std::get<1>(payload_).ttl_ = UINT64_MAX;
         }
         if (ptr != nullptr)
         {


### PR DESCRIPTION
Two changes:

- Bump `third_party/src/rocksdb-cloud` to `7b4210e` (eloqdata/rocksdb-cloud main), which publishes the smallest-file-number guard object in `RollNewCookie` before the new epoch becomes reachable (#20) and fixes the const-qualification compile error in `PutSmallestFileNumberObject` (#21).
- Fix silent data loss on RocksDB(-Cloud) backends: `FlushRecord::SetNonVersionedPayload` reuses its `BlobTxRecord` across data-sync scan batches but only cleared `value_`, leaving the previous record's `ttl_` behind. A no-TTL object flushed into a contaminated slot was written to the KV store with another key's expiration, so the read path and the TTL compaction filter treated it as expired and the key disappeared once evicted from memory — no restart required. Reset `ttl_` to `UINT64_MAX` (the "no TTL" sentinel) on every reuse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected expiration handling when records without a time-to-live are reused, preventing stale expiration settings from affecting data.

* **Chores**
  * Updated the underlying storage infrastructure to a newer revision.
  * Incorporated upstream maintenance and improvements while preserving existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->