### PR TITLE
feat: log checkpoint trigger reasons

### DIFF
--- a/docs/07-durability-and-recovery.md
+++ b/docs/07-durability-and-recovery.md
@@ -84,6 +84,8 @@ The log service keeps multi-stage records in its state machine until the Clean r
 
 Notification sources: tx processors that find nothing clean to evict (`CcShard::NotifyCkpt`), the dirty-memory trigger (§3.5), the log service's `NotifyCheckpointer` RPC (§1.2), data-sync workers running dry, and shutdown.
 
+Accepted checkpoint requests always log at INFO: `Checkpoint requested: reason=memory_pressure` (eviction cannot free entries), `reason=dirty_memory_threshold` (the configured threshold, default 10% of the per-shard memory limit), or `reason=explicit_request` (other explicit notifications). Rate-limited and coalesced requests do not log again. The checkpointer logs `Checkpoint triggered: reason=timer` with the interval for periodic rounds and `reason=shutdown` for the final round. These trigger logs do not depend on `report_ckpt`. A request log records acceptance, not completion; the existing per-node-group begin/completion logs describe checkpoint progress.
+
 ### 3.2 Choosing the checkpoint ts — `GetNewCheckpointTs`
 
 `GetNewCheckpointTs(ng, is_last_ckpt)` (`checkpointer.cpp:98-139`) broadcasts a `CkptTsCc` to every shard (`tx_service/include/cc/cc_request.h:2983-3156`) and takes the minimum:

--- a/tx_service/include/cc/cc_shard.h
+++ b/tx_service/include/cc/cc_shard.h
@@ -501,8 +501,11 @@ public:
      * @param request_ckpt If true, request a new checkpoint. If false, just
      * notify the checkpoint thread to check whether there is a pending
      * checkpoint request.
+     * @param reason Diagnostic label forwarded to the checkpointer; consumed
+     * synchronously and ignored when request_ckpt is false.
      */
-    void NotifyCkpt(bool request_ckpt = true);
+    void NotifyCkpt(bool request_ckpt = true,
+                    const char *reason = "explicit_request");
 
     /**
      * @brief Dispatch heavy cpu-bound task, e.g. StoreRange::LoadSlice().

--- a/tx_service/include/checkpointer.h
+++ b/tx_service/include/checkpointer.h
@@ -93,8 +93,11 @@ public:
      * from ccmap. This will also be called by data sync worker thread when
      * it runs out of task.
      * @param  request_ckpt  If true, will request checkpoint immediately.
+     * @param reason Diagnostic label logged only when a request is accepted;
+     * consumed synchronously and ignored when request_ckpt is false.
      */
-    void Notify(bool request_ckpt = true);
+    void Notify(bool request_ckpt = true,
+                const char *reason = "explicit_request");
 
     bool IsTerminated();
 

--- a/tx_service/src/cc/cc_req_misc.cpp
+++ b/tx_service/src/cc/cc_req_misc.cpp
@@ -1658,7 +1658,7 @@ bool ShardCleanCc::Execute(CcShard &ccs)
                 if (free_count_ == 0 && !shard_heap->IsDefragHeapCcOnFly() &&
                     !Sharder::Instance().GetCheckpointer()->IsOngoingDataSync())
                 {
-                    ccs.NotifyCkpt(true);
+                    ccs.NotifyCkpt(true, "memory_pressure");
                 }
 
                 free_count_ = 0;

--- a/tx_service/src/cc/cc_shard.cpp
+++ b/tx_service/src/cc/cc_shard.cpp
@@ -538,7 +538,7 @@ void CcShard::CheckAndTriggerCkptByDirtyMemory()
                    << "MB), dirty_keys=" << dirty_data_key_count_ << "/"
                    << data_key_count_;
 
-        NotifyCkpt(true);  // Request immediate checkpoint
+        NotifyCkpt(true, "dirty_memory_threshold");
     }
 }
 
@@ -1767,11 +1767,11 @@ bool CcShard::FlushEntryForTest(
     }
 }
 
-void CcShard::NotifyCkpt(bool request_ckpt)
+void CcShard::NotifyCkpt(bool request_ckpt, const char *reason)
 {
     if (ckpter_ != nullptr)
     {
-        ckpter_->Notify(request_ckpt);
+        ckpter_->Notify(request_ckpt, reason);
     }
 }
 

--- a/tx_service/src/checkpointer.cpp
+++ b/tx_service/src/checkpointer.cpp
@@ -746,6 +746,11 @@ void Checkpointer::Run()
         }
 
         last_checkpoint_ts_ = std::chrono::system_clock::now();
+        if (!request_ckpt_.load(std::memory_order_acquire))
+        {
+            LOG(INFO) << "Checkpoint triggered: reason=timer, interval="
+                      << checkpoint_interval_ << " seconds";
+        }
         lk.unlock();
         Ckpt(false);
         lk.lock();
@@ -758,6 +763,7 @@ void Checkpointer::Run()
     // ensure normal shutdown execute checkpoint since we could receive
     // terminating request during the last checkpoint.
     lk.unlock();
+    LOG(INFO) << "Checkpoint triggered: reason=shutdown";
     Ckpt(true);
     lk.lock();
     // notify all waiting that one round checkpoint is done.
@@ -770,7 +776,7 @@ void Checkpointer::Run()
  * to do checkpoint if there is no freeable entries to be kicked out
  * from ccmap.
  */
-void Checkpointer::Notify(bool request_ckpt)
+void Checkpointer::Notify(bool request_ckpt, const char *reason)
 {
     if (request_ckpt)
     {
@@ -788,6 +794,9 @@ void Checkpointer::Notify(bool request_ckpt)
         }
 
         last_checkpoint_request_ts_.store(now);
+        // Log accepted requests only: repeated pressure notifications can be
+        // frequent and are coalesced or rate-limited above.
+        LOG(INFO) << "Checkpoint requested: reason=" << reason;
     }
     std::unique_lock<std::mutex> lk(ckpt_mux_);
     ckpt_cv_.notify_one();


### PR DESCRIPTION
## Context

Checkpoint logs did not explain whether memory pressure, dirty-memory growth, or the periodic interval requested a checkpoint.

## Behavior before and after

Trigger logs now always appear at INFO, including when `report_ckpt=false`:

- `memory_pressure`: eviction cannot free entries.
- `dirty_memory_threshold`: estimated dirty memory exceeds the configured threshold (default: 10% of each shard's memory limit).
- `timer`: periodic interval elapsed; the log includes the interval.
- `explicit_request` and `shutdown`: other explicit notifications and the final round.

## Implementation

`CcShard::NotifyCkpt` forwards a diagnostic label to `Checkpointer::Notify`. Accepted requests log after existing rate limiting and coalescing. `Checkpointer::Run` logs timer and shutdown triggers. The durability documentation describes these labels.

## Design decisions and alternatives

Labels are consumed synchronously without new shared state. Request logs record acceptance, not completion, and can interleave with checkpoint progress. Trigger conditions, thresholds, and scheduling remain unchanged. Default arguments preserve existing source call sites; consumers must rebuild against the changed C++ signatures.

## Test plan

- [ ] Unit/CTest coverage: not run.
- [x] Parent-project integration or manual validation.
- [x] Formatting/build checks.
- [ ] Recovery, compatibility, or performance validation: full suites not run.
- [x] Documentation updated.

Commands run successfully in the EloqKV workspace:

```sh
cmake --build bld-eloqstore-local --target eloqkv --parallel 2

# From data_substrate/
clang-format-18 --dry-run --Werror tx_service/include/checkpointer.h tx_service/include/cc/cc_shard.h tx_service/src/cc/cc_shard.cpp tx_service/src/cc/cc_req_misc.cpp tx_service/src/checkpointer.cpp
git diff origin/main...HEAD --check
```

Runtime checks used local EloqStore, two server cores, WAL disabled, and `--report_ckpt=false --logbufsecs=0`. A local ad hoc RESP2 workload (not committed) wrote distinct 4 KiB values and compared sampled GET responses:

| Scenario | Configuration | Completed check |
| --- | --- | --- |
| Timer and dirty memory | 256 MiB node memory, 10 s interval, default dirty threshold | 16,000 SETs; 101 GET comparisons passed; no OOM retries |
| Memory pressure | 64 MiB node memory, 300 s interval, dirty-memory checks disabled | 256 SETs; 129 GET comparisons passed; no OOM retries |

The pressure scenario first ran sustained writes until multiple pressure-triggered checkpoints completed. That longer workload was stopped after capturing the trigger; it is not counted as a completed 16,000-write test. The smaller check above then passed. Shutdown also logged its reason and completed a final checkpoint.

Observed log excerpts with `report_ckpt=false`:

```text
05:26:01 Checkpoint triggered: reason=timer, interval=10 seconds
05:26:10 Checkpoint requested: reason=dirty_memory_threshold
05:26:50 Checkpoint requested: reason=memory_pressure
05:28:25 Checkpoint triggered: reason=shutdown
```

Full TCL/CTest and crash-recovery suites were not run.

## Risk assessment

Adds unconditional INFO messages for accepted requests and timer/shutdown rounds. Rejected or coalesced requests do not generate additional trigger logs. No persistent-format or durability-protocol changes.

## Rollback plan

Revert this commit and rebuild; no data migration is required.

## Reviewer guide

Start with the trigger labels in `ShardCleanCc::Execute` and `CcShard::CheckAndTriggerCkptByDirtyMemory`, then review acceptance logging in `Checkpointer::Notify` and periodic logging in `Checkpointer::Run`. The complete diff against `main` contains six files.

## Follow-up work

Companion EloqKV PR: https://github.com/eloqdata/eloqkv/pull/568, pinned to this branch at `d7c12f0493cec5fa14722ba0babb4697ee1a9ef4`. Merge this PR first, then repin EloqKV to the resulting squash commit before merging the parent PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Checkpoint activity logs now identify why a checkpoint was triggered, including memory pressure, dirty-memory thresholds, explicit requests, timers, and shutdowns.
  - Logs reflect accepted requests after rate limiting and request coalescing, providing clearer operational visibility.

- **Documentation**
  - Checkpoint durability and recovery guidance now documents trigger logging behavior and clarifies that these logs are independent of checkpoint reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->