### PR TITLE
fix: release replaced standby command storage

### DIFF
--- a/docs/standby_replication_protocol.md
+++ b/docs/standby_replication_protocol.md
@@ -31,7 +31,9 @@ Committed object changes are captured on the owner shard's apply path. A
 forwarded command represents the command after owner-side execution, because
 the standby performs commit replay and does not rerun the command's execution
 phase. Whole-object replacement is available for changes that cannot safely be
-expressed as an incremental command.
+expressed as an incremental command. It releases the superseded commands while
+preserving the entry's routing and version metadata. Subsequent commands follow
+the replacement in replay order.
 
 Each `CcShard` is an independent sequence group and assigns monotonically
 increasing forward sequence ids. This provides FIFO ordering within a shard and
@@ -136,6 +138,7 @@ term or all-log-groups recovery barriers described in
 |---|---|
 | Standby entries, sequence groups, session terms, and checkpoint broadcasts define the protocol state | `tx_service/include/standby.h`; `tx_service/src/standby.cpp` |
 | Committed commands are captured on the owner-side apply path with standby replay semantics | `tx_service/include/cc/object_cc_map.h`; `tx_service/tests/StandbyForward-Test.cpp` |
+| Whole-object replacement releases superseded command storage and preserves replay metadata | `tx_service/src/standby.cpp`; `tx_service/tests/StandbyForward-Test.cpp` |
 | Per-shard sequencing, bounded buffering, retry, gap tracking, and out-of-sync handling live in `CcShard` | `tx_service/include/cc/cc_shard.h`; `tx_service/src/cc/cc_shard.cpp` |
 | Subscription, sequence reset, snapshot, and checkpoint RPCs cross the CC control plane | `tx_service/include/proto/cc_request.proto`; `tx_service/src/remote/cc_node_service.cpp` |
 | Stream receive routes standby messages back to their owning shard | `tx_service/src/remote/cc_stream_receiver.cpp`; `tx_service/src/remote/cc_stream_sender.cpp` |

--- a/docs/standby_replication_protocol.md
+++ b/docs/standby_replication_protocol.md
@@ -31,9 +31,7 @@ Committed object changes are captured on the owner shard's apply path. A
 forwarded command represents the command after owner-side execution, because
 the standby performs commit replay and does not rerun the command's execution
 phase. Whole-object replacement is available for changes that cannot safely be
-expressed as an incremental command. It releases the superseded commands while
-preserving the entry's routing and version metadata. Subsequent commands follow
-the replacement in replay order.
+expressed as an incremental command.
 
 Each `CcShard` is an independent sequence group and assigns monotonically
 increasing forward sequence ids. This provides FIFO ordering within a shard and
@@ -138,7 +136,6 @@ term or all-log-groups recovery barriers described in
 |---|---|
 | Standby entries, sequence groups, session terms, and checkpoint broadcasts define the protocol state | `tx_service/include/standby.h`; `tx_service/src/standby.cpp` |
 | Committed commands are captured on the owner-side apply path with standby replay semantics | `tx_service/include/cc/object_cc_map.h`; `tx_service/tests/StandbyForward-Test.cpp` |
-| Whole-object replacement releases superseded command storage and preserves replay metadata | `tx_service/src/standby.cpp`; `tx_service/tests/StandbyForward-Test.cpp` |
 | Per-shard sequencing, bounded buffering, retry, gap tracking, and out-of-sync handling live in `CcShard` | `tx_service/include/cc/cc_shard.h`; `tx_service/src/cc/cc_shard.cpp` |
 | Subscription, sequence reset, snapshot, and checkpoint RPCs cross the CC control plane | `tx_service/include/proto/cc_request.proto`; `tx_service/src/remote/cc_node_service.cpp` |
 | Stream receive routes standby messages back to their owning shard | `tx_service/src/remote/cc_stream_receiver.cpp`; `tx_service/src/remote/cc_stream_sender.cpp` |

--- a/tx_service/src/standby.cpp
+++ b/tx_service/src/standby.cpp
@@ -96,7 +96,11 @@ void StandbyForwardEntry::AddOverWriteCommand(TxCommand *cmd)
     assert(cmd->IsOverwrite());
     auto &req = Request();
     req.set_has_overwrite(true);
-    req.clear_cmd_list();
+    // Clear() keeps the replaced strings and their capacities inside protobuf.
+    // They are no longer needed, and ByteSizeLong() would not account for them
+    // if this entry later waits in the standby history buffer.
+    google::protobuf::RepeatedPtrField<std::string>{}.Swap(
+        req.mutable_cmd_list());
     std::string cmd_str;
     cmd->Serialize(cmd_str);
     req.add_cmd_list(std::move(cmd_str));

--- a/tx_service/tests/StandbyForward-Test.cpp
+++ b/tx_service/tests/StandbyForward-Test.cpp
@@ -116,6 +116,16 @@ struct FakeObjectCommand : public TxCommand
 
     std::string payload_;
 };
+
+struct FakeOverwriteCommand : public FakeObjectCommand
+{
+    using FakeObjectCommand::FakeObjectCommand;
+
+    bool IsOverwrite() const override
+    {
+        return true;
+    }
+};
 }  // namespace
 
 // Remote ApplyCc: the coordinator forwards a pre-ExecuteOn command image
@@ -162,6 +172,95 @@ TEST_CASE("StandbyForward local serializes executed command",
     REQUIRE(entry.Request().cmd_list_size() == 1);
     REQUIRE(entry.Request().cmd_list(0) == "POST");
     REQUIRE(entry.Request().has_overwrite() == false);
+}
+
+TEST_CASE("Standby overwrite releases discarded command storage",
+          "[standby-forward][memory]")
+{
+    constexpr size_t image_size = 1024 * 1024;
+    constexpr size_t command_count = 8;
+    FakeObjectCommand large_command(std::string(image_size, 'x'));
+    ApplyCc cc_req(/*is_local=*/true);
+    cc_req.local_input_.key_ = nullptr;
+    cc_req.local_input_.cmd_ = &large_command;
+
+    StandbyForwardEntry entry;
+    for (size_t i = 0; i < command_count; ++i)
+    {
+        entry.AddTxCommand(cc_req);
+    }
+    REQUIRE(entry.Message().SpaceUsedLong() >= image_size * command_count);
+
+    FakeOverwriteCommand overwrite("replacement");
+    entry.AddOverWriteCommand(&overwrite);
+
+    REQUIRE(entry.Request().cmd_list_size() == 1);
+    REQUIRE(entry.Request().cmd_list(0) == "replacement");
+    REQUIRE(entry.Request().has_overwrite());
+
+    StandbyForwardEntry fresh_entry;
+    fresh_entry.AddOverWriteCommand(&overwrite);
+    // Compare owned protobuf storage, not just serialized bytes: Clear() made
+    // the old implementation small on the wire while keeping all 8 MiB alive.
+    REQUIRE(entry.Message().SpaceUsedLong() <=
+            fresh_entry.Message().SpaceUsedLong() + 4096);
+
+    // The same entry may accumulate more commands before another overwrite.
+    entry.AddTxCommand(cc_req);
+    entry.AddOverWriteCommand(&overwrite);
+    REQUIRE(entry.Request().cmd_list_size() == 1);
+    REQUIRE(entry.Message().SpaceUsedLong() <=
+            fresh_entry.Message().SpaceUsedLong() + 4096);
+}
+
+TEST_CASE("Standby overwrite preserves routing and following commands",
+          "[standby-forward]")
+{
+    StandbyForwardEntry entry;
+    entry.SetSequenceId(17);
+    auto &req = entry.Request();
+    req.set_key("key");
+    req.set_table_name("table");
+    req.set_key_shard_code(42);
+    req.set_primary_leader_term(3);
+    req.set_forward_seq_grp(2);
+    req.set_forward_seq_id(17);
+    req.set_object_version(19);
+    req.set_commit_ts(23);
+    req.set_schema_version(29);
+    req.set_tx_number(31);
+
+    FakeObjectCommand preceding("discarded");
+    ApplyCc cc_req(/*is_local=*/true);
+    cc_req.local_input_.key_ = nullptr;
+    cc_req.local_input_.cmd_ = &preceding;
+    entry.AddTxCommand(cc_req);
+
+    FakeOverwriteCommand overwrite("replacement");
+    entry.AddOverWriteCommand(&overwrite);
+    FakeObjectCommand following("following");
+    cc_req.local_input_.cmd_ = &following;
+    entry.AddTxCommand(cc_req);
+
+    remote::CcMessage received;
+    REQUIRE(received.ParseFromString(entry.Message().SerializeAsString()));
+    const auto &received_req = received.key_obj_standby_forward_req();
+    REQUIRE(received_req.cmd_list_size() == 2);
+    REQUIRE(received_req.cmd_list(0) == "replacement");
+    REQUIRE(received_req.cmd_list(1) == "following");
+    REQUIRE(received_req.has_overwrite());
+    REQUIRE_FALSE(received_req.out_of_sync());
+    REQUIRE(entry.SequenceId() == 17);
+    REQUIRE(received_req.key() == "key");
+    REQUIRE(received_req.table_name() == "table");
+    REQUIRE(received_req.key_shard_code() == 42);
+    REQUIRE(received_req.primary_leader_term() == 3);
+    REQUIRE(received_req.forward_seq_grp() == 2);
+    REQUIRE(received_req.forward_seq_id() == 17);
+    REQUIRE(received_req.object_version() == 19);
+    REQUIRE(received_req.commit_ts() == 23);
+    REQUIRE(received_req.schema_version() == 29);
+    REQUIRE(received_req.tx_number() == 31);
 }
 
 }  // namespace txservice


### PR DESCRIPTION
## Context

A standby forward entry can accumulate large serialized commands before an internally generated overwrite replaces them. Protobuf `clear_cmd_list()` removed the logical commands but retained their strings and capacities in that live entry. These obsolete bytes were also absent from the history buffer's `ByteSizeLong()` accounting.

## Behavior before and after

Replacing eight 1 MiB commands with a small overwrite now releases the replaced command storage immediately. Routing/version fields and the overwrite-plus-following-command sequence stay unchanged; the wire format is unchanged.

## Implementation

Swap the old repeated string field with an empty non-arena field in `StandbyForwardEntry::AddOverWriteCommand`, then serialize the overwrite. The temporary field destroys the replaced strings before a new payload is added. Keep the protobuf storage-retention rationale in the source comment beside the swap.

## Design decisions and alternatives

Release only the obsolete command field. Rebuilding the whole message would unnecessarily replace routing/version metadata. This runs on the owner shard while constructing the forward entry, before it is handed to the stream/history path. The change does not redefine total history memory accounting or allocator RSS behavior.

## Test plan

This revision removes the PR-specific architecture prose and its source-map row. The existing architecture model remains sufficient; the local cleanup rationale stays beside the implementation.

Checks run for this documentation revision (all passed):

```text
git diff --exit-code d1acea36aac64bd92ea14541096bed4e55d8fe24 HEAD -- . ':(exclude)docs/**'
git diff --exit-code 5c0be9f09b40b3358c14b7401765127b1f4210ed HEAD -- docs/
git diff --check 5c0be9f09b40b3358c14b7401765127b1f4210ed HEAD
```

These checks verify that product code, tests, and build files are unchanged, the PR has no remaining architecture-document diff, and the complete merge-base diff has no whitespace errors. No build, C++ test, integration, HA, sanitizer, or performance test was rerun for this Markdown-only revision. No current-head CI result is claimed here.

Prior verification, recorded before this revision and not rerun here:

The prior PR record reports 30 assertions in 4 cases and CTest 4/4 passing on commit `c320f94a99fc3717a9ae3e69d37c0f5aad407cb7` (base `ee0f476`). Its baseline control retained 8,389,192 bytes against a 4,344-byte limit and failed as expected.

Those tests preceded the rebase onto `5c0be9f`; they are not presented as a local test run on the current head.

## Risk assessment

The replaced field is exclusively owned by the forward entry; no new concurrency or durability boundary is introduced. Large-to-large overwrites may allocate a fresh command string instead of reusing an obsolete capacity. The result's live capacity and other protocol bookkeeping may still exceed serialized size.

## Rollback plan

Revert this commit. No configuration, protocol, or persisted-data migration is required.

## Reviewer guide

Review `StandbyForwardEntry::AddOverWriteCommand` and the two new cases in `StandbyForward-Test.cpp`: one measures actual protobuf-owned storage after repeated replacement, the other round-trips the message and verifies routing metadata and command order.

## Follow-up work

Candidate cancellation/history GC and terminal replay ownership are separate changes; this PR does not address them.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved standby replication handling when overwrite commands replace earlier commands, preventing unnecessary retained memory.
  - Preserved routing and version information during overwrite processing.
  - Ensured commands added after an overwrite continue to be retained correctly.
  - Corrected remote forwarding so it carries the executed command state rather than an outdated pre-execution state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->