### PR TITLE
fix: bound FetchRecord pool and release retained buffers

### DIFF
--- a/docs/03-concurrency-control.md
+++ b/docs/03-concurrency-control.md
@@ -39,7 +39,10 @@ Rules of the model (verified in `tx_service/src/cc/cc_shard.cpp::ProcessRequests
    `ProcessRequests()` dequeues in batches of up to 64 (`req_buf_`) and calls `Execute(*this)`;
    if `Execute` returns `true` it calls `req->Free()`, returning the request to its
    `CcRequestPool` (`cc_req_pool.h` — a circular vector of reusable request objects keyed on the
-   `in_use_` flag). Stack-owned requests that notify an external waiter before `Execute()`
+   `in_use_` flag). A finite pool limit also caps its initial allocation and growth;
+   `NextRequest()` returns `nullptr` when that limit is exhausted (including a zero limit),
+   so callers using a finite limit must handle saturation. The default remains unbounded.
+   Stack-owned requests that notify an external waiter before `Execute()`
    unwinds must return `false`, or must keep `in_use_` set until the scheduler-side `Free()`
    has completed; otherwise the owner can reset or destroy the stack object while
    `ProcessRequests()` still holds its raw pointer.
@@ -102,6 +105,23 @@ the cursor after a checkpoint. The actual eviction loop is driven by the self-re
 **DispatchTask.** `CcShard::DispatchTask(idx, task)` wraps a `std::function<bool(CcShard&)>` in a
 pooled `RunOnTxProcessorCc` and enqueues it to another shard — the standard way to run CPU-bound
 work (e.g. `StoreRange::LoadSlice()`) on a specific shard's context.
+
+**Record-fetch pool retention.** `FetchRecordCc` keeps at most 128 reusable requests per
+shard. Saturation allocates a temporary request, preserving concurrent reads and single-flight
+coalescing. The active-fetch map owns both kinds through a deleter that calls `Free()` for a
+pooled request or deletes a temporary request on removal. Backfill and reopen retries keep
+that owner alive until the fetch reaches its existing terminal removal path.
+
+`FetchRecordCc::Free()` releases serialized values, archive records, owned keys,
+session/boundary strings and requester storage before publishing the pooled request as idle.
+`std::string::clear()` alone would retain the capacity of a previously fetched large value.
+Erasing an active owner can destroy the currently executing request: release pins and recycle
+locks first, then return without accessing the request. Declare the active map after the pool
+so its owners are released first during shard destruction; callbacks must already be quiescent.
+
+The 128-object limit bounds retained request shells, not in-flight bytes. Returning payload
+allocations to the allocator also does not guarantee an immediate RSS decrease. A fetched
+string moved from a DSS worker retains the heap ownership of its original allocation.
 
 ## 3. LocalCcShards — the node-level container (`local_cc_shards.h`)
 

--- a/docs/09-store-handler.md
+++ b/docs/09-store-handler.md
@@ -157,7 +157,7 @@ store_hd_->PersistKV(kv_table_names)              local_cc_shards.cpp:5964
 
 ```
 CcMap::Execute miss (template_cc_map.h / object_cc_map.h)
-  │ CcShard::FetchRecord → may return Retry when saturated (cc_shard.cpp:1979)
+  │ CcShard::FetchRecord → reuse a pooled request or allocate a temporary one
   ▼
 DataStoreServiceClient::FetchRecord(fetch_cc)
   │ kv_partition = KvPartitionIdOf(partition_id, !IsHashPartitioned())
@@ -170,6 +170,12 @@ Read closure (local bypass or RPC) ─► FetchRecordCallback
   ▼
 fetch_cc->SetFinish(0)  → re-enqueued on the owning CcShard          [03]
 ```
+
+The record-fetch pool retains at most 128 reusable objects per shard; exceeding that limit
+does not reject a read. The active-fetch map owns temporary requests until the fetch reaches
+its terminal removal path, while backfill/reopen retries keep the request alive. Completed
+pooled requests release their value, archive and owned key buffers before reuse. A synchronous
+store `Retry` still unwinds the fetch as before.
 
 ### Slice load (`LoadRangeSlice`)
 

--- a/tx_service/include/cc/cc_req_misc.h
+++ b/tx_service/include/cc/cc_req_misc.h
@@ -563,6 +563,18 @@ public:
 struct FetchRecordCc : public FetchCc
 {
 public:
+    /**
+     * Returns a completed pooled request to its pool, or destroys a temporary
+     * request. The active-fetch map keeps this owner until all fetch retries
+     * and backfill work have finished on the owning shard.
+     */
+    struct Deleter
+    {
+        bool pooled_{false};
+        void operator()(FetchRecordCc *request) const;
+    };
+    using uptr = std::unique_ptr<FetchRecordCc, Deleter>;
+
     FetchRecordCc() = default;
     FetchRecordCc(const TableName *tbl_name,
                   const TableSchema *tbl_schema,
@@ -596,6 +608,9 @@ public:
     bool Execute(CcShard &ccs) override;
 
     void SetFinish(int err);
+
+    /** Releases completed fetch data before publishing the request as idle. */
+    void Free() override;
 
     // table_name is a string view, cannot access it outside TxProcessor.
     TableName table_name_{

--- a/tx_service/include/cc/cc_req_pool.h
+++ b/tx_service/include/cc/cc_req_pool.h
@@ -21,6 +21,7 @@
  */
 #pragma once
 
+#include <algorithm>
 #include <memory>
 #include <vector>
 
@@ -33,11 +34,17 @@ template <typename T>
 class CcRequestPool
 {
 public:
+    /**
+     * Retains at most max_size request objects; zero disables the pool.
+     * NextRequest returns nullptr when every retained request is in use and
+     * the limit has been reached. Acquisition runs on the owning shard.
+     */
     explicit CcRequestPool(size_t max_size = UINT64_MAX)
         : head_(0), max_size_(max_size)
     {
-        pool_.reserve(8);
-        for (size_t idx = 0; idx < 8; ++idx)
+        const size_t initial_size = std::min<size_t>(8, max_size_);
+        pool_.reserve(initial_size);
+        for (size_t idx = 0; idx < initial_size; ++idx)
         {
             pool_.emplace_back(std::make_unique<T>());
         }
@@ -64,20 +71,26 @@ public:
 
         if (count == pool_.size())
         {
-            if (count == max_size_)
+            if (count >= max_size_)
             {
                 return nullptr;
             }
 
-            size_t old_size = pool_.size();
-            pool_.resize((size_t) (old_size * 1.5));
-            for (size_t idx = old_size; idx < pool_.size(); ++idx)
+            const size_t old_size = pool_.size();
+            // Clamp the increment before adding it to avoid exceeding the
+            // limit or overflowing the unlimited default's size arithmetic.
+            const size_t growth = std::min(max_size_ - old_size,
+                                           std::max<size_t>(1, old_size / 2));
+            const size_t new_size = old_size + growth;
+            pool_.reserve(new_size);
+            for (size_t idx = old_size; idx < new_size; ++idx)
             {
-                pool_[idx] = std::make_unique<T>();
+                pool_.emplace_back(std::make_unique<T>());
             }
             req_ptr = static_cast<CcRequestBase *>(pool_[old_size].get());
             req_ptr->Use();
             head_ = old_size + 1;
+            head_ = head_ == pool_.size() ? 0 : head_;
             return pool_[old_size].get();
         }
         else

--- a/tx_service/include/cc/cc_shard.h
+++ b/tx_service/include/cc/cc_shard.h
@@ -1351,11 +1351,13 @@ private:
 
     std::unordered_map<TableName, std::unique_ptr<FetchCc>> fetch_reqs_;
 
-    // FetchRecordCc addresses must remain stable while data-store callbacks are
-    // in flight. The pool owns the requests and the flat map only indexes the
-    // active single-flight fetch for each entry.
-    absl::flat_hash_map<LruEntry *, FetchRecordCc *> fetch_record_reqs_;
-    CcRequestPool<FetchRecordCc> fetch_record_cc_pool_;
+    // Keep a bounded set of reusable shells after a burst of cold reads.
+    // Saturation allocates temporary requests rather than limiting reads.
+    CcRequestPool<FetchRecordCc> fetch_record_cc_pool_{128};
+    // Addresses stay stable across async callbacks. Erasing an active owner
+    // recycles a pooled request or deletes a temporary one. Declare the map
+    // after the pool so these owners are released before the pool is destroyed.
+    absl::flat_hash_map<LruEntry *, FetchRecordCc::uptr> fetch_record_reqs_;
 
     // For load snapshot from kvstore asynchronously
     CcRequestPool<FetchSnapshotCc> fetch_snapshot_cc_pool_;

--- a/tx_service/src/cc/cc_req_misc.cpp
+++ b/tx_service/src/cc/cc_req_misc.cpp
@@ -818,6 +818,36 @@ FetchRecordCc::FetchRecordCc(const TableName *tbl_name,
 {
 }
 
+void FetchRecordCc::Deleter::operator()(FetchRecordCc *request) const
+{
+    if (pooled_)
+    {
+        request->Free();
+    }
+    else
+    {
+        delete request;
+    }
+}
+
+void FetchRecordCc::Free()
+{
+    // BackFill and all retry/reopen paths must be finished before the owner
+    // releases this request. clear() alone keeps large strings allocated in
+    // idle pool slots, including after a later missing-key or tiny-value read.
+    std::string().swap(rec_str_);
+    archive_records_.reset();
+    tx_key_ = TxKey();
+    std::string().swap(kv_session_id_);
+    std::string().swap(kv_start_key_);
+    std::string().swap(kv_end_key_);
+    std::vector<CcRequestBase *>().swap(requesters_);
+    cce_ = nullptr;
+    lock_ = nullptr;
+    table_schema_ = nullptr;
+    CcRequestBase::Free();
+}
+
 void FetchRecordCc::Reset(const TableName *tbl_name,
                           const TableSchema *tbl_schema,
                           TxKey tx_key,
@@ -1017,9 +1047,10 @@ bool FetchRecordCc::Execute(CcShard &ccs)
         {
             // Gives up on the reopen, as the previous shape did when its
             // FetchRecord returned Retry.
-            ccs.RemoveFetchRecordRequest(cce_);
             cce_->GetKeyGapLockAndExtraData()->ReleasePin();
             cce_->RecycleKeyLock(ccs);
+            // Removing the active owner can destroy a temporary request.
+            ccs.RemoveFetchRecordRequest(cce_);
         }
         return false;
     }

--- a/tx_service/src/cc/cc_shard.cpp
+++ b/tx_service/src/cc/cc_shard.cpp
@@ -2201,7 +2201,15 @@ store::DataStoreHandler::DataStoreOpStatus CcShard::FetchRecord(
     FetchRecordCc *fetch_req = nullptr;
     if (tab_it == fetch_record_reqs_.end())
     {
-        fetch_req = fetch_record_cc_pool_.NextRequest();
+        FetchRecordCc::uptr request(fetch_record_cc_pool_.NextRequest(),
+                                    FetchRecordCc::Deleter{true});
+        if (request == nullptr)
+        {
+            request = FetchRecordCc::uptr(new FetchRecordCc(),
+                                          FetchRecordCc::Deleter{false});
+            request->Use();
+        }
+        fetch_req = request.get();
         fetch_req->Reset(&table_name,
                          tbl_schema,
                          std::move(key),
@@ -2215,13 +2223,13 @@ store::DataStoreHandler::DataStoreOpStatus CcShard::FetchRecord(
                          only_fetch_archives,
                          reopen);
         const bool inserted =
-            fetch_record_reqs_.try_emplace(cce, fetch_req).second;
+            fetch_record_reqs_.try_emplace(cce, std::move(request)).second;
         assert(inserted);
         (void) inserted;
     }
     else
     {
-        fetch_req = tab_it->second;
+        fetch_req = tab_it->second.get();
     }
     fetch_req->AddRequester(requester);
 
@@ -2422,13 +2430,10 @@ void CcShard::RemoveFetchRecordRequest(LruEntry *cce)
 {
     auto fetch_it = fetch_record_reqs_.find(cce);
     assert(fetch_it != fetch_record_reqs_.end());
-    FetchRecordCc *fetch_req = fetch_it->second;
+    // Both fetch completion and acquisition run on this shard. A pooled
+    // request cannot be reused until Execute unwinds; a temporary request is
+    // destroyed here, so the caller must not access it after this erasure.
     fetch_record_reqs_.erase(fetch_it);
-
-    // Free marks the request reusable while its Execute call is unwinding, but
-    // both FetchRecord and resumed requesters run on this shard, so NextRequest
-    // cannot observe it until control returns to the shard loop.
-    fetch_req->Free();
 }
 
 CcMap *CcShard::CreateOrUpdatePkCcMap(const TableName &table_name,

--- a/tx_service/tests/CMakeLists.txt
+++ b/tx_service/tests/CMakeLists.txt
@@ -63,7 +63,9 @@ set(CATCH_MAIN_TESTS
     CcPage-Test
     LargeObjLRU-Test
     CcRequestWait-Test
+    CcRequestPool-Test
     CheckpointMetricsState-Test
+    FetchRecordCc-Test
     NonBlockingLock-Test
     AcquireAllError-Test
     StandbyForward-Test

--- a/tx_service/tests/CcRequestPool-Test.cpp
+++ b/tx_service/tests/CcRequestPool-Test.cpp
@@ -1,0 +1,120 @@
+/**
+ *    Copyright (C) 2026 EloqData Inc.
+ *
+ *    This program is free software: you can redistribute it and/or modify
+ *    it under either of the following two licenses:
+ *    1. GNU Affero General Public License, version 3, as published by the Free
+ *    Software Foundation.
+ *    2. GNU General Public License, version 2, as published by the Free
+ *    Software Foundation.
+ *
+ *    This program is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *    GNU Affero General Public License and GNU General Public License for
+ *    more details. If not, see <http://www.gnu.org/licenses/>.
+ */
+#include <catch2/catch_all.hpp>
+#include <cstddef>
+#include <unordered_set>
+#include <vector>
+
+#include "cc/cc_req_pool.h"
+
+namespace txservice
+{
+namespace
+{
+class PoolTestRequest : public CcRequestBase
+{
+public:
+    bool Execute(CcShard &) override
+    {
+        return true;
+    }
+};
+}  // namespace
+
+TEST_CASE("CcRequestPool respects zero, small and odd capacity limits",
+          "[cc-request-pool]")
+{
+    const size_t limit = GENERATE(0, 1, 3, 8, 9, 13, 17);
+    CAPTURE(limit);
+    CcRequestPool<PoolTestRequest> pool(limit);
+    std::unordered_set<PoolTestRequest *> requests;
+
+    REQUIRE(pool.IsAllFree());
+    for (size_t i = 0; i < limit; ++i)
+    {
+        PoolTestRequest *request = pool.NextRequest();
+        REQUIRE(request != nullptr);
+        REQUIRE(request->InUse());
+        REQUIRE(requests.insert(request).second);
+    }
+
+    REQUIRE(pool.NextRequest() == nullptr);
+    REQUIRE(pool.NextRequest() == nullptr);
+    for (PoolTestRequest *request : requests)
+    {
+        request->Free();
+    }
+    REQUIRE(pool.IsAllFree());
+}
+
+TEST_CASE("CcRequestPool reuses freed requests after reaching its limit",
+          "[cc-request-pool]")
+{
+    const size_t limit = GENERATE(1, 3, 9, 13);
+    CAPTURE(limit);
+    CcRequestPool<PoolTestRequest> pool(limit);
+    std::vector<PoolTestRequest *> requests;
+    for (size_t i = 0; i < limit; ++i)
+    {
+        PoolTestRequest *request = pool.NextRequest();
+        REQUIRE(request != nullptr);
+        requests.push_back(request);
+    }
+    REQUIRE(pool.NextRequest() == nullptr);
+
+    std::unordered_set<PoolTestRequest *> freed;
+    for (size_t i = 0; i < limit; i += 2)
+    {
+        requests[i]->Free();
+        freed.insert(requests[i]);
+    }
+    while (!freed.empty())
+    {
+        PoolTestRequest *request = pool.NextRequest();
+        REQUIRE(request != nullptr);
+        REQUIRE(freed.erase(request) == 1);
+        REQUIRE(request->InUse());
+    }
+    REQUIRE(pool.NextRequest() == nullptr);
+
+    for (PoolTestRequest *request : requests)
+    {
+        request->Free();
+    }
+    REQUIRE(pool.IsAllFree());
+}
+
+TEST_CASE("CcRequestPool default grows and preserves request addresses",
+          "[cc-request-pool]")
+{
+    CcRequestPool<PoolTestRequest> pool;
+    std::unordered_set<PoolTestRequest *> requests;
+    for (size_t i = 0; i < 64; ++i)
+    {
+        PoolTestRequest *request = pool.NextRequest();
+        REQUIRE(request != nullptr);
+        REQUIRE(requests.insert(request).second);
+    }
+
+    for (PoolTestRequest *request : requests)
+    {
+        REQUIRE(request->InUse());
+        request->Free();
+    }
+    REQUIRE(pool.IsAllFree());
+}
+}  // namespace txservice

--- a/tx_service/tests/FetchRecordCc-Test.cpp
+++ b/tx_service/tests/FetchRecordCc-Test.cpp
@@ -1,0 +1,417 @@
+/**
+ *    Copyright (C) 2025 EloqData Inc.
+ *
+ *    This program is free software: you can redistribute it and/or modify
+ *    it under either of the following two licenses:
+ *    1. GNU Affero General Public License, version 3, as published by the Free
+ *    Software Foundation.
+ *    2. GNU General Public License, version 2, as published by the Free
+ *    Software Foundation.
+ *
+ *    This program is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *    GNU Affero General Public License or GNU General Public License for more
+ *    details.
+ *
+ *    You should have received a copy of the GNU Affero General Public License
+ *    and GNU General Public License V2 along with this program. If not, see
+ *    <http://www.gnu.org/licenses/>.
+ */
+#include <array>
+#include <catch2/catch_all.hpp>
+#include <cstddef>
+#include <map>
+#include <memory>
+#include <string>
+#include <tuple>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "cc/cc_req_misc.h"
+#include "cc/cc_req_pool.h"
+#include "cc/cc_shard.h"
+#include "cc/local_cc_shards.h"
+#include "data_store_service_client.h"
+#include "include/mock/mock_catalog_factory.h"
+#include "sharder.h"
+#include "tx_key.h"
+
+namespace txservice
+{
+namespace
+{
+constexpr size_t kPayloadSize = 64 * 1024;
+
+class CountedKey : public CompositeKey<std::string>
+{
+public:
+    CountedKey() = default;
+
+    explicit CountedKey(size_t *destroyed)
+        : CompositeKey<std::string>(std::string(kPayloadSize, 'k')),
+          destroyed_(destroyed)
+    {
+    }
+
+    ~CountedKey()
+    {
+        if (destroyed_ != nullptr)
+        {
+            ++*destroyed_;
+        }
+    }
+
+    static const TxKeyInterface *TxKeyImpl()
+    {
+        static const TxKeyInterface key_interface{CountedKey{}};
+        return &key_interface;
+    }
+
+private:
+    size_t *destroyed_{nullptr};
+};
+
+class ObservedFetchRecordCc : public FetchRecordCc
+{
+public:
+    explicit ObservedFetchRecordCc(size_t *destroyed = nullptr)
+        : destroyed_(destroyed)
+    {
+    }
+
+    ~ObservedFetchRecordCc() override
+    {
+        if (destroyed_ != nullptr)
+        {
+            ++*destroyed_;
+        }
+    }
+
+    void Populate(size_t *destroyed_keys)
+    {
+        tx_key_ = TxKey(std::make_unique<CountedKey>(destroyed_keys));
+        rec_str_.assign(kPayloadSize, 'v');
+        kv_session_id_.assign(kPayloadSize, 's');
+        kv_start_key_.assign(kPayloadSize, 'a');
+        kv_end_key_.assign(kPayloadSize, 'z');
+        archive_records_ = std::make_unique<
+            std::vector<std::tuple<uint64_t, RecordStatus, std::string>>>();
+        archive_records_->emplace_back(
+            1, RecordStatus::Normal, std::string(kPayloadSize, 'h'));
+        requesters_.assign(256, nullptr);
+    }
+
+    size_t RequesterCapacity() const
+    {
+        return requesters_.capacity();
+    }
+
+private:
+    size_t *destroyed_{nullptr};
+};
+
+void CheckReleased(const ObservedFetchRecordCc &request)
+{
+    const size_t empty_capacity = std::string{}.capacity();
+    REQUIRE_FALSE(request.InUse());
+    REQUIRE_FALSE(request.tx_key_.IsOwner());
+    REQUIRE(request.archive_records_ == nullptr);
+    REQUIRE(request.RequesterCount() == 0);
+    REQUIRE(request.RequesterCapacity() == 0);
+    for (const std::string *buffer : {&request.rec_str_,
+                                      &request.kv_session_id_,
+                                      &request.kv_start_key_,
+                                      &request.kv_end_key_})
+    {
+        REQUIRE(buffer->empty());
+        REQUIRE(buffer->capacity() <= empty_capacity);
+    }
+}
+
+class DeferredFetchStore : public EloqDS::DataStoreServiceClient
+{
+public:
+    using DataStoreServiceClient::DataStoreServiceClient;
+
+    DataStoreOpStatus FetchRecord(FetchRecordCc *request,
+                                  FetchSnapshotCc *snapshot = nullptr) override
+    {
+        REQUIRE(snapshot == nullptr);
+        requests_.push_back(request);
+        request->rec_str_.assign(kPayloadSize, 'v');
+        request->rec_status_ = RecordStatus::Normal;
+        request->rec_ts_ = 1;
+        return DataStoreOpStatus::Success;
+    }
+
+    std::vector<FetchRecordCc *> requests_;
+};
+
+/** A real shard queue with manually completed storage; no RPC service starts.
+ */
+class FetchShardFixture
+{
+public:
+    FetchShardFixture()
+    {
+        cluster_.Initialize("127.0.0.1", 8600);
+        store_ = std::make_unique<DeferredFetchStore>(
+            false, factories_.data(), cluster_, true);
+        shards_ = std::make_unique<LocalCcShards>(0,
+                                                  0,
+                                                  config_,
+                                                  factories_.data(),
+                                                  nullptr,
+                                                  &nodes_,
+                                                  1,
+                                                  store_.get(),
+                                                  nullptr,
+                                                  true);
+        shards_->BindThreadToFastMetaDataShard(0);
+        Shard().Init();
+    }
+
+    CcShard &Shard()
+    {
+        return *shards_->GetCcShard(0);
+    }
+
+    DeferredFetchStore &Store()
+    {
+        return *store_;
+    }
+
+private:
+    MockCatalogFactory factory_;
+    std::array<CatalogFactory *, 5> factories_{
+        &factory_, &factory_, &factory_, &factory_, &factory_};
+    std::unordered_map<uint32_t, std::vector<NodeConfig>> nodes_{
+        {0, {NodeConfig(0, "127.0.0.1", 8600)}}};
+    std::map<std::string, uint32_t> config_{
+        {"node_memory_limit_mb", 128},
+        {"range_slice_memory_limit_percent", 20},
+        {"realtime_sampling", 0},
+        {"range_split_worker_num", 1},
+        {"core_num", 1},
+        {"enable_key_cache", 0},
+        {"enable_shard_heap_defragment", 0}};
+    EloqDS::DataStoreServiceClusterManager cluster_;
+    std::unique_ptr<DeferredFetchStore> store_;
+    std::unique_ptr<LocalCcShards> shards_;
+};
+
+class RetryingBackFillMap
+    : public TemplateCcMap<CompositeKey<int>, CompositeRecord<int>, true, true>
+{
+public:
+    explicit RetryingBackFillMap(CcShard *shard, const TableName &table)
+        : TemplateCcMap(shard, 0, table, 1)
+    {
+    }
+
+    bool BackFill(LruEntry *entry,
+                  uint64_t commit_ts,
+                  RecordStatus status,
+                  const std::string &record) override
+    {
+        REQUIRE(record == std::string(kPayloadSize, 'v'));
+        ++calls_;
+        if (entry == retry_entry_ && !retried_)
+        {
+            retried_ = true;
+            return false;
+        }
+        entry->GetKeyGapLockAndExtraData()->ReleasePin();
+        return true;
+    }
+
+    LruEntry *retry_entry_{nullptr};
+    size_t calls_{0};
+    bool retried_{false};
+};
+}  // namespace
+
+TEST_CASE("FetchRecordCc releases owned results before pool reuse",
+          "[fetch-record-cc]")
+{
+    CcRequestPool<ObservedFetchRecordCc> pool(1);
+    size_t destroyed_keys = 0;
+    ObservedFetchRecordCc *request = pool.NextRequest();
+    REQUIRE(request != nullptr);
+    request->Populate(&destroyed_keys);
+    REQUIRE(request->rec_str_.capacity() >= kPayloadSize);
+    REQUIRE(request->tx_key_.IsOwner());
+
+    CcRequestBase *base = request;
+    base->Free();
+
+    CheckReleased(*request);
+    REQUIRE(destroyed_keys == 1);
+    ObservedFetchRecordCc *reused = pool.NextRequest();
+    REQUIRE(reused == request);
+    REQUIRE(reused->InUse());
+    reused->rec_str_ = "small";
+    reused->Free();
+    CheckReleased(*reused);
+    REQUIRE(destroyed_keys == 1);
+}
+
+TEST_CASE("FetchRecordCc recycling preserves borrowed keys",
+          "[fetch-record-cc]")
+{
+    size_t destroyed_keys = 0;
+    {
+        CountedKey key(&destroyed_keys);
+        ObservedFetchRecordCc request;
+        request.Use();
+        request.tx_key_ = TxKey(&key);
+        request.Free();
+
+        REQUIRE_FALSE(request.InUse());
+        REQUIRE_FALSE(request.tx_key_.IsOwner());
+        REQUIRE(destroyed_keys == 0);
+        REQUIRE(key.ToString().size() > kPayloadSize);
+    }
+    REQUIRE(destroyed_keys == 1);
+}
+
+TEST_CASE("FetchRecordCc pooled owner recycles without destroying the request",
+          "[fetch-record-cc]")
+{
+    size_t destroyed_requests = 0;
+    size_t destroyed_keys = 0;
+    {
+        ObservedFetchRecordCc request(&destroyed_requests);
+        request.Use();
+        request.Populate(&destroyed_keys);
+        {
+            FetchRecordCc::uptr owner(&request, FetchRecordCc::Deleter{true});
+        }
+
+        REQUIRE(destroyed_requests == 0);
+        REQUIRE(destroyed_keys == 1);
+        CheckReleased(request);
+    }
+    REQUIRE(destroyed_requests == 1);
+    REQUIRE(destroyed_keys == 1);
+}
+
+TEST_CASE("FetchRecordCc overflow owner destroys once after ownership transfer",
+          "[fetch-record-cc]")
+{
+    size_t destroyed_requests = 0;
+    size_t destroyed_keys = 0;
+    {
+        auto request =
+            std::make_unique<ObservedFetchRecordCc>(&destroyed_requests);
+        request->Use();
+        request->Populate(&destroyed_keys);
+        FetchRecordCc::uptr owner(request.release(),
+                                  FetchRecordCc::Deleter{false});
+
+        FetchRecordCc::uptr transferred = std::move(owner);
+        REQUIRE(owner == nullptr);
+        REQUIRE(transferred->InUse());
+        REQUIRE(transferred->rec_str_.size() == kPayloadSize);
+        REQUIRE(destroyed_requests == 0);
+        REQUIRE(destroyed_keys == 0);
+
+        transferred.reset();
+        REQUIRE(destroyed_requests == 1);
+        REQUIRE(destroyed_keys == 1);
+    }
+    REQUIRE(destroyed_requests == 1);
+    REQUIRE(destroyed_keys == 1);
+}
+
+TEST_CASE(
+    "FetchRecordCc keeps overflow and deduplicated fetches alive on retry",
+    "[fetch-record-cc]")
+{
+    constexpr size_t request_count = 129;
+    std::array<size_t, request_count> destroyed_keys{};
+    FetchShardFixture fixture;
+    CcShard &shard = fixture.Shard();
+    const TableName table(
+        std::string("fetch-retry"), TableType::Primary, TableEngine::EloqSql);
+    MockTableSchema schema(table, "", 1);
+    RetryingBackFillMap map(&shard, table);
+    LruPage page(&map);
+    std::array<LruEntry, request_count> entries;
+    std::array<KeyGapLockAndExtraData, request_count> locks;
+    // This fixture has no cluster services: all three term sources report
+    // -1. Matching that term exercises lifecycle, not leader election.
+    const int64_t term = Sharder::Instance().LeaderTerm(0);
+
+    for (size_t i = 0; i < request_count; ++i)
+    {
+        locks[i].Reset(&map, &page, &entries[i]);
+        entries[i].cc_lock_and_extra_ = &locks[i];
+        REQUIRE(shard.FetchRecord(
+                    table,
+                    &schema,
+                    TxKey(std::make_unique<CountedKey>(&destroyed_keys[i])),
+                    &entries[i],
+                    0,
+                    term,
+                    nullptr,
+                    0) == store::DataStoreHandler::DataStoreOpStatus::Success);
+    }
+    REQUIRE(fixture.Store().requests_.size() == request_count);
+
+    // The 129th active fetch exceeds the shard's reusable pool. A second
+    // waiter on that same entry must share its in-flight storage request.
+    const size_t overflow = request_count - 1;
+    FetchRecordCc *request = fixture.Store().requests_[overflow];
+    CountedKey borrowed_key;
+    REQUIRE(shard.FetchRecord(table,
+                              &schema,
+                              TxKey(&borrowed_key),
+                              &entries[overflow],
+                              0,
+                              term,
+                              nullptr,
+                              0) ==
+            store::DataStoreHandler::DataStoreOpStatus::Success);
+    REQUIRE(fixture.Store().requests_.size() == request_count);
+    REQUIRE(request->RequesterCount() == 2);
+
+    map.retry_entry_ = &entries[overflow];
+    request->SetFinish(0);
+    REQUIRE(shard.ProcessRequests() == 1);
+    REQUIRE(map.calls_ == 1);
+    REQUIRE(request->InUse());
+    REQUIRE(request->rec_str_.size() == kPayloadSize);
+    REQUIRE(request->RequesterCount() == 2);
+    REQUIRE(destroyed_keys[overflow] == 0);
+
+    REQUIRE(shard.ProcessRequests() == 1);
+    REQUIRE(map.calls_ == 2);
+    REQUIRE(destroyed_keys[overflow] == 1);
+
+    for (size_t i = 0; i < overflow; ++i)
+    {
+        fixture.Store().requests_[i]->SetFinish(0);
+    }
+    size_t processed = 0;
+    while (processed < overflow)
+    {
+        const size_t batch = shard.ProcessRequests();
+        REQUIRE(batch > 0);
+        processed += batch;
+    }
+    REQUIRE(processed == overflow);
+    for (size_t i = 0; i < request_count; ++i)
+    {
+        REQUIRE(destroyed_keys[i] == 1);
+    }
+    for (size_t i = 0; i < overflow; ++i)
+    {
+        REQUIRE_FALSE(fixture.Store().requests_[i]->InUse());
+        REQUIRE(fixture.Store().requests_[i]->rec_str_.capacity() <=
+                std::string{}.capacity());
+    }
+}
+}  // namespace txservice


### PR DESCRIPTION
## Context

Idle `FetchRecordCc` objects retain serialized-value capacity, archives and owned keys after
completion. Peak cold-read concurrency can also permanently grow the reusable request pool.
This PR releases those retained fetch allocations and bounds request reuse.

## Behavior before and after

- Keep at most 128 reusable `FetchRecordCc` objects per shard. Additional concurrent misses
  use temporary requests, which are deleted when removed from the active-fetch map.
- Release owned values, archives, keys, session/boundary strings and waiter storage before
  publishing a completed pooled request as idle.
- Preserve single-flight coalescing and request lifetime through backfill/reopen retries.

## Implementation

`CcRequestPool` clamps initialization and growth to its configured limit and returns null
when saturated. This is required for the fetch pool's limit to be effective; the generic
default remains unbounded.

The active-fetch map holds a unique owner with a deleter that recycles pooled requests or
deletes temporary ones. The map is declared after the pool so its owners are destroyed first.
On reopen `Retry`, release the pin and recycle the lock before erasing an owner that may
delete the executing request. Terminal paths return without accessing that request again.

## Design decisions and alternatives

The limit bounds reusable shells, not concurrency or in-flight bytes. Temporary overflow
preserves reads during bursts; releasing idle payloads trades buffer reuse for lower retention.
There are no wire-format, persisted-record or durability-boundary changes.

## Test plan

- [ ] Final FetchRecord integration run: GitHub CI pending; 5 focused cases remain in `FetchRecordCc-Test`.
- [ ] Parent-project integration or manual validation: not rerun after the split.
- [x] Independent generic pool test: 457 assertions / 3 cases passed on the narrowed working tree.
- [x] Formatting checks: all 7 changed/new C++ files passed; `git diff --check` passed.
- [ ] Recovery or performance validation: production HA and memory measurements remain unrun.
- [x] Documentation updated for the FetchRecord ownership contract.

The FetchRecord cases cover owned-buffer release, borrowed keys, pooled recycling, temporary
destruction, and 129 concurrent requests with coalescing/backfill retry on a real shard queue
with manually completed storage. The fixture does not start an RPC service or test leadership.

Commands run from the narrowed PR worktree:

```bash
g++ -std=c++20 -O0 -g -DWITH_GLOG=1 \
  -I/tmp/eloq-fetch-pool-pr.g3ndsvcp/tx_service/include \
  -I/tmp/eloq-fetch-pool-pr.g3ndsvcp/tx_service/include/cc \
  -I/opt/eloq/third_party/include tx_service/tests/CcRequestPool-Test.cpp \
  /opt/eloq/third_party/lib/libCatch2Main.a /opt/eloq/third_party/lib/libCatch2.a \
  -L/opt/eloq/third_party/lib -Wl,-rpath,/opt/eloq/third_party/lib \
  -lglog -lbrpc -luring -pthread -ldl \
  -o /tmp/eloq-heap-audit.LD4e1b/CcRequestPool-PR567-Test
LD_LIBRARY_PATH=/opt/eloq/third_party/lib:/opt/eloq/third_party/lib64 \
  /tmp/eloq-heap-audit.LD4e1b/CcRequestPool-PR567-Test '[cc-request-pool]' --reporter compact
# Passed: 457 assertions in 3 cases.
git diff --name-only 1b44e27 -- '*.cpp' '*.h' | xargs clang-format-18 --dry-run --Werror
git diff --check 1b44e27
```

The narrowed engine build is left to GitHub CI. No complete ASan/UBSan validation is claimed.

## Risk assessment

Review temporary ownership and terminal erasure carefully: a temporary request can be
destroyed while its `Execute()` unwinds. Shard destruction still requires callback quiescence.
Repeated cold reads may allocate more often. Allocator page retention can delay an RSS drop,
and the production single-shard memory skew is not conclusively attributed to this path.

## Rollback plan

Revert this PR and rebuild consumers; no data migration is involved.

## Reviewer guide

Start with `CcShard::FetchRecord`, `RemoveFetchRecordRequest`, `FetchRecordCc::Free`, and the
reopen `Retry` order. Then review the pool boundary cases and overflow/coalescing test.
Land this submodule PR before updating the parent EloqKV pointer.

## Follow-up work

Other value pools, scanner cache cleanup and callback fixes are deferred. In particular,
the existing stale-term primary-fetch RPC completion omission is outside this PR.
Validate the patched binary under the production read/write mix before concluding the
memory skew is resolved.
