### PR TITLE
fix: ccentry range split cluster verify

### DIFF
--- a/tx_service/include/cc/cc_req_misc.h
+++ b/tx_service/include/cc/cc_req_misc.h
@@ -1156,11 +1156,13 @@ public:
         NodeGroupId node_group_id,
         int64_t term,
         const TableName &table_name,
-        absl::flat_hash_map<size_t, std::vector<CkptTsEntry>> &cce_entries)
+        absl::flat_hash_map<size_t, std::vector<CkptTsEntry>> &cce_entries,
+        bool update_ckpt_ts)
         : cce_entries_(cce_entries),
           node_group_id_(node_group_id),
           term_(term),
-          table_name_(table_name)
+          table_name_(table_name),
+          update_ckpt_ts_(update_ckpt_ts)
     {
         unfinished_core_cnt_ = cce_entries_.size();
         assert(unfinished_core_cnt_ > 0);
@@ -1253,6 +1255,7 @@ private:
     NodeGroupId node_group_id_;
     int64_t term_;
     TableName table_name_;
+    bool update_ckpt_ts_;
     mutable bthread::Mutex mux_;
     bthread::ConditionVariable cv_;
 

--- a/tx_service/include/cc/cc_request.h
+++ b/tx_service/include/cc/cc_request.h
@@ -6226,8 +6226,8 @@ public:
         case CleanType::CleanBucketData:
         {
             // Cannot clean entries being checkpointed — the checkpoint
-            // callback (UpdateCceCkptTsCc) will decrement dirty count,
-            // and cleaning here would cause a double-decrement.
+            // callback still owns the cce pointer and normally decrements the
+            // dirty count, so cleaning here could cause a double-decrement.
             //
             // An alternative approach would be to have
             // DataSyncForHashPartition acquire bucket read locks (as

--- a/tx_service/include/data_sync_task.h
+++ b/tx_service/include/data_sync_task.h
@@ -253,6 +253,8 @@ public:
     bool during_split_range_{false};
     bool export_base_table_items_{false};
     uint64_t tx_number_{0};
+    // Core that owns source CCEs collected while flushing a split range.
+    uint16_t cce_owner_core_{0};
 
     bthread::Mutex update_cce_mux_;
     std::string kv_table_name_;

--- a/tx_service/src/cc/cc_req_misc.cpp
+++ b/tx_service/src/cc/cc_req_misc.cpp
@@ -1332,15 +1332,48 @@ bool UpdateCceCkptTsCc::Execute(CcShard &ccs)
 
     size_t last_index = std::min(index + SCAN_BATCH_SIZE, records.size());
 
-    CcMap *ccm = ccs.GetCcm(table_name_, node_group_id_);
-    assert(ccm != nullptr);
-
     bool range_partitioned = !table_name_.IsHashPartitioned();
     bool versioned_payload = table_name_.Engine() != TableEngine::EloqKv;
+    CcMap *ccm = nullptr;
+    if (update_ckpt_ts_)
+    {
+        ccm = ccs.GetCcm(table_name_, node_group_id_);
+        assert(ccm != nullptr);
+    }
 
     for (; index < last_index; ++index)
     {
         const CkptTsEntry &ref = records[index];
+        if (!update_ckpt_ts_)
+        {
+            // The split copy is durable under its destination range, but the
+            // source cce remains dirty. Only release its in-flight state.
+            if (range_partitioned)
+            {
+                if (versioned_payload)
+                {
+                    static_cast<VersionedLruEntry<true, true> *>(ref.cce_)
+                        ->ClearBeingCkpt();
+                }
+                else
+                {
+                    static_cast<VersionedLruEntry<false, true> *>(ref.cce_)
+                        ->ClearBeingCkpt();
+                }
+            }
+            else if (versioned_payload)
+            {
+                static_cast<VersionedLruEntry<true, false> *>(ref.cce_)
+                    ->ClearBeingCkpt();
+            }
+            else
+            {
+                static_cast<VersionedLruEntry<false, false> *>(ref.cce_)
+                    ->ClearBeingCkpt();
+            }
+            continue;
+        }
+
         if (range_partitioned)
         {
             if (versioned_payload)

--- a/tx_service/src/cc/cc_req_misc.cpp
+++ b/tx_service/src/cc/cc_req_misc.cpp
@@ -1346,29 +1346,18 @@ bool UpdateCceCkptTsCc::Execute(CcShard &ccs)
         const CkptTsEntry &ref = records[index];
         if (!update_ckpt_ts_)
         {
+            assert(range_partitioned);
+
             // The split copy is durable under its destination range, but the
             // source cce remains dirty. Only release its in-flight state.
-            if (range_partitioned)
+            if (versioned_payload)
             {
-                if (versioned_payload)
-                {
-                    static_cast<VersionedLruEntry<true, true> *>(ref.cce_)
-                        ->ClearBeingCkpt();
-                }
-                else
-                {
-                    static_cast<VersionedLruEntry<false, true> *>(ref.cce_)
-                        ->ClearBeingCkpt();
-                }
-            }
-            else if (versioned_payload)
-            {
-                static_cast<VersionedLruEntry<true, false> *>(ref.cce_)
+                static_cast<VersionedLruEntry<true, true> *>(ref.cce_)
                     ->ClearBeingCkpt();
             }
             else
             {
-                static_cast<VersionedLruEntry<false, false> *>(ref.cce_)
+                static_cast<VersionedLruEntry<false, true> *>(ref.cce_)
                     ->ClearBeingCkpt();
             }
             continue;

--- a/tx_service/src/cc/local_cc_shards.cpp
+++ b/tx_service/src/cc/local_cc_shards.cpp
@@ -6111,7 +6111,7 @@ void LocalCcShards::FlushDataImpl(FlushDataTask *cur_work,
     }
 
     std::unordered_set<uint16_t> updated_ckpt_ts_core_ids;
-    // Update cce ckpt ts in memory
+    // Finalize in-memory state for successfully flushed CCEs.
     if (succ)
     {
         size_t iterations_since_yield = 0;
@@ -6121,17 +6121,14 @@ void LocalCcShards::FlushDataImpl(FlushDataTask *cur_work,
         {
             for (auto &entry : entries)
             {
-                if (!entry->data_sync_task_->need_update_ckpt_ts_)
-                {
-                    continue;
-                }
-
                 absl::flat_hash_map<size_t,
                                     std::vector<UpdateCceCkptTsCc::CkptTsEntry>>
                     cce_entries_map;
 
                 auto &table_name =
                     entries.front()->data_sync_task_->table_name_;
+                bool update_ckpt_ts =
+                    entry->data_sync_task_->need_update_ckpt_ts_;
 
                 for (auto &rec : *(entry->data_sync_vec_))
                 {
@@ -6139,7 +6136,14 @@ void LocalCcShards::FlushDataImpl(FlushDataTask *cur_work,
                     if (cce != nullptr)
                     {
                         size_t key_core_idx = 0;
-                        if (!table_name.IsHashPartitioned())
+                        if (!update_ckpt_ts)
+                        {
+                            // Split scans collected these CCEs from the source
+                            // range; id_ identifies the destination range.
+                            key_core_idx =
+                                entry->data_sync_task_->cce_owner_core_;
+                        }
+                        else if (!table_name.IsHashPartitioned())
                         {
                             int32_t range_id = entry->data_sync_task_->id_;
                             key_core_idx = static_cast<size_t>(
@@ -6163,11 +6167,15 @@ void LocalCcShards::FlushDataImpl(FlushDataTask *cur_work,
                         entry->data_sync_task_->node_group_id_,
                         entry->data_sync_task_->node_group_term_,
                         table_name,
-                        cce_entries_map);
+                        cce_entries_map,
+                        update_ckpt_ts);
                     update_cce_req.SetCoroCallbacks(&yield_fn, &resume_fn);
                     for (auto &[core_idx, cce_entries] : cce_entries_map)
                     {
-                        updated_ckpt_ts_core_ids.insert(core_idx);
+                        if (update_ckpt_ts)
+                        {
+                            updated_ckpt_ts_core_ids.insert(core_idx);
+                        }
                         EnqueueToCcShard(core_idx, &update_cce_req);
                     }
 

--- a/tx_service/src/data_sync_task.cpp
+++ b/tx_service/src/data_sync_task.cpp
@@ -104,6 +104,7 @@ DataSyncTask::DataSyncTask(const TableName &table_name,
     int32_t old_range_id = range_entry_->GetRangeInfo()->PartitionId();
     uint16_t old_range_owner_shard =
         static_cast<uint16_t>((old_range_id & 0x3FF) % local_shard_count);
+    cce_owner_core_ = old_range_owner_shard;
     uint16_t new_range_owner_shard =
         static_cast<uint16_t>((id_ & 0x3FF) % local_shard_count);
     need_update_ckpt_ts_ =


### PR DESCRIPTION
## Context

A data import stopped after TiDoc returned the Mongo-compatible error `ExceededMemoryLimit: Transaction failed due to out of memory`. Afterward, TiDoc repeatedly logged:

```text
Failed to clean all target ccentries
```

The cleanup storm was caused by a cross-core range split leaving source CCEntries permanently marked as `BeingCkpt`.

## Behavior before and after

Before this change:

- A range split could collect CCEntries from one core and persist them under a destination range owned by another core.
- The successful flush path skipped post-flush processing when the source checkpoint timestamp must not be updated.
- `BeingCkpt` remained set on the source CCEntries.
- Cleanup correctly refused to remove entries still marked as being checkpointed, so retries repeatedly emitted `Failed to clean all target ccentries`.

After this change:

- Successful cross-core split flushes finalize the source CCEntries on their owning core.
- Only `BeingCkpt` is cleared for cross-core split copies.
- The source checkpoint timestamp, dirty count, and data-store size remain unchanged.
- Normal checkpoint flush behavior is unchanged.
- There are no wire-format, storage-format, or Mongo API compatibility changes.

## Implementation

- Record the source CCEntry owner core in `DataSyncTask` when creating a range-split data-sync task.
- Update `LocalCcShards::FlushDataImpl()` to finalize all successfully flushed CCEntries, including entries whose checkpoint timestamp must not be updated.
- Route cross-core split finalization back to the source CCEntry core instead of deriving the core from the destination range.
- Add an explicit mode to `UpdateCceCkptTsCc`:
  - Normal checkpoint mode updates checkpoint metadata and clears `BeingCkpt`.
  - Cross-core split mode clears only `BeingCkpt`.
- Preserve the existing term validation and batched CC-request execution model.

## Design decisions and alternatives

The source CCEntry remains dirty because the split copy is durable under the destination range, not as a checkpoint of the source range. Updating the source checkpoint timestamp, dirty count, or data-store size would incorrectly treat the source entry as fully checkpointed.

Finalization is dispatched to the source owner core to preserve the existing invariant that CCEntry state is accessed only by its owning `CcShard`.

## Test plan

- [ ] Unit/CTest coverage — not run; the reproduced scenario requires a multi-core range split.
- [x] Parent-project integration or manual validation
- [x] Formatting/build checks
- [x] Recovery, compatibility, or performance validation, when relevant
- [x] Documentation reviewed — no update required because no public API, protocol, configuration, or persistence semantics changed.

Commands and results:

```text
git diff --check
# PASS

cmake --build \
  src/mongo/db/modules/eloq/build-centos7-aarch64 \
  --target txservice -j
# PASS

Observed cross-core range splits:
- 3194 -> 3195
- 3193 -> 3196
- 1445 -> 1450

Baseline result:
- "Failed to clean all target ccentries" reproduced within approximately
  30–40 seconds on the same data.

Patched result:
- Zero occurrences of "Failed to clean all target ccentries" during the
  validation window.
```

## Risk assessment

The behavioral change is limited to successful range-split flush finalization when the source and destination ranges map to different cores.

Concurrency risk is controlled by dispatching finalization to the source owner core and retaining the existing node-group term validation.

Durability behavior is unchanged: `BeingCkpt` is cleared only after persistence succeeds. Cross-core split copies do not advance the source checkpoint metadata.

There are no on-disk, RPC, Mongo protocol, or KV client compatibility changes.

## Rollback plan

Revert this PR and rebuild/deploy the previous ABI-matched Eloq/TiDoc library set.

No data migration or storage rollback is required.

## Reviewer guide

The highest-value review points are:

- `DataSyncTask` range-split constructor:
  - Verify that `cce_owner_core_` is derived from the source range ID.
- `LocalCcShards::FlushDataImpl()`:
  - Verify that cross-core split CCEntries are dispatched to their source owner core.
  - Verify that checkpoint metadata tracking remains limited to normal checkpoint updates.
- `UpdateCceCkptTsCc::Execute()`:
  - Verify that cross-core split mode clears only `BeingCkpt`.
  - Verify that normal checkpoint behavior remains unchanged.
  - Verify that CCEntry type selection remains consistent for range/hash partitioning and versioned/non-versioned payloads.

The main invariant is that a source CCEntry copied during a cross-core split remains dirty but must no longer remain marked as actively checkpointing after the destination copy is durable.

## Follow-up work

- Add targeted automated coverage for cross-core range-split checkpoint finalization when a suitable multi-core test harness is available.
- Handle recovery-period retry log rate limiting separately; it is intentionally outside the scope of this fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved data synchronization when checkpoint timestamps do not need updating.
  * Prevented duplicate checkpoint processing and incorrect dirty-state notifications.
  * Improved handling of dropped, already-synchronized, or non-owner data ranges.
  * Prevented metadata operations from being blocked during long-running synchronization actions.
  * Improved checkpoint ownership handling during split-range synchronization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->