### PR TITLE
Avoid cloud object listings during RocksDB Cloud startup

### DIFF
--- a/store_handler/eloq_data_store_service/rocksdb_cloud_data_store.cpp
+++ b/store_handler/eloq_data_store_service/rocksdb_cloud_data_store.cpp
@@ -368,9 +368,10 @@ bool RocksDBCloudDataStore::StartDB(int64_t term)
     // Temp fix for very slow open db issue
     // TODO(monkeyzilla): implement customized sst file manager
     cfs_options_.constant_sst_file_size_in_sst_file_manager = 64 * 1024 * 1024L;
-    // Skip listing cloud files in GetChildren when DumpDBSummary,
-    // SanitizeOptions, Recover(CheckConsistency), WriteOptions to speed up open
-    // db
+    // Skip listing cloud files while opening the DB and persisting the startup
+    // option changes below. Both SetOptions() and SetDBOptions() rewrite the
+    // local OPTIONS file, whose cleanup otherwise lists every object under the
+    // cloud DB path even though OPTIONS files are local-only.
     cfs_options_.skip_cloud_files_in_getchildren = true;
 
     DLOG(INFO) << "RocksDBCloudDataStore::StartDB, purger_periodicity_millis: "
@@ -709,6 +710,14 @@ bool RocksDBCloudDataStore::OpenCloudDB(
         std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
     LOG(INFO) << "DBCloud Open took " << duration.count() << " ms";
 
+    auto restore_cloud_children_listing = [this]()
+    {
+        rocksdb::CloudFileSystem *cfs =
+            dynamic_cast<rocksdb::CloudFileSystem *>(cloud_fs_.get());
+        auto &cfs_options_ref = cfs->GetMutableCloudFileSystemOptions();
+        cfs_options_ref.skip_cloud_files_in_getchildren = false;
+    };
+
     if (!status.ok())
     {
         LOG(ERROR) << "Unable to open db at path " << storage_path_
@@ -718,13 +727,6 @@ bool RocksDBCloudDataStore::OpenCloudDB(
         // db does not exist. This node cannot escalate to be the ng leader.
         return false;
     }
-
-    // Restore skip_cloud_files_in_getchildren to false
-    // after DB::Open
-    rocksdb::CloudFileSystem *cfs =
-        dynamic_cast<rocksdb::CloudFileSystem *>(cloud_fs_.get());
-    auto &cfs_options_ref = cfs->GetMutableCloudFileSystemOptions();
-    cfs_options_ref.skip_cloud_files_in_getchildren = false;
 
     // Stop background work - memtable flush and compaction
     // before blocking purger
@@ -737,6 +739,7 @@ bool RocksDBCloudDataStore::OpenCloudDB(
         db_->Close();
         delete db_;
         db_ = nullptr;
+        restore_cloud_children_listing();
         return false;
     }
 
@@ -751,17 +754,16 @@ bool RocksDBCloudDataStore::OpenCloudDB(
         db_->Close();
         delete db_;
         db_ = nullptr;
+        restore_cloud_children_listing();
         return false;
     }
     if (current_epoch.empty())
     {
         LOG(ERROR) << "Current epoch from db is empty";
+        restore_cloud_children_listing();
         db_->ContinueBackgroundWork();
         return false;
     }
-
-    // Resume background work
-    db_->ContinueBackgroundWork();
 
     // Enable auto compactions after blocking purger
     status = db_->SetOptions({{"disable_auto_compactions", "false"}});
@@ -774,6 +776,7 @@ bool RocksDBCloudDataStore::OpenCloudDB(
         db_->Close();
         delete db_;
         db_ = nullptr;
+        restore_cloud_children_listing();
         return false;
     }
 
@@ -788,8 +791,18 @@ bool RocksDBCloudDataStore::OpenCloudDB(
         db_->Close();
         delete db_;
         db_ = nullptr;
+        restore_cloud_children_listing();
         return false;
     }
+
+    // Restore the normal cloud directory view after startup no longer needs to
+    // rewrite OPTIONS files. Changing this flag does not perform a listing;
+    // later GetChildren() calls retain their original cloud-aware behavior.
+    restore_cloud_children_listing();
+
+    // Resume only after restoring the cloud directory view so background flush
+    // and compaction jobs cannot observe the temporary startup-only setting.
+    db_->ContinueBackgroundWork();
 
     if (cloud_config_.warm_up_thread_num_ != 0)
     {


### PR DESCRIPTION
## Context

During RocksDB Cloud failover, `DBCloud::Open()` completed in 364 ms but `OpenDataStore` took 70.272 s. The startup log contained two approximately 34-second gaps: one at `SetOptions(disable_auto_compactions=false)` and one at `SetDBOptions(max_open_files=-1)`.

Both APIs persist a local OPTIONS file. RocksDB then cleans obsolete OPTIONS files through `GetChildren()`; after `DBCloud::Open()`, EloqDS had already restored `skip_cloud_files_in_getchildren=false`, so each cleanup issued an OBS `ListObjectsV2` over the complete DB object prefix. OPTIONS files are local-only, so those cloud listings do not contribute to correctness.

## Behavior before and after

Before: startup restores cloud-aware directory listing immediately after `DBCloud::Open()`. The two subsequent startup option updates can each list every cloud object, extending failover by roughly the size and latency of two full-prefix listings.

After: cloud listings remain skipped until both startup option updates finish. Normal cloud-aware `GetChildren()` behavior is restored before background work and warm-up resume. Runtime behavior and persisted options are unchanged.

## Implementation

- Keep `skip_cloud_files_in_getchildren=true` through `SetOptions()` and `SetDBOptions()`.
- Keep background flush and compaction paused while the mutable CloudFileSystem option is temporary.
- Restore the option on every post-open success and failure path.
- Resume background work only after restoring the normal cloud directory view.

## Design decisions and alternatives

The change narrows an existing startup-only optimization instead of permanently disabling cloud listings. `GetMutableCloudFileSystemOptions()` exposes the live option object, and `CloudFileSystemImpl::GetChildren()` reads this flag on each call, so no reopen is required.

Leaving the flag permanently enabled was rejected because it would change runtime directory visibility. Restoring it immediately after `DBCloud::Open()` preserves the two expensive startup listings and does not solve the failover delay.

## Test plan

- [ ] Unit/CTest coverage
- [ ] Parent-project integration or manual validation
- [x] Formatting/build checks
- [ ] Recovery, compatibility, or performance validation, when relevant
- [x] Documentation updated, when behavior changed

Commands and results:

```text
clang-format-18 -i store_handler/eloq_data_store_service/rocksdb_cloud_data_store.cpp
# completed

git diff --check origin/main...HEAD
# passed

/usr/bin/c++ <bld-rocksdb-cloud data_substrate compile definitions/includes/flags, with third_party/src/rocksdb-cloud/include first> -fsyntax-only store_handler/eloq_data_store_service/rocksdb_cloud_data_store.cpp
# passed

cmake --build bld-rocksdb-cloud --target data_substrate --parallel 16
# not completed: the existing build tree uses a stale installed rocksdb-cloud
# header and fails on pre-existing code because CloudFileSystemOptions lacks
# publish_file_number_guard. The current rocksdb-cloud submodule header contains
# that member; the modified translation unit passes with the matching header.
```

A production-scale OBS failover timing test was not run in this workspace.

## Risk assessment

Low and startup-scoped. The mutable flag is restored before background work resumes, avoiding concurrent background `GetChildren()` calls observing the temporary value. Failure paths also restore it. No transaction visibility, durability boundary, on-disk format, or cloud object lifecycle behavior changes.

The main residual risk is that an unrecognized synchronous startup operation between DB open and restoration requires cloud-only directory entries. Existing DB open already runs with listings skipped, and the added interval contains epoch validation plus local OPTIONS persistence.

## Rollback plan

Revert this PR. That restores the previous timing of the option reset and the two cloud-aware startup cleanups; no data or configuration migration is required.

## Reviewer guide

Review `RocksDBCloudDataStore::OpenCloudDB()` and verify these invariants:

1. `skip_cloud_files_in_getchildren` stays true across both startup option writes.
2. Every return after successful DB open restores the flag when needed.
3. Background work resumes only after the flag is false.
4. Normal runtime and warm-up run with cloud-aware listing restored.

## Follow-up work

Run an OBS deployment failover benchmark and confirm the two approximately 34-second gaps disappear.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved cloud-backed database startup recovery when initialization encounters an error.
  - Restored normal cloud directory listings after failed startup attempts.
  - Preserved configuration settings during database startup, improving consistency for subsequent operations.
  - Ensured background processing resumes with the correct cloud storage behavior after recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->