### PR TITLE
fix: release unconsumed local read buffers before pooling

### DIFF
--- a/docs/09-store-handler.md
+++ b/docs/09-store-handler.md
@@ -53,6 +53,11 @@ owner uses the same service operation through an in-process request path;
 otherwise the client uses the protobuf RPC surface. Local bypass changes
 transport cost, not storage semantics.
 
+A read closure keeps its returned value valid until the final callback returns.
+The consumer may transfer, copy, or discard that value; any unconsumed value
+buffer is released before the closure returns to its pool. Pending retries keep
+ownership of the closure until the operation reaches terminal completion.
+
 ## Shard ownership and retries
 
 `DataStoreService` gates requests by per-shard ownership and lifecycle state.
@@ -129,6 +134,7 @@ term writable again.
 | `DataStoreHandler` defines the tx/storage persistence and lifecycle boundary | `tx_service/include/store/data_store_handler.h` |
 | Startup selects embedded RocksDB or an EloqDSS client/backend composition | `core/src/storage_init.cpp`; `CMakeLists.txt`; `store_handler/eloq_data_store_service/CMakeLists.txt` |
 | EloqDSS client routing supports local service bypass and remote RPC completion | `store_handler/data_store_service_client.h`; `store_handler/data_store_service_client.cpp`; `store_handler/data_store_service_client_closure.h`; `store_handler/data_store_service_client_closure.cpp` |
+| Read closures retain values through callbacks and release unconsumed buffers before pool reuse | `store_handler/data_store_service_client_closure.h`; `store_handler/eloq_data_store_service/object_pool.h`; `tx_service/tests/ReadClosureLifetime-Test.cpp` |
 | EloqDSS owns versioned data shards behind a pluggable `DataStore` interface | `store_handler/eloq_data_store_service/data_store_service.h`; `store_handler/eloq_data_store_service/data_store_service.cpp`; `store_handler/eloq_data_store_service/data_store.h`; `store_handler/eloq_data_store_service/ds_request.proto` |
 | Embedded RocksDB implements the same handler contract without DSS transport | `store_handler/rocksdb_handler.h`; `store_handler/rocksdb_handler.cpp` |
 | Checkpoint data sync depends on `PutAll` and the optional persistence barrier | `tx_service/src/cc/local_cc_shards.cpp`; `tx_service/include/data_sync_task.h`; `tx_service/src/data_sync_task.cpp`; `tx_service/src/checkpointer.cpp` |

--- a/store_handler/data_store_service_client_closure.h
+++ b/store_handler/data_store_service_client_closure.h
@@ -818,7 +818,9 @@ public:
         shard_id_ = UINT32_MAX;
         key_ = "";
         result_.Clear();
-        value_.clear();
+        // A callback may discard an expired value or copy it instead of taking
+        // ownership. Do not retain that buffer while this closure is idle.
+        std::string{}.swap(value_);
         ts_ = 0;
         callback_ = nullptr;
         callback_data_ = nullptr;

--- a/tx_service/tests/CMakeLists.txt
+++ b/tx_service/tests/CMakeLists.txt
@@ -79,6 +79,10 @@ if(WITH_DATA_STORE STREQUAL "ELOQDSS_ROCKSDB" OR
     list(APPEND CATCH_MAIN_TESTS TTLCompactionFilter-Test)
 endif()
 
+if(WITH_DATA_STORE MATCHES "^ELOQDSS_")
+    list(APPEND CATCH_MAIN_TESTS ReadClosureLifetime-Test)
+endif()
+
 # Tests that define their own int main() (they need gflags::ParseCommandLineFlags
 # before brpc is used). They link Catch2::Catch2 (no bundled main).
 set(OWN_MAIN_TESTS

--- a/tx_service/tests/ReadClosureLifetime-Test.cpp
+++ b/tx_service/tests/ReadClosureLifetime-Test.cpp
@@ -1,0 +1,270 @@
+/**
+ *    Copyright (C) 2026 EloqData Inc.
+ *
+ *    This program is free software: you can redistribute it and/or  modify
+ *    it under either of the following two licenses:
+ *    1. GNU Affero General Public License, version 3, as published by the Free
+ *    Software Foundation.
+ *    2. GNU General Public License as published by the Free Software
+ *    Foundation; version 2 of the License.
+ *
+ *    This program is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU Affero General Public License or GNU General Public License for more
+ *    details.
+ *
+ *    You should have received a copy of the GNU Affero General Public License
+ *    and GNU General Public License V2 along with this program.  If not, see
+ *    <http://www.gnu.org/licenses/>.
+ *
+ */
+#include <catch2/catch_all.hpp>
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "data_store_service_client_closure.h"
+#include "eloq_data_store_service/data_store_service_config.h"
+#include "eloq_data_store_service/internal_request.h"
+#include "eloq_data_store_service/object_pool.h"
+
+namespace
+{
+constexpr size_t kLargeValueSize = 1024 * 1024;
+
+enum class Consumption
+{
+    Take,
+    Copy,
+    Discard
+};
+
+struct Completion
+{
+    Consumption consumption{Consumption::Discard};
+    size_t calls{0};
+    size_t observed_size{0};
+    uint64_t observed_ttl{0};
+    int error_code{0};
+    bool in_use_during_callback{false};
+    std::string value;
+};
+
+void OnRead(void *data,
+            google::protobuf::Closure *closure,
+            EloqDS::DataStoreServiceClient &,
+            const EloqDS::remote::CommonResult &result)
+{
+    auto &completion = *static_cast<Completion *>(data);
+    auto &read = *static_cast<EloqDS::ReadClosure *>(closure);
+    ++completion.calls;
+    completion.observed_size = read.Value().size();
+    completion.observed_ttl = read.Ttl();
+    completion.error_code = result.error_code();
+    completion.in_use_during_callback = read.InUse();
+    if (completion.consumption == Consumption::Take)
+    {
+        completion.value = read.TakeValue();
+    }
+    else if (completion.consumption == Consumption::Copy)
+    {
+        completion.value.assign(read.Value());
+    }
+}
+
+class ReadFixture
+{
+public:
+    // No DSS, RPC or database is started. The real client only supplies the
+    // callback argument; its constructor's idle worker is joined on
+    // destruction.
+    ReadFixture() : client_(false, catalogs_, cluster_, false)
+    {
+    }
+
+    void Reset(EloqDS::ReadClosure &read, Completion &completion)
+    {
+        read.Reset(&client_, "table", 0, 0, "key", false, &completion, OnRead);
+        read.LocalTsRef() = 42;
+        read.LocalTtlRef() = 0;
+    }
+
+    void CompleteLocal(EloqDS::ReadClosure &read,
+                       EloqDS::remote::DataStoreError error,
+                       uint64_t ttl = 0)
+    {
+        // This is the same wrapper/closure completion chain used by the local
+        // storage backend, including Run's final PoolableGuard.
+        EloqDS::ReadLocalRequest request;
+        request.Reset(nullptr,
+                      "table",
+                      0,
+                      0,
+                      "key",
+                      false,
+                      &read.LocalValueRef(),
+                      &read.LocalTsRef(),
+                      &read.LocalTtlRef(),
+                      &read.LocalResultRef(),
+                      &read);
+        request.SetRecordTtl(ttl);
+        request.SetFinish(error);
+    }
+
+private:
+    txservice::CatalogFactory *catalogs_[3]{nullptr, nullptr, nullptr};
+    EloqDS::DataStoreServiceClusterManager cluster_;
+    EloqDS::DataStoreServiceClient client_;
+};
+
+void RequireReleased(EloqDS::ReadClosure &read)
+{
+    REQUIRE_FALSE(read.InUse());
+    REQUIRE(read.LocalValueRef().empty());
+    REQUIRE(read.LocalValueRef().capacity() == std::string{}.capacity());
+}
+}  // namespace
+
+TEST_CASE("ReadClosure Clear releases even a shortened local buffer",
+          "[read-closure]")
+{
+    const size_t final_size = GENERATE(kLargeValueSize, size_t{1}, size_t{0});
+    EloqDS::ReadClosure read;
+    read.LocalValueRef().assign(kLargeValueSize, 'x');
+    read.LocalValueRef().resize(final_size);
+    REQUIRE(read.LocalValueRef().capacity() >= kLargeValueSize);
+    read.Clear();
+    RequireReleased(read);
+}
+
+TEST_CASE(
+    "Local read completion preserves the consumer and releases the closure",
+    "[read-closure]")
+{
+    const auto consumption =
+        GENERATE(Consumption::Take, Consumption::Copy, Consumption::Discard);
+    // An expired value may still be returned by storage before compaction. The
+    // consumer decides whether to discard it, while the closure owns cleanup.
+    const uint64_t ttl = GENERATE(uint64_t{0}, uint64_t{1});
+    ReadFixture fixture;
+    EloqDS::ReadClosure read;
+    Completion completion;
+    completion.consumption = consumption;
+    read.Use();
+    fixture.Reset(read, completion);
+    read.LocalValueRef().assign(kLargeValueSize, 'x');
+    fixture.CompleteLocal(read, EloqDS::remote::NO_ERROR, ttl);
+
+    REQUIRE(completion.calls == 1);
+    REQUIRE(completion.in_use_during_callback);
+    REQUIRE(completion.observed_size == kLargeValueSize);
+    REQUIRE(completion.observed_ttl == ttl);
+    REQUIRE(completion.error_code == EloqDS::remote::NO_ERROR);
+    RequireReleased(read);
+    REQUIRE(completion.value == (consumption == Consumption::Discard
+                                     ? std::string{}
+                                     : std::string(kLargeValueSize, 'x')));
+}
+
+TEST_CASE("Local read errors release an unconsumed result at completion",
+          "[read-closure]")
+{
+    const auto error = GENERATE(EloqDS::remote::KEY_NOT_FOUND,
+                                EloqDS::remote::READ_FAILED,
+                                EloqDS::remote::DB_NOT_OPEN);
+    ReadFixture fixture;
+    EloqDS::ReadClosure read;
+    Completion completion;
+    read.Use();
+    fixture.Reset(read, completion);
+    read.LocalValueRef().assign(kLargeValueSize, 'x');
+    // Missing/error paths can clear the output's length before completing.
+    read.LocalValueRef().clear();
+    fixture.CompleteLocal(read, error);
+
+    REQUIRE(completion.calls == 1);
+    REQUIRE(completion.in_use_during_callback);
+    REQUIRE(completion.error_code == error);
+    RequireReleased(read);
+}
+
+TEST_CASE(
+    "A released retry guard retains the local buffer until final completion",
+    "[read-closure]")
+{
+    ReadFixture fixture;
+    EloqDS::ReadClosure read;
+    Completion completion;
+    completion.consumption = Consumption::Take;
+    read.Use();
+    fixture.Reset(read, completion);
+    read.LocalValueRef().assign(kLargeValueSize, 'x');
+    {
+        EloqDS::PoolableGuard attempt_guard(&read);
+        REQUIRE(attempt_guard.Release() == &read);
+    }
+    REQUIRE(read.InUse());
+    REQUIRE(read.LocalValueRef().size() == kLargeValueSize);
+    REQUIRE(completion.calls == 0);
+
+    // Exercise a local-to-remote continuation without sending an RPC. The
+    // production retry dispatcher is outside this ownership-boundary test.
+    read.PrepareRequest(false);
+    read.ReadResponse()->set_value("next attempt");
+    read.ReadResponse()->mutable_result()->set_error_code(
+        EloqDS::remote::NO_ERROR);
+    read.Run();
+    REQUIRE(completion.calls == 1);
+    REQUIRE(completion.in_use_during_callback);
+    REQUIRE(completion.value == "next attempt");
+    RequireReleased(read);
+}
+
+TEST_CASE(
+    "Pooled local read closures release payloads before the next checkout",
+    "[read-closure]")
+{
+    ReadFixture fixture;
+    EloqDS::ObjectPool<EloqDS::ReadClosure> pool;
+    std::vector<EloqDS::ReadClosure *> first_round;
+    bool released = true;
+    bool reused = true;
+    size_t callbacks = 0;
+    for (size_t round = 0; round < 3; ++round)
+    {
+        for (size_t slot = 0; slot < 8; ++slot)
+        {
+            auto *read = pool.NextObject();
+            // Keep assertions after completion so a failing assertion cannot
+            // leave an occupied slot blocking the pool's destructor.
+            EloqDS::PoolableGuard cleanup_on_failure(read);
+            if (round == 0)
+            {
+                first_round.push_back(read);
+            }
+            else
+            {
+                reused = reused && read == first_round[slot];
+                released = released && read->LocalValueRef().empty() &&
+                           read->LocalValueRef().capacity() ==
+                               std::string{}.capacity();
+            }
+            Completion completion;
+            fixture.Reset(*read, completion);
+            read->LocalValueRef().assign(kLargeValueSize, 'x');
+            fixture.CompleteLocal(*read, EloqDS::remote::NO_ERROR, 1);
+            cleanup_on_failure.Release();
+            callbacks += completion.calls;
+            released =
+                released && !read->InUse() && read->LocalValueRef().empty() &&
+                read->LocalValueRef().capacity() == std::string{}.capacity();
+        }
+    }
+    REQUIRE(callbacks == 24);
+    REQUIRE(reused);
+    REQUIRE(released);
+    REQUIRE(pool.IsAllFree());
+}


### PR DESCRIPTION
## Context

A local DSS read can leave its payload in a pooled `ReadClosure` when the callback discards an expired EloqKV record or copies a range record. `value_.clear()` reset the string length but retained the allocation while the closure was idle.

## Behavior before and after

A completed read now releases any unconsumed local buffer before the closure becomes reusable. The callback can still inspect the result or transfer it with `TakeValue()` until it returns. Read results, errors, TTL handling and the RPC format are unchanged.

## Implementation

Replace `value_.clear()` with an empty-string swap in `ReadClosure::Clear()`. The existing `PoolableGuard` runs this cleanup after the final callback and before publishing the closure as free. Update the store-handler ownership documentation and add a focused `ReadClosureLifetime-Test` target for DSS builds.

## Design decisions and alternatives

Release at terminal completion instead of the next checkout: an idle closure should not keep an unread large value indefinitely. The existing retry guard releases remain unchanged, preserving in-flight state across retries. The successful `TakeValue()` path keeps its move semantics.

## Test plan

- [x] Current-head scoped regression tests and the upstream range-scan regression
- [x] Incremental Debug/S3 build with all affected header dependencies rebuilt
- [x] clang-format-18 and merge-base diff checks
- [x] Architecture updated in the current document structure and source maps
- [ ] Live HA, RPC fault injection, alternate backends and unrelated full CTest suite (not run)

Validated head `dff10e942f7e76c85e9c20bb777cb7e9812f2d90` on base `5c0be9f09b40b3358c14b7401765127b1f4210ed`. The original fix's business source and test files are byte-identical to the pre-rebase commit; architecture text follows the new upstream layout. Dependency files confirm 38 objects using the changed shared headers were compiled after those headers changed.

The actual local read wrapper and final callback/guard chain cover taken, copied and discarded 1 MiB values, shortened output buffers, errors, a guard-released local-to-remote continuation, and repeated pool-slot reuse. The retry dispatcher and expiration decision are outside the fixture. `RangeScanMemory-Test` additionally exercises the upstream source-shard result-release change.

Results: CTest **6/6 passed**. ReadClosureLifetime-Test: 98 assertions in 5 test cases.

Environment: `PATH=/opt/eloq/third_party/bin:$PATH`; `LD_LIBRARY_PATH=/opt/eloq/third_party/lib:/opt/eloq/third_party/lib64`.

```sh
cmake --build /tmp/eloq-read-closure-fix.riiqrqSG/bld --target ReadClosureLifetime-Test RangeScanMemory-Test --parallel 2
ctest --test-dir /tmp/eloq-read-closure-fix.riiqrqSG/bld -L '^(ReadClosureLifetime-Test|RangeScanMemory-Test)$' --output-on-failure
/tmp/eloq-read-closure-fix.riiqrqSG/bld/tx_service/tests/ReadClosureLifetime-Test --reporter compact
clang-format-18 --dry-run --Werror store_handler/data_store_service_client_closure.h tx_service/tests/ReadClosureLifetime-Test.cpp
git diff --check 5c0be9f09b40b3358c14b7401765127b1f4210ed...HEAD
```

Exact configure/build/test argv, source hashes and dependency checks are saved in `rebase-verification.json` beside the isolated build. Current-run logs use the `rebase-` prefix.

## Risk assessment

Callbacks finish before cleanup, and retry attempts retain their guard ownership. Repeated unconsumed reads may allocate anew on subsequent use instead of retaining a large idle allocation. The allocator may retain freed pages, so this change does not promise an immediate RSS decrease. No disk data, WAL, checkpoint or wire-format changes.

## Rollback plan

Revert this PR; no migration or data rollback is needed.

## Reviewer guide

Review `ReadClosure::Clear()` with `ReadClosure::Run()` and `PoolableGuard::~PoolableGuard()`: cleanup must remain after final callback completion and before `Poolable::Free()` publishes availability. The new lifetime tests check both data survival and release of idle capacity.

## Follow-up work

This fix does not cap the number of pooled closures or change other datastore request pools.
