### PR TITLE
fix: release pooled transaction recovery images at completion

### DIFF
--- a/docs/04-transaction-execution.md
+++ b/docs/04-transaction-execution.md
@@ -102,6 +102,12 @@ A failed `CatalogAcquireAllOp` reports `AcquireAllOp::RepresentativeError()` on 
 ## Gotchas
 
 - Operation objects are *members* of the txm (`read_`, `acquire_write_`, `write_log_`, ...) — they are reused across requests; `Reset()` correctness on every path matters.
+- A TTL-reset object command may capture a full-object recovery image in its
+  handler result. Ordinary operation completion preserves the result for later
+  commit replies; terminal transaction reset releases the image's capacity
+  before the txm returns to its pool. Log records and standby forwarding use
+  independently owned storage. Capture remains enabled with WAL off; terminal
+  cleanup does not change the standby recovery contract.
 - `ReadLocalOperation` reads node-local meta (cluster config, ranges, buckets) without remote hops; it relies on meta cc maps being replicated to every node ([03](03-concurrency-control.md)).
 - Blocking object commands (e.g. Redis BLPOP-style, `BlockOperation` in `tx_command.h`) park in `tx_progress_block_` on the processor and are re-enlisted by `CheckWaitingTxs()` (10ms cadence; regular stuck txs at 2s).
 - `RETRY_NUM` / `state_forward_cnt_` guard against infinite re-execution; `ForwardFailed` keeps a tx on the on-fly queue rather than spinning.

--- a/docs/04-transaction-execution.md
+++ b/docs/04-transaction-execution.md
@@ -103,11 +103,14 @@ A failed `CatalogAcquireAllOp` reports `AcquireAllOp::RepresentativeError()` on 
 
 - Operation objects are *members* of the txm (`read_`, `acquire_write_`, `write_log_`, ...) — they are reused across requests; `Reset()` correctness on every path matters.
 - A TTL-reset object command may capture a full-object recovery image in its
-  handler result. Ordinary operation completion preserves the result for later
-  commit replies; terminal transaction reset releases the image's capacity
-  before the txm returns to its pool. Log records and standby forwarding use
-  independently owned storage. Capture remains enabled with WAL off; terminal
-  cleanup does not change the standby recovery contract.
+  handler result. `ObjectCommandResult::Reset()` releases the image's capacity
+  when the result is reset for reuse. Ordinary operation completion preserves
+  the result for later commit replies. Once the reply has copied its result,
+  terminal transaction reset resets the handler value before the txm returns
+  to its pool, even if it is never reused. Log records and standby forwarding
+  use independently owned storage.
+  Capture remains enabled with WAL off; cleanup does not change the standby
+  recovery contract.
 - `ReadLocalOperation` reads node-local meta (cluster config, ranges, buckets) without remote hops; it relies on meta cc maps being replicated to every node ([03](03-concurrency-control.md)).
 - Blocking object commands (e.g. Redis BLPOP-style, `BlockOperation` in `tx_command.h`) park in `tx_progress_block_` on the processor and are re-enlisted by `CheckWaitingTxs()` (10ms cadence; regular stuck txs at 2s).
 - `RETRY_NUM` / `state_forward_cnt_` guard against infinite re-execution; `ForwardFailed` keeps a tx on the on-fly queue rather than spinning.

--- a/tx_service/include/tx_execution.h
+++ b/tx_service/include/tx_execution.h
@@ -808,5 +808,6 @@ private:
     friend struct InvalidateTableCacheOp;
     friend struct InvalidateTableCacheCompositeOp;
     friend class TxProcessor;
+    friend class TransactionExecutionTestPeer;
 };
 }  // namespace txservice

--- a/tx_service/include/tx_operation_result.h
+++ b/tx_service/include/tx_operation_result.h
@@ -1001,8 +1001,8 @@ struct ObjectCommandResult
     bool ttl_reset_{false};
     // Full-object snapshot image the owner shard serialized when the command
     // reset a live TTL — the single capture point for local and remote owners
-    // (remote responses carry it in ApplyResponse). Non-empty iff ttl_reset_.
-    // Written to the WAL as an overwrite record.
+    // (remote responses carry it in ApplyResponse). Used for WAL overwrites.
+    // Terminal txm reset releases this image before the other reply fields.
     std::string recover_cmd_image_{};
 };
 

--- a/tx_service/include/tx_operation_result.h
+++ b/tx_service/include/tx_operation_result.h
@@ -963,7 +963,9 @@ struct ObjectCommandResult
         ttl_expired_ = false;
         ttl_ = UINT64_MAX;
         ttl_reset_ = false;
-        recover_cmd_image_.clear();
+        // Results may be reused inside a live transaction or pooled CC request.
+        // Release the old snapshot allocation when its contents are discarded.
+        std::string{}.swap(recover_cmd_image_);
     }
 
     // cce commit_ts, used to set transaction's commit_ts.
@@ -1002,7 +1004,7 @@ struct ObjectCommandResult
     // Full-object snapshot image the owner shard serialized when the command
     // reset a live TTL — the single capture point for local and remote owners
     // (remote responses carry it in ApplyResponse). Used for WAL overwrites.
-    // Terminal txm reset releases this image before the other reply fields.
+    // Released when this result is reset for reuse or transaction completion.
     std::string recover_cmd_image_{};
 };
 

--- a/tx_service/src/tx_execution.cpp
+++ b/tx_service/src/tx_execution.cpp
@@ -132,6 +132,11 @@ void TransactionExecution::Reset()
     commit_ts_bound_ = 0;
     rw_set_.Reset();
     cmd_set_.Reset();
+    // Commit/abort no longer needs this result image. Log and standby records
+    // use independently owned storage, so release its capacity before the txm
+    // returns to the reusable pool. Keep the other handler result fields intact
+    // until their ordinary operation reset.
+    std::string{}.swap(obj_cmd_.hd_result_.Value().recover_cmd_image_);
     wset_iters_.clear();
     wset_reverse_iters_.clear();
     scans_.clear();

--- a/tx_service/src/tx_execution.cpp
+++ b/tx_service/src/tx_execution.cpp
@@ -132,11 +132,10 @@ void TransactionExecution::Reset()
     commit_ts_bound_ = 0;
     rw_set_.Reset();
     cmd_set_.Reset();
-    // Commit/abort no longer needs this result image. Log and standby records
-    // use independently owned storage, so release its capacity before the txm
-    // returns to the reusable pool. Keep the other handler result fields intact
-    // until their ordinary operation reset.
-    std::string{}.swap(obj_cmd_.hd_result_.Value().recover_cmd_image_);
+    // Final replies have copied the command result before terminal reset.
+    // Release its snapshot and stale metadata before the txm returns to its
+    // pool.
+    obj_cmd_.hd_result_.Value().Reset();
     wset_iters_.clear();
     wset_reverse_iters_.clear();
     scans_.clear();

--- a/tx_service/tests/CMakeLists.txt
+++ b/tx_service/tests/CMakeLists.txt
@@ -70,6 +70,7 @@ set(CATCH_MAIN_TESTS
     AcquireAllError-Test
     StandbyForward-Test
     ApplyResponseBoundary-Test
+    TransactionImageLifetime-Test
 )
 
 if(WITH_DATA_STORE STREQUAL "ELOQDSS_ROCKSDB" OR

--- a/tx_service/tests/TransactionImageLifetime-Test.cpp
+++ b/tx_service/tests/TransactionImageLifetime-Test.cpp
@@ -1,0 +1,230 @@
+/**
+ *    Copyright (C) 2025 EloqData Inc.
+ *
+ *    This program is free software: you can redistribute it and/or  modify
+ *    it under either of the following two licenses:
+ *    1. GNU Affero General Public License, version 3, as published by the Free
+ *    Software Foundation.
+ *    2. GNU General Public License as published by the Free Software
+ *    Foundation; version 2 of the License.
+ *
+ *    This program is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU Affero General Public License or GNU General Public License for more
+ *    details.
+ *
+ *    You should have received a copy of the GNU Affero General Public License
+ *    and GNU General Public License V2 along with this program.  If not, see
+ *    <http://www.gnu.org/licenses/>.
+ *
+ */
+#include <atomic>
+#include <catch2/catch_all.hpp>
+#include <cstdint>
+#include <string>
+#include <utility>
+
+#include "cc_request.pb.h"
+#include "read_write_entry.h"
+#include "remote/apply_response_util.h"
+#include "tx_execution.h"
+#include "tx_operation.h"
+#include "tx_operation_result.h"
+#include "tx_req_result.h"
+#include "tx_request.h"
+
+namespace txservice
+{
+// Seed a completed CC operation, then let the real Forward/commit-tail code
+// finish the transaction. This isolates result ownership from the networking,
+// catalog, and storage harnesses; it does not emulate their execution.
+class TransactionExecutionTestPeer
+{
+public:
+    static TxmStatus Forward(TransactionExecution &txm)
+    {
+        return txm.Forward();
+    }
+
+    static ObjectCommandOp &ObjectOp(TransactionExecution &txm)
+    {
+        return txm.obj_cmd_;
+    }
+
+    static void FinishObjectReply(TransactionExecution &txm,
+                                  TxResult<RecordStatus> &reply,
+                                  bool post_process_tail = false)
+    {
+        txm.rec_resp_ = &reply;
+        PrepareTail(txm, TxnStatus::Committed, post_process_tail);
+    }
+
+    static void FinishExplicitReply(TransactionExecution &txm,
+                                    TxResult<bool> &reply,
+                                    bool commit,
+                                    bool post_process_tail)
+    {
+        txm.bool_resp_ = &reply;
+        PrepareTail(txm,
+                    commit ? TxnStatus::Committed : TxnStatus::Aborted,
+                    post_process_tail);
+    }
+
+private:
+    static void PrepareTail(TransactionExecution &txm,
+                            TxnStatus status,
+                            bool post_process_tail)
+    {
+        txm.tx_status_.store(status, std::memory_order_relaxed);
+        if (post_process_tail)
+        {
+            txm.post_process_.Reset(0, 0, 0, 0, false);
+            txm.post_process_.is_running_ = true;
+            txm.state_stack_.push_back(&txm.post_process_);
+        }
+        else
+        {
+            txm.update_txn_.is_running_ = true;
+            txm.update_txn_.hd_result_.SetFinished();
+            txm.state_stack_.push_back(&txm.update_txn_);
+        }
+    }
+};
+
+namespace
+{
+constexpr size_t kLargeImageSize = 1024 * 1024;
+
+ObjectCommandResult &SeedImage(TransactionExecution &txm)
+{
+    auto &result =
+        TransactionExecutionTestPeer::ObjectOp(txm).hd_result_.Value();
+    result.rec_status_ = RecordStatus::Normal;
+    result.commit_ts_ = 123;
+    result.ttl_reset_ = true;
+    result.recover_cmd_image_.assign(kLargeImageSize, 'x');
+    return result;
+}
+
+void RequireImageReleased(const ObjectCommandResult &result)
+{
+    REQUIRE(result.recover_cmd_image_.empty());
+    REQUIRE(result.recover_cmd_image_.capacity() == std::string{}.capacity());
+    // Final request replies still depend on handler-result status. This change
+    // must not indiscriminately reset the rest of the operation result.
+    REQUIRE(result.rec_status_ == RecordStatus::Normal);
+    REQUIRE(result.commit_ts_ == 123);
+    REQUIRE(result.ttl_reset_);
+}
+}  // namespace
+
+TEST_CASE("Object commit tail releases the image after preserving the reply",
+          "[transaction-image]")
+{
+    const bool post_process_tail = GENERATE(false, true);
+    TransactionExecution txm(nullptr, nullptr, nullptr);
+    auto &result = SeedImage(txm);
+    auto &op = TransactionExecutionTestPeer::ObjectOp(txm);
+    op.Reset();
+    REQUIRE(result.recover_cmd_image_.size() == kLargeImageSize);
+
+    TxResult<RecordStatus> reply(nullptr, nullptr);
+    TransactionExecutionTestPeer::FinishObjectReply(
+        txm, reply, post_process_tail);
+    REQUIRE(TransactionExecutionTestPeer::Forward(txm) == TxmStatus::Finished);
+    REQUIRE(reply.Status() == TxResultStatus::Finished);
+    REQUIRE(reply.Value() == RecordStatus::Normal);
+    RequireImageReleased(result);
+}
+
+TEST_CASE("Explicit commit and abort tails release pooled recovery images",
+          "[transaction-image]")
+{
+    const bool commit = GENERATE(false, true);
+    const bool post_process_tail = GENERATE(false, true);
+    TransactionExecution txm(nullptr, nullptr, nullptr);
+    auto &result = SeedImage(txm);
+    TxResult<bool> reply(nullptr, nullptr);
+    TransactionExecutionTestPeer::FinishExplicitReply(
+        txm, reply, commit, post_process_tail);
+    REQUIRE(TransactionExecutionTestPeer::Forward(txm) == TxmStatus::Finished);
+    REQUIRE(reply.Status() == TxResultStatus::Finished);
+    REQUIRE(reply.Value() == commit);
+    RequireImageReleased(result);
+}
+
+TEST_CASE("Terminal abort releases a large image after a small command reuse",
+          "[transaction-image]")
+{
+    TransactionExecution txm(nullptr, nullptr, nullptr);
+    auto &result = SeedImage(txm);
+    auto &op = TransactionExecutionTestPeer::ObjectOp(txm);
+    op.Reset(nullptr, nullptr, nullptr);
+    REQUIRE(result.recover_cmd_image_.empty());
+    REQUIRE(result.recover_cmd_image_.capacity() >= kLargeImageSize);
+    result.recover_cmd_image_ = "small";
+
+    // An unstarted/fenced transaction takes the actual early-abort Reset path.
+    AbortTxRequest abort;
+    txm.ProcessTxRequest(abort);
+    REQUIRE(abort.tx_result_.Status() == TxResultStatus::Finished);
+    REQUIRE_FALSE(abort.Result());
+    REQUIRE(txm.TxStatus() == TxnStatus::Finished);
+    REQUIRE(result.recover_cmd_image_.empty());
+    REQUIRE(result.recover_cmd_image_.capacity() == std::string{}.capacity());
+}
+
+TEST_CASE("Remote response and copied log image outlive transaction cleanup",
+          "[transaction-image]")
+{
+    TransactionExecution txm(nullptr, nullptr, nullptr);
+    auto &result = SeedImage(txm);
+    remote::ApplyResponse owner_response;
+    owner_response.set_rec_status(remote::RecordStatusType::NORMAL);
+    owner_response.set_commit_ts(123);
+    owner_response.set_ttl_reset(true);
+    owner_response.set_ttl(UINT64_MAX);
+    owner_response.set_recover_cmd_image(std::string(kLargeImageSize, 'r'));
+    std::string wire;
+    REQUIRE(owner_response.SerializeToString(&wire));
+    remote::ApplyResponse received;
+    REQUIRE(received.ParseFromString(wire));
+
+    // Use the production backfill helper under the same latch held by the
+    // receiver. The actual remote receiver's stale-message checks are covered
+    // by source review, not a fabricated network-response path here.
+    txm.AcquireSharedForwardLatch();
+    remote::BackfillObjectCommandResult(result, received);
+    txm.ReleaseSharedForwardLatch();
+    CmdSetEntry log_entry(1, 2, 3, std::string("key"), false);
+    log_entry.AddOverwriteCommandImage(result.recover_cmd_image_, UINT64_MAX);
+    REQUIRE(log_entry.cmd_str_list_.size() == 1);
+
+    TxResult<RecordStatus> reply(nullptr, nullptr);
+    TransactionExecutionTestPeer::FinishObjectReply(txm, reply);
+    REQUIRE(TransactionExecutionTestPeer::Forward(txm) == TxmStatus::Finished);
+    RequireImageReleased(result);
+    REQUIRE(received.recover_cmd_image() == std::string(kLargeImageSize, 'r'));
+    REQUIRE(log_entry.cmd_str_list_.front() == received.recover_cmd_image());
+}
+
+TEST_CASE("An active remote-result reader prevents terminal image release",
+          "[transaction-image]")
+{
+    TransactionExecution txm(nullptr, nullptr, nullptr);
+    auto &result = SeedImage(txm);
+    TxResult<RecordStatus> reply(nullptr, nullptr);
+    TransactionExecutionTestPeer::FinishObjectReply(txm, reply);
+
+    txm.AcquireSharedForwardLatch();
+    REQUIRE(TransactionExecutionTestPeer::Forward(txm) ==
+            TxmStatus::ForwardFailed);
+    REQUIRE(result.recover_cmd_image_.size() == kLargeImageSize);
+    REQUIRE(reply.Status() == TxResultStatus::Unknown);
+    txm.ReleaseSharedForwardLatch();
+
+    REQUIRE(TransactionExecutionTestPeer::Forward(txm) == TxmStatus::Finished);
+    RequireImageReleased(result);
+}
+}  // namespace txservice

--- a/tx_service/tests/TransactionImageLifetime-Test.cpp
+++ b/tx_service/tests/TransactionImageLifetime-Test.cpp
@@ -107,15 +107,13 @@ ObjectCommandResult &SeedImage(TransactionExecution &txm)
     return result;
 }
 
-void RequireImageReleased(const ObjectCommandResult &result)
+void RequireResultReset(const ObjectCommandResult &result)
 {
     REQUIRE(result.recover_cmd_image_.empty());
     REQUIRE(result.recover_cmd_image_.capacity() == std::string{}.capacity());
-    // Final request replies still depend on handler-result status. This change
-    // must not indiscriminately reset the rest of the operation result.
-    REQUIRE(result.rec_status_ == RecordStatus::Normal);
-    REQUIRE(result.commit_ts_ == 123);
-    REQUIRE(result.ttl_reset_);
+    REQUIRE(result.rec_status_ == RecordStatus::Unknown);
+    REQUIRE(result.commit_ts_ == 0);
+    REQUIRE_FALSE(result.ttl_reset_);
 }
 }  // namespace
 
@@ -135,7 +133,7 @@ TEST_CASE("Object commit tail releases the image after preserving the reply",
     REQUIRE(TransactionExecutionTestPeer::Forward(txm) == TxmStatus::Finished);
     REQUIRE(reply.Status() == TxResultStatus::Finished);
     REQUIRE(reply.Value() == RecordStatus::Normal);
-    RequireImageReleased(result);
+    RequireResultReset(result);
 }
 
 TEST_CASE("Explicit commit and abort tails release pooled recovery images",
@@ -151,19 +149,40 @@ TEST_CASE("Explicit commit and abort tails release pooled recovery images",
     REQUIRE(TransactionExecutionTestPeer::Forward(txm) == TxmStatus::Finished);
     REQUIRE(reply.Status() == TxResultStatus::Finished);
     REQUIRE(reply.Value() == commit);
-    RequireImageReleased(result);
+    RequireResultReset(result);
 }
 
-TEST_CASE("Terminal abort releases a large image after a small command reuse",
+TEST_CASE("Result reset releases the previous command image before reuse",
+          "[transaction-image]")
+{
+    const bool reset_through_operation = GENERATE(false, true);
+    TransactionExecution txm(nullptr, nullptr, nullptr);
+    auto &result = SeedImage(txm);
+    if (reset_through_operation)
+    {
+        TransactionExecutionTestPeer::ObjectOp(txm).Reset(
+            nullptr, nullptr, nullptr);
+    }
+    else
+    {
+        result.Reset();
+    }
+
+    REQUIRE(result.recover_cmd_image_.empty());
+    REQUIRE(result.recover_cmd_image_.capacity() == std::string{}.capacity());
+    REQUIRE(result.rec_status_ == RecordStatus::Unknown);
+    REQUIRE(result.commit_ts_ == 0);
+    REQUIRE_FALSE(result.ttl_reset_);
+}
+
+TEST_CASE("Terminal abort releases a large image capacity with short contents",
           "[transaction-image]")
 {
     TransactionExecution txm(nullptr, nullptr, nullptr);
     auto &result = SeedImage(txm);
-    auto &op = TransactionExecutionTestPeer::ObjectOp(txm);
-    op.Reset(nullptr, nullptr, nullptr);
-    REQUIRE(result.recover_cmd_image_.empty());
+    result.recover_cmd_image_.resize(5);
+    REQUIRE(result.recover_cmd_image_.size() == 5);
     REQUIRE(result.recover_cmd_image_.capacity() >= kLargeImageSize);
-    result.recover_cmd_image_ = "small";
 
     // An unstarted/fenced transaction takes the actual early-abort Reset path.
     AbortTxRequest abort;
@@ -204,7 +223,7 @@ TEST_CASE("Remote response and copied log image outlive transaction cleanup",
     TxResult<RecordStatus> reply(nullptr, nullptr);
     TransactionExecutionTestPeer::FinishObjectReply(txm, reply);
     REQUIRE(TransactionExecutionTestPeer::Forward(txm) == TxmStatus::Finished);
-    RequireImageReleased(result);
+    RequireResultReset(result);
     REQUIRE(received.recover_cmd_image() == std::string(kLargeImageSize, 'r'));
     REQUIRE(log_entry.cmd_str_list_.front() == received.recover_cmd_image());
 }
@@ -225,6 +244,6 @@ TEST_CASE("An active remote-result reader prevents terminal image release",
     txm.ReleaseSharedForwardLatch();
 
     REQUIRE(TransactionExecutionTestPeer::Forward(txm) == TxmStatus::Finished);
-    RequireImageReleased(result);
+    RequireResultReset(result);
 }
 }  // namespace txservice


### PR DESCRIPTION
## Context

Changing a live TTL can capture a full-object image in `ObjectCommandResult::recover_cmd_image_`. Pooled transactions retained this string after completion, and the result's ordinary reset used `clear()`, which retained its allocation. Multiple transactions touching the same large object could therefore retain many copies on that object's CCS heap.

For example, repeatedly issuing `SET k <large value> EX 3600` followed by `EXPIRE k 7200` exercises the capture path. The EXPIRE updates an existing live TTL. Bare SET clears the TTL, so bare SET followed by the first EXPIRE does not enter this particular path. Capture also occurs with WAL disabled.

## Behavior before and after

Before: an idle transaction could retain a large recovery image indefinitely; resetting its result for a subsequent small command retained the large capacity.

After: `ObjectCommandResult::Reset()` releases the image allocation. `TransactionExecution::Reset()` calls that result reset before returning the transaction to its pool, including transactions that are never reused. Final request replies already own their copied results before this terminal cleanup.

Ordinary `ObjectCommandOp::Reset()` at command completion still preserves the result until the commit reply consumes it. There are no protocol or storage-format changes.

## Implementation

- Replace the recovery string's `clear()` in `ObjectCommandResult::Reset()` with an empty-string swap.
- Reset `obj_cmd_.hd_result_.Value()` at transaction completion, using the same capacity-release implementation. The `CcHandlerResult` wrapper's completion state is not reset here.
- Add focused regression coverage for result reuse and transaction completion, including external reply correctness, copied log/remote images and forward-latch exclusion.
- Document the distinction between operation completion, result reuse and terminal transaction cleanup.

The final change contains six files. Runtime changes are in the shared result reset and terminal transaction reset; the remaining changes are comments, documentation and tests.

## Design decisions and alternatives

Both cleanup points are needed: result reuse can occur within an active transaction or pooled CC request, while an idle transaction may never reach another reuse. The terminal path therefore calls the shared result reset.

All six terminal reset call sites were inspected. The object reply is copied before cleanup in both commit tails and in the WAL-off direct-commit path; initialization failure and early commit/abort also finish their replies first. Resetting the remaining result metadata at that boundary is safe. The ordinary operation-completion reset remains unchanged because the commit reply may still need the result at that earlier stage.

CommandSet records and standby forwarding own their serialized storage. Remote response handling uses the existing forward latch and transaction/command identity checks. Result reuse keeps its existing synchronization boundaries; this change adds no lock or waiting protocol.

An empty-string swap releases the allocation; `clear()` retains it and `shrink_to_fit()` is not a guaranteed release. This trades buffer reuse across operations for reclaiming large value storage promptly.

## Test plan

- [x] Final-source unit coverage through standard CMake targets
- [x] Prior terminal-cleanup HA comparison, explicitly scoped below
- [x] Formatting and diff checks
- [x] Old-version negative control for the added reuse regression
- [x] Documentation updated

Final-source build and checks use a fresh, isolated source snapshot at `/tmp/eloq-result-reset-build.wtp7brim/src`, with the exact changed-file hashes recorded in `source-manifest.json`. The standard CMake target dependency closure is rebuilt, including all consumers of the modified inline header; no old business object files are reused.

```text
cmake -S /tmp/eloq-result-reset-build.wtp7brim/src \
  -B /tmp/eloq-result-reset-build.wtp7brim/bld \
  -DCMAKE_BUILD_TYPE=Debug -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
  -DWITH_TESTS=ON -DWITH_DATA_STORE=ELOQDSS_ROCKSDB_CLOUD_S3 \
  -DWITH_LOG_STATE=ROCKSDB_CLOUD_S3 -DWITH_LOG_SERVICE=ON \
  -DEXT_TX_PROC_ENABLED=ON -DELOQ_MODULE_ENABLED=ON \
  -DELOQ_THIRD_PARTY_PREFIX=/opt/eloq/third_party \
  -DELOQ_THIRD_PARTY_REQUIRED=ON \
  -DCMAKE_INSTALL_PREFIX=/tmp/eloq-result-reset-build.wtp7brim/install
  PASS: configure.

LD_LIBRARY_PATH=/opt/eloq/third_party/lib:/opt/eloq/third_party/lib64 \
  cmake --build /tmp/eloq-result-reset-build.wtp7brim/bld \
  --target TransactionImageLifetime-Test ApplyResponseBoundary-Test --parallel 6
  PASS: complete target dependency build and Catch discovery.

LD_LIBRARY_PATH=/opt/eloq/third_party/lib:/opt/eloq/third_party/lib64 \
  /tmp/eloq-result-reset-build.wtp7brim/bld/tx_service/tests/TransactionImageLifetime-Test --reporter compact
  PASS: 87 assertions in 6 test cases.
LD_LIBRARY_PATH=/opt/eloq/third_party/lib:/opt/eloq/third_party/lib64 \
  /tmp/eloq-result-reset-build.wtp7brim/bld/tx_service/tests/ApplyResponseBoundary-Test --reporter compact
  PASS: 25 assertions in 5 test cases.

clang-format-18 --dry-run --Werror tx_service/src/tx_execution.cpp \
  tx_service/include/tx_execution.h tx_service/include/tx_operation_result.h \
  tx_service/tests/TransactionImageLifetime-Test.cpp
git diff --check
  PASS.
```

The first build reached Catch discovery but could not load `libabsl_city.so.2308.0.0`; rerunning with the runtime library path shown above completed successfully. All 41 recorded consumers of `tx_operation_result.h` were rebuilt. Exact configure/build/test commands, logs and dependency verification are in `/tmp/eloq-result-reset-build.wtp7brim/`. The final changed-file hashes match commit `dfb969f85788e84eea865bd69a8f33cca0f31479`. Tests were run directly; the CTest runner itself was not run.

The added reuse regression was compiled against a complete source snapshot of the previous PR head `7b80f07` and its matching frozen engine library, then run by itself. Compilation and linking passed. Both capacity assertions failed as expected (`1048576 != 15`), while both empty-string assertions passed; the test exited 2. This confirms that the test detects retained capacity after both direct result reset and the real operation-reset call. Exact commands, header dependencies, library hashes and output are preserved in `/tmp/eloq-result-reset-negative.umefv6b2/`.

The tests seed completed CC states and exercise real Forward/commit tails. They verify caller-visible replies instead of requiring stale handler fields to survive terminal cleanup. The remote case exercises the production backfill helper and independent copies; it is not a real delayed-RPC integration test. Full WAL crash recovery, full explicit-transaction integration, broad TCL and sanitizers were not run for this revision.

### Prior HA evidence

The following measurements belong to the original terminal-cleanup implementation at `7b80f07`, before the review revision consolidated cleanup into `ObjectCommandResult::Reset()`. They demonstrate the retained-image mechanism and its terminal-release fix. The final review revision is validated separately by the fresh build/tests above; its full HA workload has not been rerun.

Both HA variants used four CCS, epoll, WAL off, S3 storage, 4096 MiB/node, 128 pipelined connections and 512 hot keys: one 1 MiB value on CCS0 plus 511 1 KiB values. Three SET EX/EXPIRE rounds were followed by two ordinary SET rounds in the same processes.

| After subsequent SET, replication drain and connection closure | Baseline `f3c87df` | Terminal cleanup `7b80f07` |
|---|---:|---:|
| CCS0 allocated | 298,772,208 B | 10,791,592 B |
| Idle transactions retaining large recovery images | 183 | 0 |
| Actual allocator bytes in those images | 287,834,112 B (274.5 MiB) | 0 |

All baseline image allocations belonged to CCS0. Fixed active transactions still generated full images; the final 192 idle transactions retained no image capacity. Both versions passed primary and standby byte comparisons of all 512 hot values. Listed drain endpoints had zero replication history, candidate count and sequence gap.

These were bounded read-only external-Txm snapshots with binary-specific allocator layouts. Internal Txm queues were excluded, and snapshots were approximate. Fixed sampling had a 123-second idle gap and a 44-second gap covering the first subsequent SET round; neither missing interval was filled with zero. The fixed TTL load had 12 standby resubscriptions, which ended before the subsequent SET phase. This is not a throughput or uninterrupted-replication claim.

Workload commands and raw data are preserved under `/tmp/eloq-pipeline-1mb.u6zxa0qb/`; the aligned report and JSON are under `/tmp/eloq-heap-audit.LD4e1b/txm-retention/ttl-terminal-reset-ab-report.md` and `ttl-terminal-reset-ab.json`. The amount of production memory attributable to this pool remains unmeasured.

## Risk assessment

The principal risk is releasing a result before its consumer is finished. Reply-copy ordering, independent log/standby storage, existing synchronization and regression tests address that boundary. Allocation frequency may increase for repeated TTL changes in long active transactions, since result reuse now also releases capacity. Cross-thread allocator accounting can lag deallocation.

The shared result reset also improves capacity release when RemoteApplyCc and MultiObject results are reused. This does not add an idle sweep for those separate pools or change their pool sizes.

## Rollback plan

Revert this PR. No data or configuration migration is needed; rollback restores the previous buffer retention.

## Reviewer guide

Start with `ObjectCommandResult::Reset()` and its call from `TransactionExecution::Reset()`. Check that `PostProcess(UpdateTxnStatus&)`, `PostProcess(PostProcessOp&)` and the WAL-off object-command tail finish their replies before terminal reset. Then review the test's external reply assertions, result-reuse case, copied recovery images and forward-latch check.

## Follow-up work

A wider audit of Reset methods, pool size limits and idle cleanup remains separate. Avoiding redundant capture with WAL disabled also requires its own ownership and standby-contract review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved transaction cleanup by releasing recovery-image memory when transactions reach terminal reset, helping reduce retained memory while preserving reply status and result data.
  - Ensured log records, standby forwarding, and active remote-result readers retain required data independently during cleanup.

- **Documentation**
  - Updated transaction execution guidance to clarify recovery-image handling, terminal reset behavior, and WAL-disabled operation.
  - Clarified the lifecycle and usage of full-object recovery snapshots.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->