### PR TITLE
fix: refresh defragmented keys in place without leaking temporary objects

### DIFF
--- a/docs/03-concurrency-control.md
+++ b/docs/03-concurrency-control.md
@@ -116,6 +116,8 @@ replacement. Entry addresses used across asynchronous steps are valid only
 while a lock, intent, or explicit pin preserves the associated indirection;
 page split, merge, compaction, and eviction may otherwise move or destroy the
 entry.
+Page maintenance owns temporary key copies through relocation and destroys
+those temporary objects after transferring their contents into resident keys.
 
 Only state that is no longer transactionally owned and is already persistent
 may be evicted. Dirty entries remain resident until checkpointing advances

--- a/docs/03-concurrency-control.md
+++ b/docs/03-concurrency-control.md
@@ -116,8 +116,6 @@ replacement. Entry addresses used across asynchronous steps are valid only
 while a lock, intent, or explicit pin preserves the associated indirection;
 page split, merge, compaction, and eviction may otherwise move or destroy the
 entry.
-Page maintenance owns temporary key copies through relocation and destroys
-those temporary objects after transferring their contents into resident keys.
 
 Only state that is no longer transactionally owned and is already persistent
 may be evicted. Dirty entries remain resident until checkpointing advances

--- a/tx_service/include/cc/template_cc_map.h
+++ b/tx_service/include/cc/template_cc_map.h
@@ -9098,14 +9098,10 @@ protected:
             TxKey tx_key = TxKey(key);
             if (tx_key.NeedsDefrag(heap))
             {
-                // Copy before erase invalidates key; the temporary needs no
-                // separate heap allocation.
-                KeyT key_copy(*key);
-                auto &keys = current_page_->keys_;
-                auto it = keys.begin() + idx_in_page_;
-                assert(it != keys.end());
-                it = keys.erase(it);
-                it = keys.emplace(it, std::move(key_copy));
+                // Copy construction refreshes key-owned storage before the
+                // old value is released. Assign in place to preserve page
+                // positions and avoid growing the key vector on a full page.
+                *key = KeyT(*key);
                 defraged = true;
             }
 

--- a/tx_service/include/cc/template_cc_map.h
+++ b/tx_service/include/cc/template_cc_map.h
@@ -9103,7 +9103,8 @@ protected:
                 auto it = keys.begin() + idx_in_page_;
                 assert(it != keys.end());
                 it = keys.erase(it);
-                it = keys.emplace(it, std::move(*(key_clone.release())));
+                // The page takes the key contents, not the temporary object.
+                it = keys.emplace(it, std::move(*key_clone));
                 defraged = true;
             }
 

--- a/tx_service/include/cc/template_cc_map.h
+++ b/tx_service/include/cc/template_cc_map.h
@@ -9098,13 +9098,14 @@ protected:
             TxKey tx_key = TxKey(key);
             if (tx_key.NeedsDefrag(heap))
             {
-                auto key_clone = std::make_unique<KeyT>(*key);
+                // Copy before erase invalidates key; the temporary needs no
+                // separate heap allocation.
+                KeyT key_copy(*key);
                 auto &keys = current_page_->keys_;
                 auto it = keys.begin() + idx_in_page_;
                 assert(it != keys.end());
                 it = keys.erase(it);
-                // The page takes the key contents, not the temporary object.
-                it = keys.emplace(it, std::move(*key_clone));
+                it = keys.emplace(it, std::move(key_copy));
                 defraged = true;
             }
 

--- a/tx_service/tests/CMakeLists.txt
+++ b/tx_service/tests/CMakeLists.txt
@@ -61,6 +61,7 @@ set(CATCH_MAIN_TESTS
     CcEntry-Test
     CcMessagePool-Test
     CcPage-Test
+    CcPageDefrag-Test
     LargeObjLRU-Test
     CcRequestWait-Test
     CcRequestPool-Test

--- a/tx_service/tests/CcPageDefrag-Test.cpp
+++ b/tx_service/tests/CcPageDefrag-Test.cpp
@@ -1,0 +1,143 @@
+/**
+ *    Copyright (C) 2026 EloqData Inc.
+ *
+ *    This program is free software: you can redistribute it and/or  modify
+ *    it under either of the following two licenses:
+ *    1. GNU Affero General Public License, version 3, as published by the Free
+ *    Software Foundation.
+ *    2. GNU General Public License as published by the Free Software
+ *    Foundation; version 2 of the License.
+ *
+ *    This program is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU Affero General Public License or GNU General Public License for more
+ *    details.
+ *
+ *    You should have received a copy of the GNU Affero General Public License
+ *    and GNU General Public License V2 along with this program.  If not, see
+ *    <http://www.gnu.org/licenses/>.
+ */
+#include <catch2/catch_all.hpp>
+#include <cstddef>
+#include <memory>
+#include <utility>
+
+#include "cc/cc_entry.h"
+#include "cc/template_cc_map.h"
+#include "mimalloc.h"
+#include "tx_key.h"
+#include "tx_record.h"
+
+namespace txservice
+{
+namespace
+{
+// Force the real iterator's key-relocation branch without depending on the
+// allocator's current page occupancy, and count every temporary key lifetime.
+class DefragTestKey : public CompositeKey<int>
+{
+public:
+    DefragTestKey()
+    {
+        ++live_count_;
+    }
+
+    explicit DefragTestKey(int value) : CompositeKey<int>(std::move(value))
+    {
+        ++live_count_;
+    }
+
+    DefragTestKey(const DefragTestKey &other) : CompositeKey<int>(other)
+    {
+        ++live_count_;
+    }
+
+    DefragTestKey(DefragTestKey &&other) noexcept
+        : CompositeKey<int>(std::move(other))
+    {
+        ++live_count_;
+    }
+
+    DefragTestKey &operator=(const DefragTestKey &) = default;
+    DefragTestKey &operator=(DefragTestKey &&) noexcept = default;
+
+    ~DefragTestKey()
+    {
+        --live_count_;
+    }
+
+    bool NeedsDefrag(mi_heap_t *)
+    {
+        return true;
+    }
+
+    static const TxKeyInterface *TxKeyImpl()
+    {
+        static const TxKeyInterface interface{DefragTestKey{}};
+        return &interface;
+    }
+
+    static inline size_t live_count_{0};
+};
+
+using TestRecord = CompositeRecord<int>;
+template <bool Versioned>
+class TestMap
+    : public TemplateCcMap<DefragTestKey, TestRecord, Versioned, false>
+{
+    using BaseMap = TemplateCcMap<DefragTestKey, TestRecord, Versioned, false>;
+
+public:
+    using BaseMap::DEFRAGED;
+    using BaseMap::Iterator;
+};
+}  // namespace
+
+TEMPLATE_TEST_CASE_SIG("Page key defragmentation releases temporary owners",
+                       "[cc-page][defrag]",
+                       ((bool Versioned), Versioned),
+                       true,
+                       false)
+{
+    using TestPage = CcPage<DefragTestKey, TestRecord, Versioned, false>;
+    using TestEntry = CcEntry<DefragTestKey, TestRecord, Versioned, false>;
+    REQUIRE(DefragTestKey::live_count_ == 0);
+    {
+        TestPage page(nullptr, nullptr, nullptr);
+        for (int value = 1; value <= 3; ++value)
+        {
+            page.keys_.emplace_back(value);
+            auto entry = std::make_unique<TestEntry>();
+            entry->payload_.cur_payload_ = std::make_unique<TestRecord>(value);
+            entry->SetCommitTsPayloadStatus(2, RecordStatus::Normal);
+            entry->SetCkptTs(2);
+            page.entries_.emplace_back(std::move(entry));
+        }
+
+        // Repeatedly relocate first, middle and last vector elements. Each
+        // completed relocation must leave exactly the three page-owned keys.
+        for (size_t round = 0; round < 8; ++round)
+        {
+            for (size_t index = 0; index < page.keys_.size(); ++index)
+            {
+                typename TestMap<Versioned>::Iterator it(&page, index, nullptr);
+                REQUIRE(it.DefragCurrentIfNecessary(mi_heap_get_default()) ==
+                        TestMap<Versioned>::DEFRAGED);
+                REQUIRE(DefragTestKey::live_count_ == page.keys_.size());
+                REQUIRE(page.keys_.size() == 3);
+                REQUIRE(page.entries_.size() == 3);
+                for (size_t pos = 0; pos < page.keys_.size(); ++pos)
+                {
+                    REQUIRE(std::get<0>(page.keys_[pos].Tuple()) ==
+                            static_cast<int>(pos + 1));
+                    REQUIRE(std::get<0>(page.entries_[pos]
+                                            ->payload_.cur_payload_->Tuple()) ==
+                            static_cast<int>(pos + 1));
+                }
+            }
+        }
+    }
+    REQUIRE(DefragTestKey::live_count_ == 0);
+}
+}  // namespace txservice

--- a/tx_service/tests/CcPageDefrag-Test.cpp
+++ b/tx_service/tests/CcPageDefrag-Test.cpp
@@ -20,11 +20,16 @@
  */
 #include <catch2/catch_all.hpp>
 #include <cstddef>
+#include <cstdint>
 #include <memory>
+#include <string>
+#include <string_view>
 #include <utility>
+#include <vector>
 
 #include "cc/cc_entry.h"
 #include "cc/template_cc_map.h"
+#include "eloq_string_key_record.h"
 #include "mimalloc.h"
 #include "tx_key.h"
 #include "tx_record.h"
@@ -82,15 +87,33 @@ public:
 };
 
 using TestRecord = CompositeRecord<int>;
-template <bool Versioned>
-class TestMap
-    : public TemplateCcMap<DefragTestKey, TestRecord, Versioned, false>
+template <bool Versioned, typename KeyT = DefragTestKey>
+class TestMap : public TemplateCcMap<KeyT, TestRecord, Versioned, false>
 {
-    using BaseMap = TemplateCcMap<DefragTestKey, TestRecord, Versioned, false>;
+    using BaseMap = TemplateCcMap<KeyT, TestRecord, Versioned, false>;
 
 public:
     using BaseMap::DEFRAGED;
     using BaseMap::Iterator;
+};
+
+// Retain the production string key's copy/move semantics while forcing the
+// relocation branch independently of allocator page occupancy.
+class DefragStringKey : public EloqStringKey
+{
+public:
+    using EloqStringKey::EloqStringKey;
+
+    bool NeedsDefrag(mi_heap_t *)
+    {
+        return true;
+    }
+
+    static const TxKeyInterface *TxKeyImpl()
+    {
+        static const TxKeyInterface interface{DefragStringKey{}};
+        return &interface;
+    }
 };
 }  // namespace
 
@@ -139,5 +162,54 @@ TEMPLATE_TEST_CASE_SIG("Page key defragmentation releases temporary owners",
         }
     }
     REQUIRE(DefragTestKey::live_count_ == 0);
+}
+
+TEMPLATE_TEST_CASE_SIG("Page key defragmentation refreshes full-page storage",
+                       "[cc-page][defrag]",
+                       ((bool Versioned), Versioned),
+                       true,
+                       false)
+{
+    using TestPage = CcPage<DefragStringKey, TestRecord, Versioned, false>;
+    using TestEntry = CcEntry<DefragStringKey, TestRecord, Versioned, false>;
+    TestPage page(nullptr, nullptr, nullptr);
+    std::vector<std::string> expected;
+    for (size_t index = 0; index < TestPage::split_threshold_; ++index)
+    {
+        expected.push_back(std::to_string(100 + index) + std::string(128, 'x'));
+        page.keys_.emplace_back(std::string_view(expected.back()));
+        auto entry = std::make_unique<TestEntry>();
+        entry->payload_.cur_payload_ =
+            std::make_unique<TestRecord>(static_cast<int>(index));
+        entry->SetCommitTsPayloadStatus(2, RecordStatus::Normal);
+        entry->SetCkptTs(2);
+        page.entries_.emplace_back(std::move(entry));
+    }
+    REQUIRE(page.Full());
+    const auto *page_keys = page.keys_.data();
+    const size_t capacity = page.keys_.capacity();
+
+    for (size_t index : {size_t{0}, expected.size() / 2, expected.size() - 1})
+    {
+        const uintptr_t old_buffer =
+            reinterpret_cast<uintptr_t>(page.keys_[index].Data());
+        typename TestMap<Versioned, DefragStringKey>::Iterator it(
+            &page, index, nullptr);
+        REQUIRE(it.DefragCurrentIfNecessary(mi_heap_get_default()) ==
+                TestMap<Versioned, DefragStringKey>::DEFRAGED);
+        REQUIRE(reinterpret_cast<uintptr_t>(page.keys_[index].Data()) !=
+                old_buffer);
+        REQUIRE(page.keys_.data() == page_keys);
+        REQUIRE(page.keys_.capacity() == capacity);
+        REQUIRE(page.keys_.size() == expected.size());
+        REQUIRE(it->first == &page.keys_[index]);
+        for (size_t pos = 0; pos < expected.size(); ++pos)
+        {
+            REQUIRE(page.keys_[pos].StringView() == expected[pos]);
+            REQUIRE(std::get<0>(
+                        page.entries_[pos]->payload_.cur_payload_->Tuple()) ==
+                    static_cast<int>(pos));
+        }
+    }
 }
 }  // namespace txservice


### PR DESCRIPTION
## Context

Heap defragmentation released a temporary key's unique_ptr before moving its contents into the page. The separately allocated KeyT object then had no owner and leaked on each qualifying relocation.

## Behavior before and after

Page keys retain their values while key-owned storage is refreshed. Relocation no longer allocates a separate temporary KeyT object or erases/reinserts the key. This applies to versioned and non-versioned entries. Defrag eligibility, locking checks, and wire/storage formats are unchanged.

## Implementation

Replace clone/erase/emplace in Iterator::DefragCurrentIfNecessary with `*key = KeyT(*key)`. Copy construction completes while the original value is valid, then rvalue assignment replaces the existing slot. The expression's temporary is automatically destroyed; there is no named key_clone/key_copy or owning pointer.

Register CcPageDefrag-Test to verify balanced key lifetimes and unchanged key/record contents, including repeated first/middle/last relocations. Full-page long-string tests additionally verify refreshed payload storage, unchanged vector allocation/capacity, and a stable iterator key address.

## Design decisions and alternatives

In-place replacement avoids shifting unrelated keys. Inserting before erasing could grow a full page's vector and invalidate element addresses; the final implementation does not change vector size. Key-owned payload allocations through the copy constructor remain necessary.

The long-string fixture retains production EloqStringKey copy/move semantics and forces defrag eligibility through the real TxKey interface, independently of allocator occupancy. Local ordering rationale is documented beside the code; no architecture change is needed.

## Test plan

- [x] Focused unit coverage
- [ ] Parent-project integration or manual validation
- [x] Formatting/build checks
- [ ] Recovery, compatibility, or performance validation
- [x] Local ownership/ordering comments updated

Commands run on 2026-09-10 using the existing isolated aarch64 S3 Debug configuration based on engine main `5c0be9f`:

```sh
LD_LIBRARY_PATH=/opt/eloq/third_party/lib:/opt/eloq/third_party/lib64 cmake --build /tmp/eloq-defrag-key-fix.qel3z8fg/bld --target CcPageDefrag-Test CcEntry-Test --parallel 2
python3 /tmp/eloq-defrag-key-fix.qel3z8fg/review_inplace_run_checks.py
# From the source checkout:
clang-format-18 --dry-run --Werror tx_service/include/cc/template_cc_map.h tx_service/tests/CcPageDefrag-Test.cpp
git diff --check 5c0be9f09b40b3358c14b7401765127b1f4210ed
```

Build passed. CcPageDefrag-Test passed 1290 assertions in 4 cases; CcEntry-Test passed 186 assertions in 5 cases. Both baseline-template lifecycle controls failed as expected at 4 live key objects versus 3 page keys. Formatting and merge-base diff checks passed.

No fresh configure, HA, live-server workload, TCL, performance benchmark, or sanitizer run was performed in this follow-up.

## Risk assessment

Storage refresh now uses KeyT copy construction and rvalue assignment instead of vector erase/emplace. Production string-key semantics are tested with long strings on full pages for both entry variants. Lifecycle tests retain coverage of the original leak. Live defrag scheduling and allocation pressure were not exercised. No concurrency or persistence boundaries change.

## Rollback plan

Revert this PR; no data migration is required.

## Reviewer guide

Start at Iterator::DefragCurrentIfNecessary and CcPageDefrag-Test.cpp. Check construction before replacement, refreshed string storage, stable page allocation, and balanced lifetimes. The final diff is limited to the production template, focused test, and CMake registration.

## Follow-up work

None in this PR. The defect requires enabled defragmentation and is not evidence that it caused the reported production value-buffer retention.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved key relocation during page defragmentation to preserve key and record data while managing temporary copies safely.

- **Documentation**
  - Clarified ownership and cleanup behavior for temporary keys during relocation.

- **Tests**
  - Added coverage for defragmenting first, middle, and last entries.
  - Verified behavior across versioned and non-versioned pages, including data ordering and resource cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->