### PR TITLE
Wait for metadata post-processing when closing a metadata-only transaction

### DIFF
--- a/docs/03-concurrency-control.md
+++ b/docs/03-concurrency-control.md
@@ -262,15 +262,17 @@ Note that the protocol changes only the *status* of a failed acquisition, never 
 That is what lets a catalog read-for-write run under `OCC` while still taking a `WriteIntent`
 (see the read-local rule in [04](04-transaction-execution.md#isolation--protocols)).
 
-**Why catalog write intents must not wait.** A catalog entry is the one entry where DDL and DML
-meet, and an API layer typically holds its `ReadLock` on that entry before escalating to a
-`WriteIntent` on the same entry. If the escalation blocks, the resulting wait edge closes a
-cycle: the DDL holding the `WriteIntent` waits in `acquire_all_lock_op_` for `NoReadLockConflict`
-so it can upgrade to a `WriteLock`, which cannot happen until the blocked waiter releases the
-read lock it is still holding. The deadlock detector sees the cycle, but a DDL past its prepare
-log cannot be aborted, so its recovery action is a no-op and the cycle re-forms. Failing fast
-instead means the waiter never enters `blocking_queue_`, so no edge is produced and the cycle
-cannot form.
+**Why catalog write intents must not wait.** A catalog read-for-write is requested only by DDL
+paths -- an API layer's create/drop collection, create/drop indexes and rename all ask for it,
+while DML and queries read the catalog without the flag. A DDL command typically holds a lock on
+the catalog entry from an earlier step before escalating to a `WriteIntent` on the same entry, so
+two commands touching one table can each hold what the other needs. If the escalation blocks, the
+resulting wait edge closes a cycle: the DDL holding the `WriteIntent` waits in
+`acquire_all_lock_op_` for `NoReadLockConflict` so it can upgrade to a `WriteLock`, which cannot
+happen until the blocked waiter releases the lock it is still holding. The deadlock detector sees
+the cycle, but a DDL past its prepare log cannot be aborted, so its recovery action is a no-op and
+the cycle re-forms. Failing fast instead means the waiter never enters `blocking_queue_`, so no
+edge is produced and the caller retries at the command layer.
 
 Release paths (`ReleaseWriteLock`, `ReleaseReadLock`, `ClearTx`, `DowngradeWriteLock`) all end in
 `TryPopBlockingQueue(ccs)`: pop queue heads while they are now grantable, granting the lock

--- a/tx_service/src/tx_execution.cpp
+++ b/tx_service/src/tx_execution.cpp
@@ -562,9 +562,23 @@ void TransactionExecution::InitTx(IsolationLevel iso_level,
 
 bool TransactionExecution::CommitTx(CommitTxRequest &commit_req)
 {
+    // The immediate path below closes the tx without waiting, so it is only
+    // safe when the tx holds nothing that close-time post-processing has to
+    // release. Catalog reads are the subtle case: their locks live in two
+    // places -- the metadata read set, released by ReleaseMetaDataReadLock()
+    // during post-processing, and locked_db_, released by
+    // ReleaseCatalogsRead() from Reset(). Returning while either is still
+    // held lets a caller that immediately reopens a tx (a retry loop) keep a
+    // catalog entry's reader count non-zero, so a DDL write intent never
+    // upgrades.
+    bool holds_catalog_read = rw_set_.MetaDataReadSetSize() > 0;
+    for (const auto &locked : locked_db_)
+    {
+        holds_catalog_read = holds_catalog_read || locked.first != nullptr;
+    }
+
     if (rw_set_.DataReadSetSize() == 0 && rw_set_.WriteSetSize() == 0 &&
-        rw_set_.MetaDataReadSetSize() == 0 &&
-        rw_set_.CatalogWriteSetSize() == 0 &&
+        !holds_catalog_read && rw_set_.CatalogWriteSetSize() == 0 &&
         cmd_set_.ObjectCntWithWriteLock() == 0)
     {
         commit_tx_req_->Reset();

--- a/tx_service/src/tx_execution.cpp
+++ b/tx_service/src/tx_execution.cpp
@@ -1829,20 +1829,22 @@ void TransactionExecution::Process(ReadOperation &read)
             // concurrency control protocol. So the isolation level is forced up
             // to at least RepeatableRead.
             //
-            // The cc protocol depends on what the read is for. A plain catalog
-            // read takes a read lock under Locking and waits, as before. A read
-            // for write takes a write intent, and under Locking it would wait
-            // in the entry's blocking queue. A catalog write intent is exactly
-            // where DDL and DML meet, so waiting there closes a lock cycle:
-            // the waiter holds this entry's read lock while the DDL holding the
-            // write intent waits for that read lock to be released so it can
-            // upgrade to a write lock. OCC makes the acquisition fail instead
-            // of enqueueing, so no wait edge is ever produced and the cycle
-            // cannot form. The lock type is unchanged either way --
-            // DeduceLockType returns WriteIntent for ReadForWrite under both
-            // protocols. UpsertTableIndexOp::acquire_all_intent_op_ and
-            // CatalogAcquireAllOp::acquire_all_intent_op_ already pick OCC for
-            // the same reason.
+            // The cc protocol depends on what the read is for. A plain
+            // catalog read takes a read lock under Locking and waits, as
+            // before. A read for write takes a write intent, and every caller
+            // that asks for one is a DDL command (create/drop collection,
+            // create/drop indexes, rename); DML and queries read the catalog
+            // without the for-write flag. Two such commands touching the same
+            // table therefore both want the write intent, and under Locking
+            // the loser enqueues behind a holder that will not release until
+            // its own schema change completes -- with each side holding what
+            // the other waits for, neither finishes. OCC makes the acquisition
+            // fail instead of enqueueing, so no wait edge is produced and the
+            // caller retries at the command layer. The lock type is unchanged
+            // either way -- DeduceLockType returns WriteIntent for ReadForWrite
+            // under both protocols. UpsertTableIndexOp::acquire_all_intent_op_
+            // and CatalogAcquireAllOp::acquire_all_intent_op_ already pick OCC
+            // for the same reason.
             if (iso_level_ < IsolationLevel::RepeatableRead)
             {
                 read.iso_level_ = IsolationLevel::RepeatableRead;

--- a/tx_service/src/tx_execution.cpp
+++ b/tx_service/src/tx_execution.cpp
@@ -563,6 +563,7 @@ void TransactionExecution::InitTx(IsolationLevel iso_level,
 bool TransactionExecution::CommitTx(CommitTxRequest &commit_req)
 {
     if (rw_set_.DataReadSetSize() == 0 && rw_set_.WriteSetSize() == 0 &&
+        rw_set_.MetaDataReadSetSize() == 0 &&
         rw_set_.CatalogWriteSetSize() == 0 &&
         cmd_set_.ObjectCntWithWriteLock() == 0)
     {

--- a/tx_service/tests/TestNodeSmoke-Test.cpp
+++ b/tx_service/tests/TestNodeSmoke-Test.cpp
@@ -1,6 +1,11 @@
 #include <catch2/catch_all.hpp>
 
+#include "catalog_key_record.h"
 #include "harness/test_node.h"
+#include "tx_execution.h"
+#include "tx_key.h"
+#include "tx_request.h"
+#include "type.h"
 
 using namespace txservice;
 using namespace txservice::test;
@@ -21,6 +26,33 @@ TEST_CASE("TestNode write/read/delete round-trip", "[testnode]")
     {
         auto t = node.BeginTx();
         REQUIRE(t.Commit());
+    }
+
+    // A metadata-only transaction must use the caller-owned close request so
+    // CommitTx does not return before metadata post-processing has completed.
+    constexpr bool close_modes[] = {true, false};
+    for (bool to_commit : close_modes)
+    {
+        auto t = node.BeginTx();
+        CatalogKey catalog_key(node.Table());
+        TxKey tx_key(&catalog_key);
+        CatalogRecord catalog_record;
+        ReadTxRequest read_req(
+            &catalog_ccm_name, 0, &tx_key, &catalog_record, false, false, true);
+        t.Txm()->Execute(&read_req);
+        read_req.Wait();
+        REQUIRE_FALSE(read_req.IsError());
+
+        CommitTxRequest close_req(to_commit);
+        const bool closed = t.Txm()->CommitTx(close_req);
+        CAPTURE(to_commit,
+                closed,
+                close_req.IsFinished(),
+                close_req.IsError(),
+                close_req.ErrorCode());
+        REQUIRE(closed == to_commit);
+        REQUIRE(close_req.IsFinished());
+        REQUIRE_FALSE(close_req.IsError());
     }
 
     // Write 1 -> 100 and commit.


### PR DESCRIPTION
Follow-up to #551, which merged before these two commits landed on its branch.

## 1. `CommitTx` must not fire-and-forget a metadata-only transaction

`CommitTx`'s fast path discards the caller's `CommitTxRequest` and fires the txm-owned `commit_tx_req_` without waiting, returning `true` unconditionally. For a transaction whose only state is a catalog (metadata) read that is wrong on three counts:

* an abort reports success — the fast path returns `true` even when `to_commit_` is false;
* the caller's request is never finished, so `CommitTx()`'s wrapper reads an `ErrorCode` that was never set;
* the catalog read locks are still held when `CommitTx` returns, because releasing them is part of the asynchronous post-processing the caller no longer waits for.

The third is the one that bites. A command that closes and immediately reopens a transaction — `writeConflictRetry` doing exactly that, with no backoff at all for the first four attempts — can keep a catalog entry's reader count permanently non-zero, so a DDL write intent never upgrades and the retry loop cannot converge.

Excluding `MetaDataReadSetSize()` from the fast-path guard routes those transactions through the waiting path, so the locks are released before `CommitTx` returns. The guard's other terms already cover the remaining state: `ForwardWriteCnt() > 0` implies `WriteSetSize() > 0` (both increment sites iterate the write set), and `cmd_set_` is the object-command path that only EloqKV drives.

Measured on EloqDoc's jstest suite (Debug, rocksdb, single node), before → after:

| | before | after |
|---|---|---|
| write conflicts across the run | 63,955 | **0** |
| worst single `createIndexes` | 4,755 retries | — |
| jstests step | 120 min (timed out) | completes |
| 835-test common subset | — | 2.2x faster than `main` |

`TestNodeSmoke` gains coverage for both close modes of a metadata-only transaction.

## 2. Corrected rationale for the catalog fail-fast (docs only)

The read-local comment and `03-concurrency-control` said the catalog entry is "where DDL and DML meet". It is not: every caller that asks for a catalog read-for-write is a DDL path (create/drop collection, create/drop indexes, rename), while DML and queries read the catalog without the flag. The cycle the fail-fast breaks is DDL against DDL on the same table. Behaviour is unchanged; only the description was wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed transactions containing only metadata reads being incorrectly treated as empty during commit.
  * Improved handling of catalog lock conflicts so operations fail promptly instead of entering unnecessary wait states.
  * Ensured close requests complete successfully and return the expected result for metadata-only transactions.

* **Documentation**
  * Clarified catalog locking behavior, lock escalation, and retry handling for schema changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->