### PR TITLE
Demote promoted dirty-range slices when their cached data is evicted

### DIFF
--- a/tx_service/include/cc/local_cc_shards.h
+++ b/tx_service/include/cc/local_cc_shards.h
@@ -1614,6 +1614,15 @@ public:
                     range_entry->PinStoreRange());
                 if (store_range == nullptr)
                 {
+                    // The keys are kicked without slice bookkeeping (no
+                    // StoreRange in memory on this node, e.g. forwarded
+                    // dirty-range data on the new owner during a split).
+                    // The pending-split slice specs cached on this entry
+                    // may have been promoted to FullyCached based on these
+                    // keys being memory-resident, so invalidate them;
+                    // otherwise the new range would be installed with
+                    // hollow FullyCached slices after the split commits.
+                    range_entry->SetAcceptsDirtyRangeData(false);
                     clean_guard->MarkCleanForOrphanKey(idx);
                     idx++;
                     continue;

--- a/tx_service/include/range_record.h
+++ b/tx_service/include/range_record.h
@@ -787,7 +787,42 @@ public:
 
         if (dirty_range_slices_ != nullptr)
         {
+            if (!accept && !std::get<0>(*dirty_range_slices_))
+            {
+                // Already invalidated (and any promoted slices demoted).
+                return;
+            }
             std::get<0>(*dirty_range_slices_) = accept;
+            if (!accept)
+            {
+                // Dirty-range data cached for the pending split has been
+                // (at least partially) evicted from memory. Any slice that
+                // was promoted to FullyCached no longer holds its complete
+                // content in memory, so demote every promoted slice back to
+                // PartiallyCached. Otherwise the new range would trust
+                // memory as authoritative after the split commits and never
+                // consult the data store for the evicted keys.
+                size_t demoted = 0;
+                for (auto &new_range_slices : std::get<2>(*dirty_range_slices_))
+                {
+                    for (auto &slice : new_range_slices.second)
+                    {
+                        if (slice.status_ == SliceStatus::FullyCached)
+                        {
+                            slice.status_ = SliceStatus::PartiallyCached;
+                            demoted++;
+                        }
+                    }
+                }
+                if (demoted > 0)
+                {
+                    LOG(WARNING)
+                        << "SLICE_DEMOTE range#" << range_info_.PartitionId()
+                        << " demoted=" << demoted
+                        << " dirty slices to PartiallyCached after dirty "
+                           "range data eviction";
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## Problem

During a range split, the future owner receives forwarded data batches (cache sync) and promotes the pending slice specs in `TableRangeEntry::dirty_range_slices_` to `FullyCached` per delivered batch. The promotion is legal at that moment — but when OOM cache cleaning later evicts those cc entries, the incubator is never told:

1. On the future owner, the **old** range entry has no StoreRange in memory, so the clean path takes the `MarkCleanForOrphanKey` branch — which kicked the keys **without** calling `SetAcceptsDirtyRangeData(false)` (structural: forwarded split data on a non-owner always lands here).
2. Even where `SetAcceptsDirtyRangeData(false)` was called, it only blocked *future* promotions; already-promoted slices stayed `FullyCached`.

PostWriteAll then installs the new range with **hollow FullyCached slices**: reads and uniqueness checks treat memory as authoritative and never consult the data store (whose data is intact). Symptoms: committed keys appear lost in contiguous runs, inserts of existing `_id`s pass the dup-check (silent overwrite on next reload), until a node restart rebuilds slices from store specs as PartiallyCached and everything "reappears".

## Fix

- `SetAcceptsDirtyRangeData(false)` now demotes every promoted slice in the incubator back to `PartiallyCached`, with an idempotent fast path so per-key orphan invocations stay cheap.
- The orphan clean branch (`PinStoreRange() == nullptr`) invalidates the incubator before kicking the keys.

Semantics: if the future owner is already evicting cache-sync data during the sync, the node is under memory pressure and should stop accepting the sync; subsequent `UploadBatchSlicesCc` batches are rejected by the existing `accepts` check, and the whole pending range degrades to PartiallyCached (one store miss on first touch — correct, just cold).

## Verification

3-node cluster, `node_memory_limit_mb=200`, 60k × 20KB mongorestore workload that deterministically reproduced the hollow-slice loss (missing runs of thousands of `_id`s while the dss held all 60,000 rows):

- before: installed specs showed `total==fully` for every split range; contiguous key ranges unreadable until restart
- after: demotion fires on every split (`demoted=1431…6336`), installed specs contain no stale FullyCached slices, and **all 60,000 documents are readable after the import with no restart**

Known separate issue (not addressed here): under memory pressure, scans silently return empty results for PartiallyCached slices whose load is rejected, causing transient false-misses until the checkpointer frees memory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup of orphaned range data when its in-memory state is unavailable.
  * Prevented stale cached range slices from being treated as authoritative after dirty data is invalidated.
  * Improved handling of pending split metadata during range-data invalidation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->