### PR TITLE
fix: reclaim standby history after candidate removal

### DIFF
--- a/docs/standby_replication_protocol.md
+++ b/docs/standby_replication_protocol.md
@@ -47,13 +47,8 @@ primary retains messages needed by a failed send or a bootstrapping candidate.
 
 The primary-side history is a bounded recovery backlog, not an unbounded audit
 log. Entries that every subscriber has passed and no candidate still needs are
-released. Cancelling a candidate or removing it after history eviction also
-releases entries that no remaining consumer needs. Promotion establishes the
-subscriber's history protection before removing its candidate on the owner
-shard, so bootstrap history remains owned throughout the transition.
-
-If a send fails, the primary retries from the subscriber's next sequence id
-while the required entries remain buffered.
+released. If a send fails, the primary retries from the subscriber's next
+sequence id while the required entries remain buffered.
 
 Memory pressure may evict an entry that a subscriber still needs. In that case
 the primary sends an explicit out-of-sync indication and stops advancing the
@@ -142,7 +137,6 @@ term or all-log-groups recovery barriers described in
 | Standby entries, sequence groups, session terms, and checkpoint broadcasts define the protocol state | `tx_service/include/standby.h`; `tx_service/src/standby.cpp` |
 | Committed commands are captured on the owner-side apply path with standby replay semantics | `tx_service/include/cc/object_cc_map.h`; `tx_service/tests/StandbyForward-Test.cpp` |
 | Per-shard sequencing, bounded buffering, retry, gap tracking, and out-of-sync handling live in `CcShard` | `tx_service/include/cc/cc_shard.h`; `tx_service/src/cc/cc_shard.cpp` |
-| Candidate removal reclaims unneeded history, while promotion preserves continuous subscriber protection | `tx_service/include/cc/cc_shard.h`; `tx_service/src/cc/cc_shard.cpp`; `tx_service/src/remote/cc_node_service.cpp`; `tx_service/tests/StandbyHistory-Test.cpp` |
 | Subscription, sequence reset, snapshot, and checkpoint RPCs cross the CC control plane | `tx_service/include/proto/cc_request.proto`; `tx_service/src/remote/cc_node_service.cpp` |
 | Stream receive routes standby messages back to their owning shard | `tx_service/src/remote/cc_stream_receiver.cpp`; `tx_service/src/remote/cc_stream_sender.cpp` |
 | Following and standby-to-leader transitions are coordinated by `CcNode` | `tx_service/include/fault/cc_node.h`; `tx_service/src/fault/cc_node.cpp` |

--- a/docs/standby_replication_protocol.md
+++ b/docs/standby_replication_protocol.md
@@ -47,8 +47,13 @@ primary retains messages needed by a failed send or a bootstrapping candidate.
 
 The primary-side history is a bounded recovery backlog, not an unbounded audit
 log. Entries that every subscriber has passed and no candidate still needs are
-released. If a send fails, the primary retries from the subscriber's next
-sequence id while the required entries remain buffered.
+released. Cancelling a candidate or removing it after history eviction also
+releases entries that no remaining consumer needs. Promotion establishes the
+subscriber's history protection before removing its candidate on the owner
+shard, so bootstrap history remains owned throughout the transition.
+
+If a send fails, the primary retries from the subscriber's next sequence id
+while the required entries remain buffered.
 
 Memory pressure may evict an entry that a subscriber still needs. In that case
 the primary sends an explicit out-of-sync indication and stops advancing the
@@ -137,6 +142,7 @@ term or all-log-groups recovery barriers described in
 | Standby entries, sequence groups, session terms, and checkpoint broadcasts define the protocol state | `tx_service/include/standby.h`; `tx_service/src/standby.cpp` |
 | Committed commands are captured on the owner-side apply path with standby replay semantics | `tx_service/include/cc/object_cc_map.h`; `tx_service/tests/StandbyForward-Test.cpp` |
 | Per-shard sequencing, bounded buffering, retry, gap tracking, and out-of-sync handling live in `CcShard` | `tx_service/include/cc/cc_shard.h`; `tx_service/src/cc/cc_shard.cpp` |
+| Candidate removal reclaims unneeded history, while promotion preserves continuous subscriber protection | `tx_service/include/cc/cc_shard.h`; `tx_service/src/cc/cc_shard.cpp`; `tx_service/src/remote/cc_node_service.cpp`; `tx_service/tests/StandbyHistory-Test.cpp` |
 | Subscription, sequence reset, snapshot, and checkpoint RPCs cross the CC control plane | `tx_service/include/proto/cc_request.proto`; `tx_service/src/remote/cc_node_service.cpp` |
 | Stream receive routes standby messages back to their owning shard | `tx_service/src/remote/cc_stream_receiver.cpp`; `tx_service/src/remote/cc_stream_sender.cpp` |
 | Following and standby-to-leader transitions are coordinated by `CcNode` | `tx_service/include/fault/cc_node.h`; `tx_service/src/fault/cc_node.cpp` |

--- a/tx_service/include/cc/cc_shard.h
+++ b/tx_service/include/cc/cc_shard.h
@@ -1140,6 +1140,11 @@ public:
     void ForwardStandbyMessage(StandbyForwardEntry *entry);
     void AddCandidateStandby(uint32_t node_id, uint64_t start_seq_id);
     void RemoveCandidateStandby(uint32_t node_id);
+    // Called on the owning shard. Install the subscriber watermark before
+    // removing its candidate so cleanup cannot discard the bootstrap history.
+    void PromoteCandidateStandby(uint32_t node_id,
+                                 uint64_t start_seq_id,
+                                 int64_t standby_node_term);
     void CheckAndFreeUnneededEntries();
     void AddSubscribedStandby(uint32_t node_id,
                               uint64_t start_seq_id,
@@ -1545,5 +1550,6 @@ private:
     friend class LocalCcHandler;
     friend class LocalCcShards;
     friend class Checkpointer;
+    friend class StandbyHistoryTestPeer;
 };
 }  // namespace txservice

--- a/tx_service/src/cc/cc_shard.cpp
+++ b/tx_service/src/cc/cc_shard.cpp
@@ -3339,7 +3339,18 @@ void CcShard::RemoveCandidateStandby(uint32_t node_id)
         candidate_standby_nodes_.erase(it);
         LOG(INFO) << "Removed candidate standby node " << node_id
                   << " from shard " << core_id_;
+        // A candidate can be the only reason these entries were buffered.
+        // Successful writes do not schedule a retry that would collect them.
+        CheckAndFreeUnneededEntries();
     }
+}
+
+void CcShard::PromoteCandidateStandby(uint32_t node_id,
+                                      uint64_t start_seq_id,
+                                      int64_t standby_node_term)
+{
+    AddSubscribedStandby(node_id, start_seq_id, standby_node_term);
+    RemoveCandidateStandby(node_id);
 }
 
 void CcShard::CheckAndFreeUnneededEntries()
@@ -3558,6 +3569,7 @@ void CcShard::ForwardStandbyMessage(StandbyForwardEntry *entry)
         }
         if (largest_removed_seq_id > 0)
         {
+            bool removed_candidate = false;
             // Check and remove affected candidates (if evicted message's seq_id
             // >= candidate's start_seq_id)
             auto candidate_it = candidate_standby_nodes_.begin();
@@ -3573,11 +3585,18 @@ void CcShard::ForwardStandbyMessage(StandbyForwardEntry *entry)
                               << " is no longer in history (evicted seq_id: "
                               << largest_removed_seq_id << ")";
                     candidate_it = candidate_standby_nodes_.erase(candidate_it);
+                    removed_candidate = true;
                 }
                 else
                 {
                     ++candidate_it;
                 }
+            }
+            if (removed_candidate)
+            {
+                // Entries below the cap can still belong only to candidates
+                // whose bootstrap was invalidated by the eviction above.
+                CheckAndFreeUnneededEntries();
             }
         }
     }

--- a/tx_service/src/remote/cc_node_service.cpp
+++ b/tx_service/src/remote/cc_node_service.cpp
@@ -2242,9 +2242,7 @@ void CcNodeService::ResetStandbySequenceId(
             if (Sharder::Instance().CheckLeaderTerm(
                     ng_id, PrimaryTermFromStandbyTerm(standby_node_term)))
             {
-                // Remove from candidates and add to subscribed
-                ccs.RemoveCandidateStandby(node_id);
-                ccs.AddSubscribedStandby(
+                ccs.PromoteCandidateStandby(
                     node_id, seq_ids.at(ccs.core_id_), standby_node_term);
             }
             return true;

--- a/tx_service/tests/CMakeLists.txt
+++ b/tx_service/tests/CMakeLists.txt
@@ -69,6 +69,7 @@ set(CATCH_MAIN_TESTS
     NonBlockingLock-Test
     AcquireAllError-Test
     StandbyForward-Test
+    StandbyHistory-Test
     ApplyResponseBoundary-Test
     TransactionImageLifetime-Test
 )

--- a/tx_service/tests/StandbyHistory-Test.cpp
+++ b/tx_service/tests/StandbyHistory-Test.cpp
@@ -1,0 +1,266 @@
+/**
+ *    Copyright (C) 2025 EloqData Inc.
+ *
+ *    This program is free software: you can redistribute it and/or  modify
+ *    it under either of the following two licenses:
+ *    1. GNU Affero General Public License, version 3, as published by the Free
+ *    Software Foundation.
+ *    2. GNU General Public License as published by the Free Software
+ *    Foundation; version 2 of the License.
+ *
+ *    This program is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU Affero General Public License or GNU General Public License for more
+ *    details.
+ *
+ *    You should have received a copy of the GNU Affero General Public License
+ *    and GNU General Public License V2 along with this program.  If not, see
+ *    <http://www.gnu.org/licenses/>.
+ *
+ */
+#include <catch2/catch_all.hpp>
+#include <cstdint>
+#include <map>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "cc/cc_shard.h"
+#include "cc/local_cc_shards.h"
+#include "standby.h"
+
+namespace txservice
+{
+// Inspect the actual owning queue, its lookup index, and its accounting
+// together; serialized byte counts alone cannot establish entry reclamation.
+class StandbyHistoryTestPeer
+{
+public:
+    static std::vector<uint64_t> Sequences(const CcShard &shard)
+    {
+        std::vector<uint64_t> sequences;
+        for (const auto &entry : shard.history_standby_msg_)
+        {
+            sequences.push_back(entry->SequenceId());
+        }
+        return sequences;
+    }
+
+    static uint64_t MemoryUsage(const CcShard &shard)
+    {
+        return shard.total_standby_buffer_memory_usage_;
+    }
+
+    static const remote::CcMessage &Message(const CcShard &shard,
+                                            uint64_t sequence)
+    {
+        return shard.seq_id_to_entry_map_.at(sequence)->Message();
+    }
+
+    static bool Consistent(const CcShard &shard)
+    {
+        if (shard.history_standby_msg_.size() !=
+            shard.seq_id_to_entry_map_.size())
+        {
+            return false;
+        }
+        uint64_t memory_usage = 0;
+        for (const auto &entry : shard.history_standby_msg_)
+        {
+            auto it = shard.seq_id_to_entry_map_.find(entry->SequenceId());
+            if (it == shard.seq_id_to_entry_map_.end() ||
+                it->second != entry.get())
+            {
+                return false;
+            }
+            memory_usage += entry->MemorySize();
+        }
+        return memory_usage == MemoryUsage(shard);
+    }
+
+    static void SetMemoryLimit(CcShard &shard, uint64_t limit)
+    {
+        shard.standby_buffer_memory_limit_ = limit;
+    }
+
+    static std::pair<uint64_t, int64_t> Subscriber(const CcShard &shard,
+                                                   uint32_t node_id)
+    {
+        return shard.subscribed_standby_nodes_.at(node_id);
+    }
+};
+
+namespace
+{
+struct HistoryFixture
+{
+    HistoryFixture()
+        : shards(0,
+                 0,
+                 config,
+                 factories,
+                 nullptr,
+                 &node_groups,
+                 1,
+                 nullptr,
+                 nullptr,
+                 false)
+    {
+    }
+
+    CcShard &Shard()
+    {
+        return *shards.GetCcShard(0);
+    }
+
+    void Forward(size_t count, size_t bytes = 1024 * 1024)
+    {
+        // There are no subscribers during capture, so this executes the real
+        // candidate buffering/cap path without starting any RPC services.
+        for (size_t i = 0; i < count; ++i)
+        {
+            auto entry = std::make_unique<StandbyForwardEntry>();
+            entry->Request().set_key("key");
+            entry->Request().add_cmd_list(std::string(bytes, 'x'));
+            Shard().ForwardStandbyMessage(entry.release());
+        }
+    }
+
+    const std::map<std::string, uint32_t> config{
+        {"core_num", 1},
+        {"node_memory_limit_mb", 1024},
+        {"range_slice_memory_limit_percent", 1},
+        {"realtime_sampling", 0},
+        {"range_split_worker_num", 1},
+        {"enable_shard_heap_defragment", 0}};
+    CatalogFactory *factories[NUM_EXTERNAL_ENGINES]{};
+    std::unordered_map<uint32_t, std::vector<NodeConfig>> node_groups{
+        {0, {NodeConfig(0, "127.0.0.1", 0)}}};
+    LocalCcShards shards;
+};
+
+void RequireHistory(CcShard &shard, const std::vector<uint64_t> &expected)
+{
+    REQUIRE(StandbyHistoryTestPeer::Sequences(shard) == expected);
+    REQUIRE(StandbyHistoryTestPeer::Consistent(shard));
+    for (uint64_t sequence : expected)
+    {
+        const auto &request = StandbyHistoryTestPeer::Message(shard, sequence)
+                                  .key_obj_standby_forward_req();
+        REQUIRE(request.forward_seq_id() == sequence);
+        REQUIRE(request.forward_seq_grp() == shard.core_id_);
+        REQUIRE(request.cmd_list_size() == 1);
+        REQUIRE(request.cmd_list(0) == std::string(1024 * 1024, 'x'));
+    }
+    if (expected.empty())
+    {
+        REQUIRE(StandbyHistoryTestPeer::MemoryUsage(shard) == 0);
+    }
+}
+}  // namespace
+
+TEST_CASE("Cancelling the final standby candidate releases its history",
+          "[standby-history][memory]")
+{
+    HistoryFixture fixture;
+    auto &shard = fixture.Shard();
+    shard.AddCandidateStandby(1, 1);
+    fixture.Forward(3);
+    RequireHistory(shard, {1, 2, 3});
+    REQUIRE(StandbyHistoryTestPeer::MemoryUsage(shard) >= 3 * 1024 * 1024);
+
+    shard.RemoveCandidateStandby(1);
+    RequireHistory(shard, {});
+    REQUIRE(shard.GetCandidateStandbys().empty());
+
+    // No retry, further write, or unsubscribe is needed to reclaim the data.
+    shard.RemoveCandidateStandby(1);
+    RequireHistory(shard, {});
+}
+
+TEST_CASE("Candidate cancellation retains other consumers' history",
+          "[standby-history]")
+{
+    HistoryFixture fixture;
+    auto &shard = fixture.Shard();
+    shard.AddCandidateStandby(1, 1);
+    shard.AddCandidateStandby(2, 3);
+    fixture.Forward(4);
+
+    shard.AddSubscribedStandby(3, 2, 5);
+    shard.RemoveCandidateStandby(1);
+    RequireHistory(shard, {2, 3, 4});
+    shard.RemoveSubscribedStandby(3);
+    RequireHistory(shard, {3, 4});
+    shard.AddSubscribedStandby(3, 4, 6);
+    shard.RemoveCandidateStandby(2);
+    RequireHistory(shard, {4});
+    REQUIRE(StandbyHistoryTestPeer::Subscriber(shard, 3).first == 3);
+
+    shard.RemoveSubscribedStandby(3);
+    RequireHistory(shard, {});
+}
+
+TEST_CASE("Candidate promotion protects the subscriber's bootstrap history",
+          "[standby-history]")
+{
+    HistoryFixture fixture;
+    auto &shard = fixture.Shard();
+    shard.AddCandidateStandby(1, 1);
+    fixture.Forward(4);
+
+    shard.PromoteCandidateStandby(1, 2, 5);
+    REQUIRE(shard.GetCandidateStandbys().empty());
+    REQUIRE(shard.GetSubscribedStandbys() == std::vector<uint32_t>{1});
+    RequireHistory(shard, {2, 3, 4});
+    REQUIRE(StandbyHistoryTestPeer::Subscriber(shard, 1) ==
+            std::make_pair(uint64_t{1}, int64_t{5}));
+
+    // A renewed subscription may advance the watermark, but a stale term
+    // must retain the existing subscriber state and its still-needed history.
+    shard.AddCandidateStandby(1, 2);
+    shard.PromoteCandidateStandby(1, 3, 6);
+    RequireHistory(shard, {3, 4});
+    shard.AddCandidateStandby(1, 3);
+    shard.PromoteCandidateStandby(1, 4, 5);
+    RequireHistory(shard, {3, 4});
+    REQUIRE(StandbyHistoryTestPeer::Subscriber(shard, 1) ==
+            std::make_pair(uint64_t{2}, int64_t{6}));
+}
+
+TEST_CASE("History cap eviction collects abandoned candidate messages",
+          "[standby-history][memory]")
+{
+    HistoryFixture fixture;
+    auto &shard = fixture.Shard();
+    constexpr uint64_t image_size = 1024 * 1024;
+    StandbyHistoryTestPeer::SetMemoryLimit(shard, 2 * image_size + 1024);
+    shard.AddCandidateStandby(1, 1);
+    fixture.Forward(2, image_size);
+    RequireHistory(shard, {1, 2});
+
+    fixture.Forward(1, image_size);
+    REQUIRE(shard.GetCandidateStandbys().empty());
+    RequireHistory(shard, {});
+}
+
+TEST_CASE("History cap eviction retains a later candidate's messages",
+          "[standby-history]")
+{
+    HistoryFixture fixture;
+    auto &shard = fixture.Shard();
+    constexpr uint64_t image_size = 1024 * 1024;
+    StandbyHistoryTestPeer::SetMemoryLimit(shard, 2 * image_size + 1024);
+    shard.AddCandidateStandby(1, 1);
+    shard.AddCandidateStandby(2, 3);
+    fixture.Forward(3, image_size);
+
+    REQUIRE(shard.GetCandidateStandbys() == std::vector<uint32_t>{2});
+    RequireHistory(shard, {3});
+    shard.RemoveCandidateStandby(2);
+    RequireHistory(shard, {});
+}
+}  // namespace txservice


### PR DESCRIPTION
## Context

A candidate standby can be the only consumer protecting large forward entries in a primary shard's history. Cancelling that candidate, or removing it after memory-cap eviction, previously erased the candidate but left otherwise-unneeded entries owned by the history queue. Successful writes do not schedule the retry cleanup, so the retained entries could remain idle until another unrelated cleanup trigger.

## Behavior before and after

Cancellation and cap-driven candidate removal now reclaim history that no remaining candidate or subscribed standby needs. Promotion preserves bootstrap messages by installing the subscriber watermark before removing its candidate on the same shard. Subscriber term acceptance, wire format, sequence allocation, and retry scheduling remain unchanged.

## Implementation

- Run existing watermark GC after a candidate is removed explicitly.
- Use `PromoteCandidateStandby` from `ResetStandbySequenceId` to preserve the required ownership order.
- Run watermark GC once after cap eviction removes affected candidates.
- Explain cleanup triggers and promotion ordering beside the affected shard code and API.

## Design decisions and alternatives

GC reuses the existing minimum-needed-sequence rule across both subscribed and candidate consumers. Merely adding GC to `RemoveCandidateStandby` with the original RPC order would temporarily leave a promoted node unprotected and discard its bootstrap history, so promotion is a single owner-shard API. The cap path finishes its candidate-map iteration before invoking GC and never reuses `entry_raw` afterward.

## Test plan

This revision removes the PR-specific architecture prose and its source-map row. The existing architecture model remains sufficient; the local cleanup rationale stays beside the implementation.

Checks run for this documentation revision (all passed):

```text
git diff --exit-code 158a2e6f82e99fdce7268bb7c716be7b08f1cb90 HEAD -- . ':(exclude)docs/**'
git diff --exit-code 5c0be9f09b40b3358c14b7401765127b1f4210ed HEAD -- docs/
git diff --check 5c0be9f09b40b3358c14b7401765127b1f4210ed HEAD
```

These checks verify that product code, tests, and build files are unchanged, the PR has no remaining architecture-document diff, and the complete merge-base diff has no whitespace errors. No build, C++ test, integration, HA, sanitizer, or performance test was rerun for this Markdown-only revision. No current-head CI result is claimed here.

Prior verification, recorded before this revision and not rerun here:

The prior PR record reports 118 assertions in 5 history cases and CTest 7/7 passing on commit `e2c686fdfed7bfb07b12db69bf8e40a98df3ec9a` (base `ee0f476`). The baseline cancellation and cap-removal controls retained sequences {1, 2, 3} and {2, 3}, respectively, and failed their release assertions as expected.

Those tests preceded the rebase onto `5c0be9f`; they are not presented as a local test run on the current head.

## Risk assessment

Cleanup can perform more destructor work in the candidate-removal callback, bounded by the already-retained history. All operations occur on the owner shard. The subscriber must be installed before candidate GC during promotion; remaining consumers must continue protecting their requested sequence ranges. This change does not alter WAL/checkpoint durability, fencing rules, or the serialized-byte history quota, and does not claim to diagnose any observed production timeout.

## Rollback plan

Revert this commit. No data/configuration migration is required.

## Reviewer guide

Review `RemoveCandidateStandby`, `PromoteCandidateStandby`, and the cap-eviction tail in `ForwardStandbyMessage`; then the `ResetStandbySequenceId` call site and the five real-queue regressions. The test peer exposes queue/index/accounting state only to the test.

## Follow-up work

Overwrite protobuf capacity and replay-terminal ownership are separate changes. Initial-subscription retry scheduling and broader generation fencing are unchanged.
