### PR TITLE
fix: reset pooled remote upload command images

### DIFF
--- a/docs/08-range-and-bucket-management.md
+++ b/docs/08-range-and-bucket-management.md
@@ -81,11 +81,6 @@ pending bucket version so retries or delayed messages cannot overwrite a newer
 ownership decision. Staged migration logs let replay resume work that crossed
 a leader failure.
 
-A remote command upload owns only its current request's serialized commands.
-The receiver retains those images through consumption and the completion
-callback, then destroys them before publishing its pooled wrapper as reusable.
-Decoded commands require independent ownership if they outlive that upload.
-
 ## Secondary-index integration
 
 Building a secondary index traverses primary-key ranges because those ranges
@@ -130,5 +125,4 @@ not to the range architecture.
 | `StoreRange` and `StoreSlice` own cached-range, pin, load, and slice-spec lifecycles | `tx_service/include/cc/range_slice.h`; `tx_service/src/cc/range_slice.cpp`; `tx_service/include/cc/range_slice_type.h` |
 | Slice loading and range checkpointing cross the store-handler boundary | `tx_service/include/store/data_store_handler.h`; `tx_service/include/data_sync_task.h`; `tx_service/src/cc/local_cc_shards.cpp` |
 | Range split and bucket migration are staged, recoverable transaction operations | `tx_service/include/tx_operation.h`; `tx_service/src/tx_operation.cpp`; `tx_service/tx-log-protos/log.proto` |
-| Remote command uploads release request-owned images after consumption and completion, before pool reuse | `tx_service/include/remote/remote_cc_request.h`; `tx_service/src/remote/remote_cc_request.cpp`; `tx_service/include/cc/object_cc_map.h` |
 | Secondary-index build dispatches range work, releases consumed source batches, and uploads derived entries by ownership | `tx_service/include/tx_index_operation.h`; `tx_service/src/tx_index_operation.cpp`; `tx_service/include/sk_generator.h`; `tx_service/src/sk_generator.cpp`; `tx_service/include/cc/local_cc_shards.h` |

--- a/docs/08-range-and-bucket-management.md
+++ b/docs/08-range-and-bucket-management.md
@@ -81,6 +81,11 @@ pending bucket version so retries or delayed messages cannot overwrite a newer
 ownership decision. Staged migration logs let replay resume work that crossed
 a leader failure.
 
+A remote command upload owns only its current request's serialized commands.
+The receiver retains those images through consumption and the completion
+callback, then destroys them before publishing its pooled wrapper as reusable.
+Decoded commands require independent ownership if they outlive that upload.
+
 ## Secondary-index integration
 
 Building a secondary index traverses primary-key ranges because those ranges
@@ -125,4 +130,5 @@ not to the range architecture.
 | `StoreRange` and `StoreSlice` own cached-range, pin, load, and slice-spec lifecycles | `tx_service/include/cc/range_slice.h`; `tx_service/src/cc/range_slice.cpp`; `tx_service/include/cc/range_slice_type.h` |
 | Slice loading and range checkpointing cross the store-handler boundary | `tx_service/include/store/data_store_handler.h`; `tx_service/include/data_sync_task.h`; `tx_service/src/cc/local_cc_shards.cpp` |
 | Range split and bucket migration are staged, recoverable transaction operations | `tx_service/include/tx_operation.h`; `tx_service/src/tx_operation.cpp`; `tx_service/tx-log-protos/log.proto` |
+| Remote command uploads release request-owned images after consumption and completion, before pool reuse | `tx_service/include/remote/remote_cc_request.h`; `tx_service/src/remote/remote_cc_request.cpp`; `tx_service/include/cc/object_cc_map.h` |
 | Secondary-index build dispatches range work, releases consumed source batches, and uploads derived entries by ownership | `tx_service/include/tx_index_operation.h`; `tx_service/src/tx_index_operation.cpp`; `tx_service/include/sk_generator.h`; `tx_service/src/sk_generator.cpp`; `tx_service/include/cc/local_cc_shards.h` |

--- a/tx_service/include/remote/remote_cc_request.h
+++ b/tx_service/include/remote/remote_cc_request.h
@@ -1037,6 +1037,10 @@ struct RemoteUploadTxCommandsCc : public UploadTxCommandsCc
 public:
     RemoteUploadTxCommandsCc();
     void Reset(std::unique_ptr<CcMessage> input_msg);
+    /**
+     * Releases owned command images before publishing the pool slot as idle.
+     */
+    void Free() override;
     uint64_t handler_addr()
     {
         if (input_msg_)

--- a/tx_service/src/remote/remote_cc_request.cpp
+++ b/tx_service/src/remote/remote_cc_request.cpp
@@ -2307,6 +2307,9 @@ void txservice::remote::RemoteUploadTxCommandsCc::Reset(
         bool has_overwrite = cmds_req.has_overwrite();
 
         assert(commit_ts > 0);
+        // Each upload contains only this request's commands, including when
+        // an existing wrapper is reset without first returning to its pool.
+        cmds_vec_.clear();
         cmds_vec_.reserve(cmds_req.cmd_list_size());
         for (int idx = 0; idx < cmds_req.cmd_list_size(); ++idx)
         {
@@ -2335,6 +2338,14 @@ void txservice::remote::RemoteUploadTxCommandsCc::Reset(
     {
         hd_ = Sharder::Instance().GetCcStreamSender();
     }
+}
+
+void txservice::remote::RemoteUploadTxCommandsCc::Free()
+{
+    // Completion has sent the response and the consumer no longer needs these
+    // images. Destroy the strings before another thread can reuse this slot.
+    cmds_vec_.clear();
+    CcRequestBase::Free();
 }
 
 txservice::remote::RemoteDbSizeCc::RemoteDbSizeCc()

--- a/tx_service/tests/CMakeLists.txt
+++ b/tx_service/tests/CMakeLists.txt
@@ -70,6 +70,7 @@ set(CATCH_MAIN_TESTS
     AcquireAllError-Test
     StandbyForward-Test
     ApplyResponseBoundary-Test
+    RemoteUploadTxCommands-Test
     TransactionImageLifetime-Test
 )
 

--- a/tx_service/tests/RemoteUploadTxCommands-Test.cpp
+++ b/tx_service/tests/RemoteUploadTxCommands-Test.cpp
@@ -1,0 +1,136 @@
+/**
+ *    Copyright (C) 2026 EloqData Inc.
+ *
+ *    This program is free software: you can redistribute it and/or  modify
+ *    it under either of the following two licenses:
+ *    1. GNU Affero General Public License, version 3, as published by the Free
+ *    Software Foundation.
+ *    2. GNU General Public License as published by the Free Software
+ *    Foundation; version 2 of the License.
+ *
+ *    This program is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU Affero General Public License or GNU General Public License for more
+ *    details.
+ *
+ *    You should have received a copy of the GNU Affero General Public License
+ *    and GNU General Public License V2 along with this program.  If not, see
+ *    <http://www.gnu.org/licenses/>.
+ */
+#include <catch2/catch_all.hpp>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "cc/cc_req_pool.h"
+#include "remote/remote_cc_request.h"
+
+namespace txservice::remote
+{
+namespace
+{
+std::unique_ptr<CcMessage> MakeUpload(uint64_t txn,
+                                      const std::vector<std::string> &commands)
+{
+    auto message = std::make_unique<CcMessage>();
+    message->set_type(CcMessage::UploadTxCommandsRequest);
+    message->set_tx_number(txn);
+    message->set_tx_term(3);
+    auto *upload = message->mutable_upload_cmds_req();
+    upload->set_node_group_id(7);
+    upload->set_object_version(txn);
+    upload->set_commit_ts(txn + 1);
+    upload->set_has_overwrite(false);
+    auto *addr = upload->mutable_cce_addr();
+    addr->set_cce_lock_ptr(8);
+    addr->set_term(5);
+    addr->set_core_id(2);
+    for (const auto &command : commands)
+    {
+        upload->add_cmd_list(command);
+    }
+    return message;
+}
+}  // namespace
+
+TEST_CASE("Remote upload Reset replaces the previous command list",
+          "[remote-upload]")
+{
+    RemoteUploadTxCommandsCc request;
+    const std::vector<std::string> first{std::string(1024 * 1024, 'a'),
+                                         std::string("first\0tail", 10)};
+    const std::vector<std::string> second{"second-only"};
+
+    request.Reset(MakeUpload(100, first));
+    REQUIRE(*request.CommandList() == first);
+
+    // Exercise the actual Reset without relying on Free to sanitize the old
+    // request. These are the bytes ObjectCcMap consumes for the second key.
+    request.Reset(MakeUpload(200, second));
+    REQUIRE(request.CommandList()->size() == second.size());
+    REQUIRE(*request.CommandList() == second);
+    REQUIRE(request.Txn() == 200);
+    REQUIRE(request.ObjectVersion() == 200);
+    REQUIRE(request.CommitTs() == 201);
+    REQUIRE(request.CceAddr()->NodeGroupId() == 7);
+    REQUIRE(request.CceAddr()->CoreId() == 2);
+
+    request.Reset(MakeUpload(300, {}));
+    REQUIRE(request.CommandList()->empty());
+}
+
+TEST_CASE("Remote upload releases command images at completion",
+          "[remote-upload]")
+{
+    const bool abort_request = GENERATE(false, true);
+    CcRequestPool<RemoteUploadTxCommandsCc> pool(1);
+    auto *request = pool.NextRequest();
+    REQUIRE(request != nullptr);
+    const std::vector<std::string> commands{std::string(1024 * 1024, 'x'),
+                                            "last-command"};
+    request->Reset(MakeUpload(100, commands));
+
+    // Replace only network delivery. The real result completion and abort
+    // paths must invoke the callback before Free publishes the idle slot.
+    bool callback_called = false;
+    request->Result()->post_lambda_ =
+        [&](CcHandlerResult<PostProcessResult> *result)
+    {
+        callback_called = true;
+        REQUIRE(request->InUse());
+        REQUIRE(*request->CommandList() == commands);
+        REQUIRE(pool.NextRequest() == nullptr);
+        REQUIRE(result->ErrorCode() ==
+                (abort_request ? CcErrorCode::REQUESTED_NODE_NOT_LEADER
+                               : CcErrorCode::NO_ERROR));
+    };
+
+    REQUIRE(*request->CommandList() == commands);
+    REQUIRE(pool.NextRequest() == nullptr);
+    if (abort_request)
+    {
+        // The production abort path invokes the virtual Free itself.
+        request->AbortCcRequest(CcErrorCode::REQUESTED_NODE_NOT_LEADER);
+    }
+    else
+    {
+        // On success the shard processor frees a request after Execute has
+        // completed the result and returned true.
+        REQUIRE(request->Result()->SetFinished());
+        request->Free();
+    }
+
+    REQUIRE(callback_called);
+    REQUIRE_FALSE(request->InUse());
+    REQUIRE(request->CommandList()->empty());
+    auto *reused = pool.NextRequest();
+    REQUIRE(reused == request);
+    const std::vector<std::string> next_commands{"next-request-only"};
+    reused->Reset(MakeUpload(200, next_commands));
+    REQUIRE(*reused->CommandList() == next_commands);
+    reused->Free();
+    REQUIRE(reused->CommandList()->empty());
+}
+}  // namespace txservice::remote


### PR DESCRIPTION
## Context

RemoteUploadTxCommandsCc is pooled for commands uploaded to a bucket's new owner. Reset appended into cmds_vec_ without removing the previous request's commands, so a later upload could expose old commands to ObjectCcMap and retain every prior command image.

## Behavior before and after

Each Reset now exposes exactly the current upload's command list. Completion destroys its command strings before returning the wrapper to the pool, including abort completion; an idle wrapper no longer retains its last command images. The message format is unchanged.

## Implementation

Clear cmds_vec_ before populating Reset. Override Free to clear its owned strings before the base release-store publishes the slot as idle. Add request-reuse and completion-boundary tests. Explain request isolation and cleanup-before-pool-publication ordering in nearby source and API comments.

## Design decisions and alternatives

Reset enforces independent request contents even when called without an intervening pool return; terminal Free additionally releases payloads when a slot is never reused. Keep vector slot capacity for reuse. Cleanup remains after completion callbacks and does not affect pending execution. ObjectCcMap has already decoded the serialized strings into independently owned commands before completing the upload.

## Test plan

This revision removes the PR-specific architecture prose and its source-map row. The existing architecture model remains sufficient; the local cleanup rationale stays beside the implementation.

Checks run for this documentation revision (all passed):

```text
git diff --exit-code 4fe82da39749a898bdcd51ac2cb9e08da93a106a HEAD -- . ':(exclude)docs/**'
git diff --exit-code 5c0be9f09b40b3358c14b7401765127b1f4210ed HEAD -- docs/
git diff --check 5c0be9f09b40b3358c14b7401765127b1f4210ed HEAD
```

These checks verify that product code, tests, and build files are unchanged, the PR has no remaining architecture-document diff, and the complete merge-base diff has no whitespace errors. No build, C++ test, integration, HA, sanitizer, or performance test was rerun for this Markdown-only revision. No current-head CI result is claimed here.

Prior verification, recorded before this revision and not rerun here:

The prior PR record reports RemoteUploadTxCommands-Test passing 36 assertions in 2 cases and CcMessagePool-Test passing 5 assertions in 1 case on commit `b50ce50` (base `ee0f476`). Independent controls without Reset or Free cleanup failed the current-command-list and post-completion-empty assertions as expected.

Those tests preceded the rebase onto `5c0be9f`; they are not presented as a local test run on the current head.

## Risk assessment

Cleanup must remain after the consumer and completion callback finish and before pool publication. The change does not alter lock acquisition, commit decisions, command decoding, or transport retry ownership. Tests exercise the request/result lifecycle but do not execute a full migration across live nodes.

## Rollback plan

Revert this PR; no storage migration is required.

## Reviewer guide

Review RemoteUploadTxCommandsCc::Reset/Free and the consumer's UploadTxCommandsCc::CommandList contract first, then the reuse and abort-boundary assertions in RemoteUploadTxCommands-Test.cpp.

## Follow-up work

None in this PR. Other remote request pools and ordinary standby command forwarding are outside this change.
