### PR TITLE
fix: limit range partition flush batch size

### DIFF
--- a/tx_service/include/cc/cc_request.h
+++ b/tx_service/include/cc/cc_request.h
@@ -3945,7 +3945,8 @@ public:
         bool export_base_table_item_only = false,
         StoreRange *store_range = nullptr,
         const std::map<TxKey, int64_t> *old_slices_delta_size = nullptr,
-        uint64_t schema_version = 0)
+        uint64_t schema_version = 0,
+        uint64_t flush_data_size_limit = 0)
         : scan_heap_is_full_(false),
           table_name_(&table_name),
           node_group_id_(node_group_id),
@@ -3963,7 +3964,8 @@ public:
           slice_coordinator_(export_base_table_item_, &slices_to_scan_),
           export_base_table_item_only_(export_base_table_item_only),
           store_range_(store_range),
-          schema_version_(schema_version)
+          schema_version_(schema_version),
+          flush_data_size_limit_(flush_data_size_limit)
     {
         tx_number_ = txn;
         assert(scan_batch_size_ > DataSyncScanBatchSize);
@@ -4288,6 +4290,12 @@ public:
     uint32_t scan_heap_is_full_{0};
 
 private:
+    bool HasReachedFlushDataSizeLimit() const
+    {
+        return flush_data_size_limit_ > 0 &&
+               accumulated_flush_data_size_ >= flush_data_size_limit_;
+    }
+
     struct SliceCoordinator
     {
         static constexpr uint16_t MaxBatchSliceCount = 128;
@@ -4453,6 +4461,10 @@ private:
     // scan is part of range split which block the schema change
     // TODO(xxx) general solution for #1130
     const uint64_t schema_version_{0};
+    // Maximum payload bytes exported in one flush batch. Zero disables the
+    // limit for callers, such as secondary-index generation, that do not
+    // produce flush batches.
+    const uint64_t flush_data_size_limit_{0};
 
     OpType op_type_{OpType::Normal};
 

--- a/tx_service/include/cc/template_cc_map.h
+++ b/tx_service/include/cc/template_cc_map.h
@@ -5148,7 +5148,8 @@ public:
         for (size_t scan_cnt = 0;
              key_it != slice_end_it && key_it != slice_end_next_page_it &&
              scan_cnt < RangePartitionDataSyncScanCc::DataSyncScanBatchSize &&
-             req.accumulated_scan_cnt_ < req.scan_batch_size_;
+             req.accumulated_scan_cnt_ < req.scan_batch_size_ &&
+             !req.HasReachedFlushDataSizeLimit();
              ++scan_cnt)
         {
             const KeyT *key = key_it->first;
@@ -5296,8 +5297,8 @@ public:
         } /* End of loop */
 
         // The conditions for exiting the main loop are: reaching the maximum
-        // scan batch size, or reach to the end slice of the current batch
-        // slices.
+        // scan batch size or flush data size, or reaching the end slice of the
+        // current batch slices.
         assert((key_it != slice_end_it && key_it != slice_end_next_page_it) ||
                req.TheBatchEnd());
         // 4. Check whether the request is finished.
@@ -5326,6 +5327,7 @@ public:
 
         if (is_scan_mem_full || no_more_data ||
             req.accumulated_scan_cnt_ >= req.scan_batch_size_ ||
+            req.HasReachedFlushDataSizeLimit() ||
             req.TheBatchEnd())
         {
             // Request is finished

--- a/tx_service/include/cc/template_cc_map.h
+++ b/tx_service/include/cc/template_cc_map.h
@@ -5327,8 +5327,7 @@ public:
 
         if (is_scan_mem_full || no_more_data ||
             req.accumulated_scan_cnt_ >= req.scan_batch_size_ ||
-            req.HasReachedFlushDataSizeLimit() ||
-            req.TheBatchEnd())
+            req.HasReachedFlushDataSizeLimit() || req.TheBatchEnd())
         {
             // Request is finished
             req.SetFinish();

--- a/tx_service/src/cc/local_cc_shards.cpp
+++ b/tx_service/src/cc/local_cc_shards.cpp
@@ -4252,6 +4252,14 @@ void LocalCcShards::DataSyncForRangePartition(
     // same Key can be generated. Our subsequent algorithms are based on this
     // assumption.
 
+    assert(worker_idx < cur_flush_buffers_.size());
+    // Keep one range scan batch within a quarter of this worker's flush
+    // buffer, leaving room for other batches accumulated by the same worker.
+    const uint64_t range_partition_data_sync_scan_data_size =
+        std::max<uint64_t>(
+            1,
+            cur_flush_buffers_[worker_idx]->GetFlushBufferSize() / 4);
+
     RangePartitionDataSyncScanCc scan_cc(table_name,
                                          data_sync_task->data_sync_ts_,
                                          ng_id,
@@ -4265,7 +4273,8 @@ void LocalCcShards::DataSyncForRangePartition(
                                          false,
                                          store_range,
                                          &slices_delta_size,
-                                         schema_version);
+                                         schema_version,
+                                         range_partition_data_sync_scan_data_size);
 
     {
         // DataSync Worker will call PostProcessDataSyncTask() to decrement

--- a/tx_service/src/cc/local_cc_shards.cpp
+++ b/tx_service/src/cc/local_cc_shards.cpp
@@ -4257,24 +4257,24 @@ void LocalCcShards::DataSyncForRangePartition(
     // buffer, leaving room for other batches accumulated by the same worker.
     const uint64_t range_partition_data_sync_scan_data_size =
         std::max<uint64_t>(
-            1,
-            cur_flush_buffers_[worker_idx]->GetFlushBufferSize() / 4);
+            1, cur_flush_buffers_[worker_idx]->GetFlushBufferSize() / 4);
 
-    RangePartitionDataSyncScanCc scan_cc(table_name,
-                                         data_sync_task->data_sync_ts_,
-                                         ng_id,
-                                         ng_term,
-                                         DATA_SYNC_SCAN_BATCH_SIZE,
-                                         tx_number,
-                                         &start_tx_key,
-                                         &end_tx_key,
-                                         last_sync_ts,
-                                         export_base_table_items,
-                                         false,
-                                         store_range,
-                                         &slices_delta_size,
-                                         schema_version,
-                                         range_partition_data_sync_scan_data_size);
+    RangePartitionDataSyncScanCc scan_cc(
+        table_name,
+        data_sync_task->data_sync_ts_,
+        ng_id,
+        ng_term,
+        DATA_SYNC_SCAN_BATCH_SIZE,
+        tx_number,
+        &start_tx_key,
+        &end_tx_key,
+        last_sync_ts,
+        export_base_table_items,
+        false,
+        store_range,
+        &slices_delta_size,
+        schema_version,
+        range_partition_data_sync_scan_data_size);
 
     {
         // DataSync Worker will call PostProcessDataSyncTask() to decrement


### PR DESCRIPTION
 This is a follow-up to #558. Slice preparation is now bounded, but the subsequent range-partition data-
  sync scan can still produce a flush batch that is too large for the checkpoint memory budget.

  The total data-sync flush quota  is calculated as:

  ```text
  flush_data_mem_quota
    = node_memory_limit * ckpt_buffer_ratio
  ```
  In my case, with node_memory_limit set to 2 GiB, flush_data_mem_quota is 256MB

  This quota is divided among the data-sync workers when constructing their current flush buffers. Before
  this change, range-partition scans were primarily bounded by record count rather than exported payload
  size, so large values could still produce an oversized batch.

  ### Observed failure

  In the affected deployment:

  1. A range grew beyond approximately 256 MiB and triggered a range split.
  2. The split transaction wrote its `PrepareSplit` log, installed the dirty range state, enabled splitting/
  forwarding, and retained the range write intent.
  3. The split data-sync task generated batches with approximately 135–158 MiB of exported payload. The
  final `flush_data_size` also included `FlushRecord` and vector allocation overhead.
  4. When a single accounted flush object exceeded the 256 MiB controller quota,
  `DataSyncMemoryController::AllocateFlushDataMemQuota()` deliberately admitted it to preserve checkpoint
  progress:

     ```cpp
     if (quota > flush_data_mem_quota_)
     {
         LOG(WARNING) << "Flush object is too large ...";
         return true;
     }
     ```

     This produced the observed log:

     ```text
     Flush object is too large ... flush data mem quota ...
     ```

  5. Admitting the oversized object caused additional shard memory pressure and eventually OOM. The range
  data-sync scan then failed with `SCAN_ERROR`.
  6. For a split-range task, the `SCAN_ERROR` path resets the error and puts the same task back at the front
  of the same worker queue. It has no retry limit or backoff and does not abort the parent split transaction
  or release its range write intent.
  7. The same range was therefore scanned again, hit OOM again, and was requeued at the front again. Other
  checkpoint tasks assigned to the worker were also starved.
  8. The parent split transaction remained at `PrepareSplit` (stage 0). It never reached `CommitSplit` or
  `CleanSplit`, so the range remained in splitting/forwarding state and the range write intent stayed held.
  9. Checkpoint progress and log truncation were blocked, making memory reclamation more difficult and
  reinforcing the cycle:

     ```text
     OOM -> front-of-queue retry -> checkpoint stalls
         -> memory cannot be reclaimed -> OOM again
     ```

  Other nodes periodically detected the long-held range lock:

  ```text
  orphan lock detected ... try to recover
  ```

  However, recovery found that the coordinator still reported the parent split transaction as ongoing:

  ```text
  The tx ... is ongoing. Does nothing for recovery.
  ```

  Recovery therefore could not take over or release the lock. The externally visible failure was a range-
  split livelock with repeated orphan-lock detection, rather than only a transient memory spike.

  ## Behavior before and after

  Before:

  - Range-partition scans stopped based on record count, scan-heap pressure, or scan completion.
  - Variable-sized values could produce a single flush batch larger than its worker's intended flush-buffer
  budget.
  - An oversized allocation could bypass the global data-sync quota and trigger the OOM/retry livelock
  described above.

  After:

  - Each range-partition scan receives an explicit exported-payload limit derived from one quarter of its
  worker's flush-buffer capacity.
  - Once the accumulated payload reaches that limit, the current scan batch finishes and the next batch
  resumes from the existing pause position.
  - Split data is emitted as smaller flush tasks, preventing one scan batch from consuming the checkpoint
  memory budget and triggering the observed failure chain.
  - Callers that do not produce flush batches, such as secondary-index generation, retain the previous
  behavior.

  There are no external API, persistent-format, or configuration changes.

  ## Implementation

  - Add an optional `flush_data_size_limit` argument to `RangePartitionDataSyncScanCc`.
  - Use zero as the default value to disable the limit for non-flush callers.
  - Add `HasReachedFlushDataSizeLimit()` based on `accumulated_flush_data_size_`.
  - Check the limit before exporting another record and when deciding whether the current scan request is
  complete.
  - Derive the limit in `LocalCcShards::DataSyncForRangePartition()` as:

    ```text
    worker_flush_buffer
        = flush_data_mem_quota / data_sync_worker_num

    range_scan_payload_limit
        = max(1, worker_flush_buffer / 4)
    ```

  - Preserve the existing pause/resume, flush, range-split, and checkpoint control flow.

  ## Design decisions and alternatives

  The limit uses actual accumulated payload bytes instead of record count because record count cannot bound
  memory usage when values have significantly different sizes.

  One quarter of the worker buffer leaves capacity for other batches accumulated by the same worker and for
  memory overhead that is added to `flush_data_size` after payload generation.

  The threshold is intentionally a soft limit. An individual record may take the batch past the threshold,
  after which the scan stops. This guarantees forward progress even when one record is larger than the batch
  target.

  A zero limit preserves the existing behavior for callers such as secondary-index generation that reuse
  `RangePartitionDataSyncScanCc` but do not create flush batches.

  This PR prevents the oversized range-scan batch that initiates the incident. It does not change the memory
  controller's oversized-object bypass or the existing unbounded `SCAN_ERROR` retry policy.

  ## Test plan

  - [x] Reproduce with `node_memory_limit_mb=2048` and a range larger than the split threshold
  - [x] Verify range-split scan batches stop near the calculated per-worker payload limit
  - [x] Verify the split reaches `CommitSplit` and `CleanSplit`
  - [x] Verify the parent transaction completes and releases the range write intent
  - [x] Verify other checkpoint tasks on the same worker continue to make progress
  - [x] Verify checkpoint/log-truncation progress is restored
  - [x] Formatting/whitespace validation


  Commands and results:

  ```text
  git diff --check refs/remotes/upstream/main...HEAD
  # PASS
  ```

  overhead and an individually oversized record may still take the final allocation above the target, which
  is why the limit reserves most of the worker buffer as headroom.

  The change does not alter record selection, checkpoint timestamps, persistence formats, or recovery
  semantics. Existing pause-position handling ensures that records after the size boundary are processed by
  a subsequent batch.

  ## Rollback plan

  Revert this PR. No configuration or data migration rollback is required.

  ## Reviewer guide

  Please focus on:

  - `RangePartitionDataSyncScanCc` default-disabled limit and reset behavior.
  - The scan-loop exit conditions in `template_cc_map.h`, especially pause-position preservation and forward
  progress.
  - The per-worker buffer calculation in `LocalCcShards::DataSyncForRangePartition()`.
  - The relationship between `accumulated_flush_data_size_` and the final `flush_data_size` passed to
  `AllocateFlushDataMemQuota()`.
  - Ensuring secondary-index generation remains unaffected through the default zero limit.

  ## Follow-up work

  - Add a focused regression test for payload-based range scan batching and the split-livelock scenario.
  - Add bounded retry/backoff or terminal handling for repeatedly failing split-range `SCAN_ERROR` tasks.
  - Revisit the oversized-object bypass in `AllocateFlushDataMemQuota()` so a single allocation cannot
  undermine the global memory budget.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable data-size limits for range-partition synchronization scans.
  * Scans now stop early when the configured flush-data threshold is reached.
  * Automatic per-worker limits help control memory used by scan batches.

* **Bug Fixes**
  * Prevented synchronization scans from accumulating excessive flush data before completing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->